### PR TITLE
fix: init rng in canister timers

### DIFF
--- a/canisters/control-panel/impl/src/controllers/canister.rs
+++ b/canisters/control-panel/impl/src/controllers/canister.rs
@@ -1,9 +1,10 @@
 //! Canister lifecycle hooks.
 use super::AVAILABLE_TOKENS_USER_REGISTRATION;
+use crate::core::ic_cdk::spawn;
 use crate::{core::ic_cdk::api::trap, services::CANISTER_SERVICE};
 use control_panel_api::CanisterInstall;
 use ic_cdk_macros::{init, post_upgrade};
-use ic_cdk_timers::set_timer_interval;
+use ic_cdk_timers::{set_timer, set_timer_interval};
 use std::time::Duration;
 
 pub const MINUTE: u64 = 60;
@@ -14,6 +15,20 @@ pub const USER_REGISTRATION_RATE: u32 = 100;
 pub const USER_REGISTRATION_LIMIT_PERIOD: Duration = Duration::from_secs(MINUTE);
 
 fn init_timers_fn() {
+    async fn initialize_rng_timer() {
+        use ic_canister_core::utils::initialize_rng;
+        if let Err(e) = initialize_rng().await {
+            ic_cdk::print(format!("initializing rng failed: {}", e));
+            ic_cdk_timers::set_timer(std::time::Duration::from_secs(60), move || {
+                spawn(initialize_rng_timer())
+            });
+        }
+    }
+
+    set_timer(std::time::Duration::from_millis(0), move || {
+        spawn(initialize_rng_timer())
+    });
+
     set_timer_interval(
         USER_REGISTRATION_LIMIT_PERIOD / USER_REGISTRATION_RATE,
         || {

--- a/libs/ic-canister-core/src/utils/random.rs
+++ b/libs/ic-canister-core/src/utils/random.rs
@@ -1,4 +1,4 @@
-use crate::cdk::api::{management_canister, trap};
+use crate::cdk::api::management_canister;
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha20Rng;
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use uuid::{Builder, Uuid};
 
 thread_local! {
-  static RNG: RefCell<Option<ChaCha20Rng>> = RefCell::new(None);
+  static RNG: RefCell<ChaCha20Rng> = RefCell::new(ChaCha20Rng::from_seed([42; 32]));
 }
 
 #[cfg(all(
@@ -16,9 +16,8 @@ thread_local! {
 ))]
 /// A getrandom implementation that works in the IC.
 pub fn custom_getrandom_bytes_impl(dest: &mut [u8]) -> Result<(), getrandom::Error> {
-    RNG.with(|maybe_rng| {
-        let mut maybe_rng = maybe_rng.borrow_mut();
-        let rng = maybe_rng.as_mut().expect("missing random number generator");
+    RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
         rng.fill_bytes(dest);
     });
 
@@ -33,41 +32,40 @@ pub fn custom_getrandom_bytes_impl(dest: &mut [u8]) -> Result<(), getrandom::Err
 getrandom::register_custom_getrandom!(custom_getrandom_bytes_impl);
 
 pub async fn random_bytes<const N: usize>() -> [u8; N] {
-    maybe_initialize_rng().await;
-
     random_bytes_gen::<N>()
 }
 
 /// Initializes the random number generator if it has not been initialized yet.
 ///
 /// This function is async because it may need to call into the management canister to get a seed with `raw_rand``.
-pub async fn maybe_initialize_rng() {
-    let is_initialized = RNG.with(|rng| rng.borrow().is_some());
-    if !is_initialized {
-        let (created_seed,) = management_canister::main::raw_rand()
-            .await
-            .unwrap_or_else(|_| trap("call to raw_rand failed"));
+pub async fn initialize_rng() -> Result<(), String> {
+    ic_cdk::print("started to initialize rng");
 
-        let seed = created_seed
-            .try_into()
-            .unwrap_or_else(|_| trap("raw_rand not 32 bytes"));
+    let (created_seed,) = management_canister::main::raw_rand()
+        .await
+        .map_err(|e| e.1)?;
 
-        initialize_rng_from_seed(seed);
-    }
+    let seed = created_seed
+        .try_into()
+        .map_err(|_| "raw_rand not 32 bytes".to_string())?;
+
+    initialize_rng_from_seed(seed);
+
+    ic_cdk::print("rng succesfully initialized");
+    Ok(())
 }
 
 /// Initializes the random number generator with the given seed.
 pub fn initialize_rng_from_seed(seed: [u8; 32]) {
     RNG.with(|rng| {
         let new_rng = ChaCha20Rng::from_seed(seed);
-        let _ = rng.borrow_mut().insert(new_rng);
+        *rng.borrow_mut() = new_rng;
     });
 }
 
 pub fn random_bytes_gen<const N: usize>() -> [u8; N] {
-    RNG.with(|maybe_rng| {
-        let mut maybe_rng = maybe_rng.borrow_mut();
-        let rng = maybe_rng.as_mut().expect("missing random number generator");
+    RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
         let mut bytes = [0u8; N];
         rng.fill_bytes(&mut bytes);
         bytes


### PR DESCRIPTION
This MR initializes the RNG in the control panel and wallet canisters deterministically after their deployment (install or upgrade) and then seeds the RNG with randomness obtained from the management canister in a timer (retrying every 60s if the call was unsuccessful).