### PR TITLE
fix: safari can open ii window

### DIFF
--- a/apps/wallet/src/pages/LoginPage.vue
+++ b/apps/wallet/src/pages/LoginPage.vue
@@ -69,10 +69,10 @@ const i18n = useI18n();
 
 const isAuthenticating = ref(false);
 
-const performLogin = async (): Promise<void> => {
+const performLogin = (): void => {
   isAuthenticating.value = true;
 
-  await session
+  session
     .signIn()
     .then(() => afterLoginRedirect())
     .catch((e: Error) => {

--- a/apps/wallet/src/services/auth.service.ts
+++ b/apps/wallet/src/services/auth.service.ts
@@ -9,12 +9,8 @@ export class AuthService {
 
   constructor(private authClient?: AuthClient) {}
 
-  invalidateAuthClient(): void {
-    this.authClient = undefined;
-  }
-
-  async client(): Promise<AuthClient> {
-    if (!this.authClient) {
+  async client(args: { reset?: boolean } = { reset: false }): Promise<AuthClient> {
+    if (!this.authClient || args.reset) {
       this.authClient = await AuthClient.create({
         idleOptions: {
           disableIdle: true,
@@ -53,7 +49,7 @@ export class AuthService {
 
     await client.logout();
 
-    this.invalidateAuthClient();
+    await this.client({ reset: true });
   }
 
   async getRemainingSessionTimeMs(): Promise<number | null> {

--- a/apps/wallet/src/stores/session.store.ts
+++ b/apps/wallet/src/stores/session.store.ts
@@ -184,7 +184,6 @@ export const useSessionStore = defineStore('session', {
       const sessionExpirationService = services().sessionExpiration;
 
       try {
-        authService.invalidateAuthClient();
         const identity = await authService.login();
 
         sessionExpirationService.notifySignedIn();
@@ -328,7 +327,7 @@ export const useSessionStore = defineStore('session', {
 
     async setReauthenticated() {
       const authService = services().auth;
-      authService.invalidateAuthClient();
+      await authService.client({ reset: true });
       const maybeIdentity = await authService.identity();
       if (!maybeIdentity) {
         logger.error(`Reauthentication failed, no identity found`);


### PR DESCRIPTION
Safari appears to be more strict then chromium based browsers for `window.open` events, which means that it was asking the user to unblock the Internet Identity popup as if the user has not done a click action.

By removing the invalidating of the `authClient` from the login flow and instead adding that to the logout flow, the issue is fixed, since the `window.open` event is right after the user click event and does not need to wait an async execution of creating a new `authClient`.