### PR TITLE
chore(ORB-44): clean up queue before start upgrade operation

### DIFF
--- a/canisters/upgrader/src/upgrade.rs
+++ b/canisters/upgrader/src/upgrade.rs
@@ -62,15 +62,13 @@ pub struct WithCleanup<T>(pub T, pub LocalRef<StableValue<UpgradeParams>>);
 #[async_trait]
 impl<T: Upgrade> Upgrade for WithCleanup<T> {
     async fn upgrade(&self, ps: UpgradeParams) -> Result<(), UpgradeError> {
-        let out = self.0.upgrade(ps).await;
-
         // Clear queue
         self.1.with(|q| {
             let mut q = q.borrow_mut();
             q.remove(&());
         });
 
-        out
+        self.0.upgrade(ps).await
     }
 }
 


### PR DESCRIPTION
Currently, the upgrade queue is inspected by a timer job every 10sec. If performing an upgrade takes longer than 10sec, then on the next timer run, the upgrade will be attempted again. This change cleans up the queue before the upgrade is attempted, which should resolve the issue.