### PR TITLE
chore: add enum for transfer status in list_account_transfers

### DIFF
--- a/canisters/wallet/api/spec.did
+++ b/canisters/wallet/api/spec.did
@@ -703,7 +703,7 @@ type ListAccountTransfersInput = record {
   // The account id to retrieve.
   account_id : UUID;
   // The transfer status in text format (e.g. "pending", "approved", etc.).
-  status : opt text;
+  status : opt TransferStatusType;
   // From which date to retrieve the transfers.
   from_dt : opt TimestampRFC3339;
   // Until which date to retrieve the transfers.
@@ -812,6 +812,14 @@ type TransferStatus = variant {
     // The base64 encoded value of the signed transaction, if available.
     signature : opt text;
   };
+};
+
+// Transfer status type for filtering on the transfer status.
+type TransferStatusType = variant {
+  Created;
+  Failed;
+  Processing;
+  Completed;
 };
 
 // A record type that can be used to represent a transfer in a given account.

--- a/canisters/wallet/api/src/transfer.rs
+++ b/canisters/wallet/api/src/transfer.rs
@@ -49,6 +49,14 @@ pub enum TransferStatusDTO {
     },
 }
 
+#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum TransferStatusTypeDTO {
+    Created,
+    Processing,
+    Completed,
+    Failed,
+}
+
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct TransferDTO {
     pub id: UuidDTO,
@@ -78,7 +86,7 @@ pub struct GetTransfersResponse {
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct ListAccountTransfersInput {
-    pub status: Option<String>,
+    pub status: Option<TransferStatusTypeDTO>,
     pub to_dt: Option<TimestampRfc3339>,
     pub from_dt: Option<TimestampRfc3339>,
     pub account_id: UuidDTO,

--- a/canisters/wallet/impl/src/mappers/transfer_status.rs
+++ b/canisters/wallet/impl/src/mappers/transfer_status.rs
@@ -1,6 +1,6 @@
 use crate::models::TransferStatus;
 use ic_canister_core::utils::timestamp_to_rfc3339;
-use wallet_api::TransferStatusDTO;
+use wallet_api::{TransferStatusDTO, TransferStatusTypeDTO};
 
 impl From<TransferStatus> for TransferStatusDTO {
     fn from(status: TransferStatus) -> Self {
@@ -21,6 +21,17 @@ impl From<TransferStatus> for TransferStatusDTO {
             TransferStatus::Failed { reason } => TransferStatusDTO::Failed {
                 reason: reason.to_owned(),
             },
+        }
+    }
+}
+
+impl From<TransferStatus> for TransferStatusTypeDTO {
+    fn from(status: TransferStatus) -> Self {
+        match status {
+            TransferStatus::Processing { .. } => TransferStatusTypeDTO::Processing,
+            TransferStatus::Created => TransferStatusTypeDTO::Created,
+            TransferStatus::Completed { .. } => TransferStatusTypeDTO::Completed,
+            TransferStatus::Failed { .. } => TransferStatusTypeDTO::Failed,
         }
     }
 }

--- a/canisters/wallet/impl/src/repositories/transfer.rs
+++ b/canisters/wallet/impl/src/repositories/transfer.rs
@@ -19,6 +19,7 @@ use ic_canister_core::{
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
 use lazy_static::lazy_static;
 use std::cell::RefCell;
+use wallet_api::TransferStatusTypeDTO;
 
 thread_local! {
   /// The memory reference to the Transfer repository.
@@ -94,7 +95,7 @@ impl TransferRepository {
         account_id: AccountId,
         created_dt_from: Option<Timestamp>,
         created_dt_to: Option<Timestamp>,
-        status: Option<String>,
+        status: Option<TransferStatusTypeDTO>,
     ) -> Vec<Transfer> {
         let transfers = self
             .account_index
@@ -108,11 +109,7 @@ impl TransferRepository {
             .iter()
             .filter_map(|id| match (self.get(&Transfer::key(*id)), status.clone()) {
                 (Some(transfer), Some(status)) => {
-                    if transfer
-                        .status
-                        .to_string()
-                        .eq_ignore_ascii_case(status.as_str())
-                    {
+                    if status == transfer.status.clone().into() {
                         Some(transfer)
                     } else {
                         None


### PR DESCRIPTION
The method `list_account_transfers` take a transfer status formatted as a String to filter the returned transfers. This MR replaces the String type with a proper enum to get stronger typing guarantees.