### PR TITLE
feat: restrict the maximum number of deployed wallets

### DIFF
--- a/canisters/control-panel/impl/src/services/deploy.rs
+++ b/canisters/control-panel/impl/src/services/deploy.rs
@@ -2,6 +2,7 @@ use super::UserService;
 use crate::{
     core::{canister_config, CallContext, INITIAL_WALLET_CYCLES},
     errors::{DeployError, UserError},
+    models::User,
     services::USER_SERVICE,
 };
 use candid::{Encode, Principal};
@@ -30,7 +31,8 @@ impl DeployService {
     /// Deploys a wallet canister for the user.
     pub async fn deploy_wallet(&self, ctx: &CallContext) -> ServiceResult<Principal> {
         let user = self.user_service.get_user(&ctx.caller(), ctx)?;
-        if !user.wallets.is_empty() {
+        let max_deployed_wallets: usize = User::MAX_DEPLOYED_WALLETS.into();
+        if user.deployed_wallets.len() >= max_deployed_wallets {
             return Err(UserError::DeployWalletQuotaExceeded)?;
         }
 
@@ -87,6 +89,10 @@ impl DeployService {
                 },
                 ctx,
             )
+            .await?;
+
+        self.user_service
+            .add_deployed_wallet(wallet_canister.canister_id, ctx)
             .await?;
 
         Ok(wallet_canister.canister_id)

--- a/canisters/control-panel/impl/src/services/user.rs
+++ b/canisters/control-panel/impl/src/services/user.rs
@@ -104,6 +104,22 @@ impl UserService {
         Ok(user)
     }
 
+    pub async fn add_deployed_wallet(
+        &self,
+        wallet_canister_id: Principal,
+        ctx: &CallContext,
+    ) -> ServiceResult<User> {
+        let mut user = self.get_user(&ctx.caller(), ctx)?;
+
+        user.deployed_wallets.push(wallet_canister_id);
+
+        user.validate()?;
+
+        self.user_repository.insert(user.to_key(), user.clone());
+
+        Ok(user)
+    }
+
     /// Checks if the caller has access to the given user.
     ///
     /// Admins have access to all users.

--- a/canisters/integration-tests/src/control_panel_tests.rs
+++ b/canisters/integration-tests/src/control_panel_tests.rs
@@ -2,7 +2,8 @@ use crate::setup::setup_new_env;
 use crate::utils::user_test_id;
 use crate::TestEnv;
 use control_panel_api::{
-    DeployWalletResponse, GetMainWalletResponse, RegisterUserInput, RegisterUserResponse,
+    DeployWalletResponse, GetMainWalletResponse, ManageUserInput, ManageUserResponse,
+    RegisterUserInput, RegisterUserResponse, UserWalletDTO,
 };
 use ic_canister_core::api::ApiResult;
 use pocket_ic::update_candid_as;
@@ -132,4 +133,73 @@ fn deploy_user_wallet() {
     .unwrap();
     let health_status = res.0;
     assert_eq!(health_status, HealthStatus::Healthy);
+}
+
+#[test]
+fn deploy_too_many_wallets() {
+    let TestEnv {
+        env, canister_ids, ..
+    } = setup_new_env();
+
+    let user_id = user_test_id(0);
+
+    // register user
+    let register_args = RegisterUserInput {
+        wallet_id: None,
+        email: Some("john@example.com".to_string()),
+    };
+    let res: (ApiResult<RegisterUserResponse>,) = update_candid_as(
+        &env,
+        canister_ids.control_panel,
+        user_id,
+        "register_user",
+        (register_args,),
+    )
+    .unwrap();
+    let user_dto = res.0.unwrap().user;
+    assert_eq!(user_dto.id, user_id);
+
+    // deploy the maximum amount of user wallets
+    let mut wallets = vec![];
+    for _ in 0..10 {
+        let res: (ApiResult<DeployWalletResponse>,) = update_candid_as(
+            &env,
+            canister_ids.control_panel,
+            user_id,
+            "deploy_wallet",
+            (),
+        )
+        .unwrap();
+        wallets.push(res.0.unwrap().canister_id);
+    }
+
+    // reset all but one deployed wallet
+    let manage_user_args = ManageUserInput {
+        main_wallet: Some(wallets[0]),
+        wallets: Some(vec![UserWalletDTO {
+            canister_id: wallets[0],
+            name: None,
+        }]),
+    };
+    let res: (ApiResult<ManageUserResponse>,) = update_candid_as(
+        &env,
+        canister_ids.control_panel,
+        user_id,
+        "manage_user",
+        (manage_user_args,),
+    )
+    .unwrap();
+    let user_dto = res.0.unwrap().user;
+    assert_eq!(user_dto.wallets.len(), 1);
+
+    // deploying an additional wallet should fail nonetheless
+    let res: (ApiResult<DeployWalletResponse>,) = update_candid_as(
+        &env,
+        canister_ids.control_panel,
+        user_id,
+        "deploy_wallet",
+        (),
+    )
+    .unwrap();
+    assert_eq!(res.0.unwrap_err().code, "DEPLOY_WALLET_QUOTA_EXCEEDED");
 }


### PR DESCRIPTION
This PR restricts the maximum number of wallets ever deployed through the control panel by a single user.