### PR TITLE
fix: make upgrader canister build

### DIFF
--- a/canisters/upgrader/Cargo.toml
+++ b/canisters/upgrader/Cargo.toml
@@ -20,3 +20,6 @@ mockall = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }


### PR DESCRIPTION
The `tokio` crate is not supported for the target `wasm32-unknown-unknown`.