### PR TITLE
fix(wallet): permission page shows individual resource section

### DIFF
--- a/apps/wallet/src/components/permissions/IndividualAccountPermissions.spec.ts
+++ b/apps/wallet/src/components/permissions/IndividualAccountPermissions.spec.ts
@@ -45,7 +45,7 @@ describe('IndividualAccountPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(true);
   });
 
   it('hides permission list when specific resource is not selected', async () => {
@@ -59,6 +59,6 @@ describe('IndividualAccountPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(false);
   });
 });

--- a/apps/wallet/src/components/permissions/IndividualAccountPermissions.vue
+++ b/apps/wallet/src/components/permissions/IndividualAccountPermissions.vue
@@ -14,14 +14,14 @@
   <DataLoader
     v-if="selectedAccountId"
     v-slot="{ data, loading }"
-    :load="() => fetchPolicies(useResourcesFromAggregatedView(resources))"
+    :load="() => fetchPermissions(useResourcesFromAggregatedView(resources))"
     :refresh-interval-ms="5000"
     :disable-refresh="disableRefresh"
   >
     <PermissionList
       :loading="loading"
       :resources="resources"
-      :permissions="data ? data.policies : []"
+      :permissions="data ? data.permissions : []"
       :privileges="data ? data.privileges : []"
       :preload-user-groups="data ? data.userGroups : []"
       :preload-users="data ? data.users : []"
@@ -50,20 +50,20 @@ import PermissionList from './PermissionList.vue';
 
 const props = withDefaults(
   defineProps<{
-    fetchPolicies?: (resources: Resource[]) => Promise<{
-      policies: Permission[];
+    fetchPermissions?: (resources: Resource[]) => Promise<{
+      permissions: Permission[];
       userGroups: UserGroup[];
       users: BasicUser[];
       privileges: PermissionCallerPrivileges[];
     }>;
   }>(),
   {
-    fetchPolicies: () =>
-      Promise.resolve({ policies: [], userGroups: [], users: [], privileges: [] }),
+    fetchPermissions: () =>
+      Promise.resolve({ permissions: [], userGroups: [], users: [], privileges: [] }),
   },
 );
 
-const { fetchPolicies } = toRefs(props);
+const { fetchPermissions } = toRefs(props);
 
 const autocomplete = useAccountsAutocomplete();
 const selectedAccountId = ref<UUID | null>(null);

--- a/apps/wallet/src/components/permissions/IndividualUserGroupPermissions.spec.ts
+++ b/apps/wallet/src/components/permissions/IndividualUserGroupPermissions.spec.ts
@@ -45,7 +45,7 @@ describe('IndividualUserGroupPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(true);
   });
 
   it('hides permission list when specific resource is not selected', async () => {
@@ -59,6 +59,6 @@ describe('IndividualUserGroupPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(false);
   });
 });

--- a/apps/wallet/src/components/permissions/IndividualUserGroupPermissions.vue
+++ b/apps/wallet/src/components/permissions/IndividualUserGroupPermissions.vue
@@ -14,14 +14,14 @@
   <DataLoader
     v-if="selectedUserGroupId"
     v-slot="{ data, loading }"
-    :load="() => fetchPolicies(useResourcesFromAggregatedView(resources))"
+    :load="() => fetchPermissions(useResourcesFromAggregatedView(resources))"
     :refresh-interval-ms="5000"
     :disable-refresh="disableRefresh"
   >
     <PermissionList
       :loading="loading"
       :resources="resources"
-      :permissions="data ? data.policies : []"
+      :permissions="data ? data.permissions : []"
       :privileges="data ? data.privileges : []"
       :preload-user-groups="data ? data.userGroups : []"
       :preload-users="data ? data.users : []"
@@ -59,20 +59,20 @@ onMounted(() => {
 
 const props = withDefaults(
   defineProps<{
-    fetchPolicies?: (resources: Resource[]) => Promise<{
-      policies: Permission[];
+    fetchPermissions?: (resources: Resource[]) => Promise<{
+      permissions: Permission[];
       userGroups: UserGroup[];
       users: BasicUser[];
       privileges: PermissionCallerPrivileges[];
     }>;
   }>(),
   {
-    fetchPolicies: () =>
-      Promise.resolve({ policies: [], userGroups: [], users: [], privileges: [] }),
+    fetchPermissions: () =>
+      Promise.resolve({ permissions: [], userGroups: [], users: [], privileges: [] }),
   },
 );
 
-const { fetchPolicies } = toRefs(props);
+const { fetchPermissions } = toRefs(props);
 
 const groupList = computed(() => {
   const groups = autocomplete.results.value.map(group => ({

--- a/apps/wallet/src/components/permissions/IndividualUserPermissions.spec.ts
+++ b/apps/wallet/src/components/permissions/IndividualUserPermissions.spec.ts
@@ -49,7 +49,7 @@ describe('IndividualUserPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(true);
   });
 
   it('hides permission list when specific resource is not selected', async () => {
@@ -63,6 +63,6 @@ describe('IndividualUserPermissions', () => {
 
     await flushPromises();
 
-    expect(wrapper.find('[data-test-id="access-policy-list"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-id="permission-list"]').exists()).toBe(false);
   });
 });

--- a/apps/wallet/src/components/permissions/IndividualUserPermissions.vue
+++ b/apps/wallet/src/components/permissions/IndividualUserPermissions.vue
@@ -14,14 +14,14 @@
   <DataLoader
     v-if="selectedUserId"
     v-slot="{ data, loading }"
-    :load="() => fetchPolicies(useResourcesFromAggregatedView(resources))"
+    :load="() => fetchPermissions(useResourcesFromAggregatedView(resources))"
     :refresh-interval-ms="5000"
     :disable-refresh="disableRefresh"
   >
     <PermissionList
       :loading="loading"
       :resources="resources"
-      :permissions="data ? data.policies : []"
+      :permissions="data ? data.permissions : []"
       :privileges="data ? data.privileges : []"
       :preload-user-groups="data ? data.userGroups : []"
       :preload-users="data ? data.users : []"
@@ -59,20 +59,20 @@ onMounted(() => {
 
 const props = withDefaults(
   defineProps<{
-    fetchPolicies?: (resources: Resource[]) => Promise<{
-      policies: Permission[];
+    fetchPermissions?: (resources: Resource[]) => Promise<{
+      permissions: Permission[];
       userGroups: UserGroup[];
       users: BasicUser[];
       privileges: PermissionCallerPrivileges[];
     }>;
   }>(),
   {
-    fetchPolicies: () =>
-      Promise.resolve({ policies: [], userGroups: [], users: [], privileges: [] }),
+    fetchPermissions: () =>
+      Promise.resolve({ permissions: [], userGroups: [], users: [], privileges: [] }),
   },
 );
 
-const { fetchPolicies } = toRefs(props);
+const { fetchPermissions } = toRefs(props);
 
 const userList = computed(() => {
   const users = autocomplete.results.value.map(user => ({

--- a/apps/wallet/src/components/permissions/PermissionList.vue
+++ b/apps/wallet/src/components/permissions/PermissionList.vue
@@ -1,5 +1,5 @@
 <template>
-  <VContainer fluid data-test-id="access-policy-list" class="px-3 pt-2">
+  <VContainer fluid data-test-id="permission-list" class="px-3 pt-2">
     <VRow>
       <VCol cols="12" class="px-0 pt-0">
         <VTable density="compact" hover class="elevation-2 rounded">


### PR DESCRIPTION
This was missed during the refactor of Access Policy to permission done before the release. With this change we can again correctly filter and show the permissions in the corresponding page for selected resource entries.