### PR TITLE
chore(ORB-43): remove hex decoding for binary blobs

### DIFF
--- a/canisters/upgrader/src/lib.rs
+++ b/canisters/upgrader/src/lib.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use crate::{
     hash::{Hash, Sha256Hasher},
     interface::{InitArg, QueueUpgradeError, QueueUpgradeResponse, UpgradeParams},
-    queue::{Queue, QueueError, Queuer, WithAuthorization, WithHexDecode},
+    queue::{Queue, QueueError, Queuer, WithAuthorization},
     upgrade::{Upgrade, Upgrader, WithCleanup},
 };
 
@@ -97,7 +97,6 @@ lazy_static! {
     static ref QUEUER: Box<dyn Queue> = {
         let q = Queuer::new(&QUEUED_UPGRADE_PARAMS);
         let q = VerifyChecksum(q, &HASHER);
-        let q = WithHexDecode(q);
         let q = CheckController(q, &TARGET_CANISTER_ID);
         let q = WithAuthorization(q, &TARGET_CANISTER_ID);
         let q = WithLogs(q, "queue".to_string());

--- a/canisters/upgrader/src/queue.rs
+++ b/canisters/upgrader/src/queue.rs
@@ -98,20 +98,6 @@ impl<T: Queue> Queue for WithAuthorization<T> {
     }
 }
 
-pub struct WithHexDecode<T>(pub T);
-
-#[async_trait]
-impl<T: Queue> Queue for WithHexDecode<T> {
-    async fn queue(&self, ps: UpgradeParams) -> Result<(), QueueError> {
-        let ps = UpgradeParams {
-            module: hex::decode(ps.module).context("failed to decode module")?,
-            checksum: hex::decode(ps.checksum).context("failed to decode checksum")?,
-        };
-
-        self.0.queue(ps).await
-    }
-}
-
 #[async_trait]
 impl<T: Queue> Queue for WithLogs<T> {
     async fn queue(&self, ps: UpgradeParams) -> Result<(), QueueError> {


### PR DESCRIPTION
Initially, hex encoding was used for the submitted binary payloads, but this is not necessary in practice. This PR removes the handling of hex-encoded blobs.