### PR TITLE
fix: use time in initial rng seed

### DIFF
--- a/libs/ic-canister-core/src/utils/random.rs
+++ b/libs/ic-canister-core/src/utils/random.rs
@@ -1,5 +1,4 @@
-use crate::cdk::api::management_canister;
-use ic_cdk::api::time;
+use crate::cdk::api::{management_canister, time};
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha20Rng;


### PR DESCRIPTION
This MR uses the current time in the initial rng seed instead of a fixed value. This way, the rng doesn't produce the same values as before right after upgrading the canister.