### PR TITLE
feat(control-panel): add registry api interface and repository

### DIFF
--- a/apps/wallet/src/generated/control-panel/control_panel.did
+++ b/apps/wallet/src/generated/control-panel/control_panel.did
@@ -341,7 +341,7 @@ type RegistryEntry = record {
   // - Names that start with `@` must have a namespace and a name separated by a `/`.
   // - Names must be between 2 and 48 characters long.
   // - Namespaces must be between 2 and 32 characters long.
-  // - Names that are not namespaced, are put in the default namespace `@a`.
+  // - Names that are not namespaced, are put in the default namespace `@default`.
   // - Namespaced names must be at most 64 characters long.
   name : text;
   // The description of the entry, which is a human-readable description of the entry.

--- a/apps/wallet/src/generated/control-panel/control_panel.did
+++ b/apps/wallet/src/generated/control-panel/control_panel.did
@@ -21,6 +21,15 @@ type ApiError = record {
   details : opt vec record { text; text };
 };
 
+type PaginationInput = record {
+  // The offset to use for pagination.
+  offset : opt nat64;
+  // The maximum number of items to retrieve.
+  //
+  // If not set, the default limit will be used.
+  limit : opt nat16;
+};
+
 // The user user information.
 type User = record {
   // The identity associated with the user.
@@ -193,19 +202,19 @@ type DeployStationResult = variant {
   Err : ApiError;
 };
 
-/// The successful result of checking if the caller can deploy a station canister.
-/// Returns the remaining number of station canisters the caller can still deploy
-/// or a reason why the caller cannot deploy a station canister
-/// (bad subscription status or exceeded quota).
+// The successful result of checking if the caller can deploy a station canister.
+// Returns the remaining number of station canisters the caller can still deploy
+// or a reason why the caller cannot deploy a station canister
+// (bad subscription status or exceeded quota).
 type CanDeployStationResponse = variant {
   NotAllowed : UserSubscriptionStatus;
   Allowed : nat64;
   QuotaExceeded;
 };
 
-/// The input for deploying a station admin user.
-///
-/// Used to associate a user with a station canister as an admin when initializing the station.
+// The input for deploying a station admin user.
+//
+// Used to associate a user with a station canister as an admin when initializing the station.
 type DeployStationAdminUserInput = record {
   // The username to associate with the station canister as an admin.
   username : text;
@@ -213,7 +222,7 @@ type DeployStationAdminUserInput = record {
   identity : principal;
 };
 
-/// The input for deploying a station canister.
+// The input for deploying a station canister.
 type DeployStationInput = record {
   // The station name to use.
   name : text;
@@ -310,8 +319,254 @@ type GetArtifactResult = variant {
   Err : ApiError;
 };
 
+// A metadata record that contains a key and a value.
+type Metadata = record {
+  key : text;
+  value : text;
+};
+
+// An entry record, which contains information and the value stored in the registry.
+type RegistryEntry = record {
+  // The UUID that identifies the entry in the registry.
+  id : UUID;
+  // The name of the entry, which is used to identify it (e.g. station). Names that start with `@` are considered
+  // to be namespaced, and the namespace is the part of the name that comes before the `/`. Within each namespace
+  // the name should refer to the same type of entry, but many entries can exist with the same name.
+  //
+  // e.g. if the namespace is "@orbit" and the name is "station", then all the entries will refer to a wasm module.
+  //
+  // Restrictions:
+  //
+  // - Names that start with `@` are considered namespaced.
+  // - Names that start with `@` must have a namespace and a name separated by a `/`.
+  // - Names must be between 2 and 48 characters long.
+  // - Namespaces must be between 2 and 32 characters long.
+  // - Names that are not namespaced, are put in the default namespace `@a`.
+  // - Namespaced names must be at most 64 characters long.
+  name : text;
+  // The description of the entry, which is a human-readable description of the entry.
+  //
+  // Restrictions:
+  //
+  // - Descriptions must be between 24 and 512 characters long.
+  description : text;
+  // The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+  //
+  // Tags are grouped within the same `namespace/name` (e.g. "@orbit/station").
+  //
+  // Restrictions:
+  //
+  // - Tags must be between 2 and 32 characters long.
+  // - There can be up to 10 tags per entry.
+  tags : vec text;
+  // The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+  // across all the entries in the registry.
+  //
+  // Restrictions:
+  //
+  // - Categories must be between 2 and 32 characters long.
+  // - There can be up to 10 categories per entry.
+  categories : vec text;
+  // The metadata of the entry in the registry.
+  //
+  // This is a key-value map that can be used to store additional information about the entry,
+  // such as the author, license, repository, docs, etc.
+  //
+  // Restrictions:
+  //
+  // - The key must be between 1 and 32 characters long.
+  // - The value must be between 1 and 512 characters long.
+  // - There can be up to 10 metadata entries per entry in the registry.
+  metadata : vec Metadata;
+  // The content of the entry in the registry.
+  value : RegistryEntryValue;
+  // The timestamp when the entry was created.
+  created_at : TimestampRFC3339;
+  // The timestamp when the entry was last updated.
+  updated_at : opt TimestampRFC3339;
+};
+
+// The registry entry value.
+type RegistryEntryValue = variant {
+  WasmModule : WasmModuleRegistryEntryValue;
+};
+
+// The wasm module registry value, which is the content of the wasm module and its version.
+type WasmModuleRegistryEntryValue = record {
+  // The id of the wasm module that is stored in the artifact repository.
+  wasm_artifact_id : UUID;
+  // The version of the wasm module.
+  //
+  // Restrictions:
+  //
+  // - Versions must be between 1 and 32 characters long.
+  version : text;
+  // The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+  //
+  // This registry ids should only reference registry entries that are of type `WasmModule`, others will be ignored.
+  dependencies : vec UUID;
+};
+
+// The search registry filter options.
+type SearchRegistryFilterKind = variant {
+  // The name of the registry entry to find, if the namespace is not provided the default namespace is used.
+  Name : text;
+};
+
+// The input for searching the registry.
+type SearchRegistryInput = record {
+  // Filters are used sequentially and are combined with an AND operation to filter the entries in the registry.
+  filter_by : vec SearchRegistryFilterKind;
+  // The pagination options to use for the search.
+  pagination : opt PaginationInput;
+};
+
+// The search registry response.
+type SearchRegistryResponse = record {
+  // The list of registry entries that match the search criteria.
+  entries : vec RegistryEntry;
+  // The total number of entries that match the search criteria.
+  total : nat64;
+  // The next offset to use for pagination.
+  next_offset : opt nat64;
+};
+
+// The search registry result.
+type SearchRegistryResult = variant {
+  // Successfull operation result.
+  Ok : SearchRegistryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The input for getting a registry entry.
+type GetRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+};
+
+// The get registry entry response.
+type GetRegistryEntryResponse = record {
+  // The registry entry that matches the provided id.
+  entry : RegistryEntry;
+};
+
+// The get registry entry result.
+type GetRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : GetRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The registry entry input.
+type RegistryEntryInput = record {
+  // The name of the entry, which is used to identify it (e.g. station).
+  name : text;
+  // The description of the entry, which is a human-readable description of the entry.
+  description : text;
+  // The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+  tags : vec text;
+  // The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+  // across all the entries in the registry.
+  categories : vec text;
+  // The metadata of the entry in the registry.
+  metadata : vec Metadata;
+  // The content of the entry in the registry.
+  value : RegistryEntryValueInput;
+};
+
+// The registry entry value input.
+type RegistryEntryValueInput = variant {
+  WasmModule : WasmModuleRegistryEntryValueInput;
+};
+
+// The wasm module registry value input, which is the content of the wasm module and its version.
+type WasmModuleRegistryEntryValueInput = record {
+  // The wasm module that should be stored in the artifact repository.
+  wasm_module : blob;
+  // The version of the wasm module.
+  version : text;
+  // The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+  dependencies : vec UUID;
+};
+
+// The input for adding a registry entry.
+type AddRegistryEntryInput = record {
+  entry : RegistryEntryInput;
+};
+
+// The response of adding a registry entry.
+type AddRegistryEntryResponse = record {
+  entry : RegistryEntry;
+};
+
+// The result of adding a registry entry.
+type AddRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : AddRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The input for editing a registry entry.
+type EditRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+  // The updated registry entry.
+  entry : RegistryEntryInput;
+};
+
+// The response of editing a registry entry.
+type EditRegistryEntryResponse = record {
+  entry : RegistryEntry;
+};
+
+// The result of editing a registry entry.
+type EditRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : EditRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The input for deleting a registry entry.
+type DeleteRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+};
+
+// The response of deleting a registry entry.
+type DeleteRegistryEntryResponse = record {
+  // The registry entry that was deleted.
+  entry : RegistryEntry;
+};
+
+// The result of deleting a registry entry.
+type DeleteRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : DeleteRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
 // The control panel service definition.
 service : () -> {
+  // Add a new entry to the registry.
+  //
+  // The caller must have the necessary permissions to add an entry to the registry.
+  add_registry_entry : (AddRegistryEntryInput) -> (AddRegistryEntryResult);
+  // Edit an existing entry in the registry.
+  // A registry entry can only be edited if it references the same kind of value.
+  //
+  // The caller must have the necessary permissions to edit an entry in the registry.
+  edit_registry_entry : (EditRegistryEntryInput) -> (EditRegistryEntryResult);
+  // Deletes an existing entry from the registry.
+  delete_registry_entry : (DeleteRegistryEntryInput) -> (DeleteRegistryEntryResult);
+  // Get the registry entry by its id.
+  get_registry_entry : (GetRegistryEntryInput) -> (GetRegistryEntryResult) query;
+  // Search the registry for entries.
+  search_registry : (SearchRegistryInput) -> (SearchRegistryResult) query;
   // Enables the caller to get an artifact by its id.
   get_artifact : (GetArtifactInput) -> (GetArtifactResult) query;
   // Uploads the canister modules for the station and upgrader canisters.

--- a/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
@@ -2,6 +2,10 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface AddRegistryEntryInput { 'entry' : RegistryEntryInput }
+export interface AddRegistryEntryResponse { 'entry' : RegistryEntry }
+export type AddRegistryEntryResult = { 'Ok' : AddRegistryEntryResponse } |
+  { 'Err' : ApiError };
 export interface ApiError {
   'code' : string,
   'message' : [] | [string],
@@ -21,6 +25,10 @@ export type CanDeployStationResponse = {
   { 'QuotaExceeded' : null };
 export type CanDeployStationResult = { 'Ok' : CanDeployStationResponse } |
   { 'Err' : ApiError };
+export interface DeleteRegistryEntryInput { 'id' : UUID }
+export interface DeleteRegistryEntryResponse { 'entry' : RegistryEntry }
+export type DeleteRegistryEntryResult = { 'Ok' : DeleteRegistryEntryResponse } |
+  { 'Err' : ApiError };
 export interface DeployStationAdminUserInput {
   'username' : string,
   'identity' : Principal,
@@ -32,9 +40,20 @@ export interface DeployStationInput {
 }
 export type DeployStationResult = { 'Ok' : { 'canister_id' : StationID } } |
   { 'Err' : ApiError };
+export interface EditRegistryEntryInput {
+  'id' : UUID,
+  'entry' : RegistryEntryInput,
+}
+export interface EditRegistryEntryResponse { 'entry' : RegistryEntry }
+export type EditRegistryEntryResult = { 'Ok' : EditRegistryEntryResponse } |
+  { 'Err' : ApiError };
 export interface GetArtifactInput { 'artifact_id' : UUID }
 export interface GetArtifactResponse { 'artifact' : Artifact }
 export type GetArtifactResult = { 'Ok' : GetArtifactResponse } |
+  { 'Err' : ApiError };
+export interface GetRegistryEntryInput { 'id' : UUID }
+export interface GetRegistryEntryResponse { 'entry' : RegistryEntry }
+export type GetRegistryEntryResult = { 'Ok' : GetRegistryEntryResponse } |
   { 'Err' : ApiError };
 export type GetUserResult = { 'Ok' : { 'user' : User } } |
   { 'Err' : ApiError };
@@ -67,10 +86,52 @@ export type ManageUserStationsInput = { 'Add' : Array<UserStation> } |
   { 'Update' : Array<{ 'station' : UserStation, 'index' : [] | [bigint] }> };
 export type ManageUserStationsResult = { 'Ok' : null } |
   { 'Err' : ApiError };
+export interface Metadata { 'key' : string, 'value' : string }
+export interface PaginationInput {
+  'offset' : [] | [bigint],
+  'limit' : [] | [number],
+}
 export interface RegisterUserInput { 'station' : [] | [UserStation] }
 export type RegisterUserResult = { 'Ok' : { 'user' : User } } |
   { 'Err' : ApiError };
+export interface RegistryEntry {
+  'id' : UUID,
+  'categories' : Array<string>,
+  'updated_at' : [] | [TimestampRFC3339],
+  'value' : RegistryEntryValue,
+  'metadata' : Array<Metadata>,
+  'name' : string,
+  'tags' : Array<string>,
+  'description' : string,
+  'created_at' : TimestampRFC3339,
+}
+export interface RegistryEntryInput {
+  'categories' : Array<string>,
+  'value' : RegistryEntryValueInput,
+  'metadata' : Array<Metadata>,
+  'name' : string,
+  'tags' : Array<string>,
+  'description' : string,
+}
+export type RegistryEntryValue = {
+    'WasmModule' : WasmModuleRegistryEntryValue
+  };
+export type RegistryEntryValueInput = {
+    'WasmModule' : WasmModuleRegistryEntryValueInput
+  };
 export type RemoveUserResult = { 'Ok' : { 'user' : User } } |
+  { 'Err' : ApiError };
+export type SearchRegistryFilterKind = { 'Name' : string };
+export interface SearchRegistryInput {
+  'pagination' : [] | [PaginationInput],
+  'filter_by' : Array<SearchRegistryFilterKind>,
+}
+export interface SearchRegistryResponse {
+  'total' : bigint,
+  'entries' : Array<RegistryEntry>,
+  'next_offset' : [] | [bigint],
+}
+export type SearchRegistryResult = { 'Ok' : SearchRegistryResponse } |
   { 'Err' : ApiError };
 export type SetUserActiveResult = { 'Ok' : null } |
   { 'Err' : ApiError };
@@ -112,11 +173,37 @@ export type UserSubscriptionStatus = { 'Unsubscribed' : null } |
   { 'Approved' : null } |
   { 'Denylisted' : null } |
   { 'Pending' : null };
+export interface WasmModuleRegistryEntryValue {
+  'version' : string,
+  'dependencies' : Array<UUID>,
+  'wasm_artifact_id' : UUID,
+}
+export interface WasmModuleRegistryEntryValueInput {
+  'wasm_module' : Uint8Array | number[],
+  'version' : string,
+  'dependencies' : Array<UUID>,
+}
 export interface _SERVICE {
+  'add_registry_entry' : ActorMethod<
+    [AddRegistryEntryInput],
+    AddRegistryEntryResult
+  >,
   'can_deploy_station' : ActorMethod<[], CanDeployStationResult>,
+  'delete_registry_entry' : ActorMethod<
+    [DeleteRegistryEntryInput],
+    DeleteRegistryEntryResult
+  >,
   'delete_user' : ActorMethod<[], RemoveUserResult>,
   'deploy_station' : ActorMethod<[DeployStationInput], DeployStationResult>,
+  'edit_registry_entry' : ActorMethod<
+    [EditRegistryEntryInput],
+    EditRegistryEntryResult
+  >,
   'get_artifact' : ActorMethod<[GetArtifactInput], GetArtifactResult>,
+  'get_registry_entry' : ActorMethod<
+    [GetRegistryEntryInput],
+    GetRegistryEntryResult
+  >,
   'get_user' : ActorMethod<[], GetUserResult>,
   'get_waiting_list' : ActorMethod<[], GetWaitingListResult>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
@@ -129,6 +216,7 @@ export interface _SERVICE {
     ManageUserStationsResult
   >,
   'register_user' : ActorMethod<[RegisterUserInput], RegisterUserResult>,
+  'search_registry' : ActorMethod<[SearchRegistryInput], SearchRegistryResult>,
   'set_user_active' : ActorMethod<[], SetUserActiveResult>,
   'subscribe_to_waiting_list' : ActorMethod<
     [string],

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -383,7 +383,7 @@ type RegistryEntry = record {
   // The timestamp when the entry was created.
   created_at : TimestampRFC3339;
   // The timestamp when the entry was last updated.
-  updated_at : TimestampRFC3339;
+  updated_at : opt TimestampRFC3339;
 };
 
 // The registry entry value.
@@ -408,15 +408,15 @@ type WasmModuleRegistryEntryValue = record {
 };
 
 // The search registry filter options.
-type SearchRegistryFilter = variant {
+type SearchRegistryFilterKind = variant {
   // The name of the registry entry to find, if the namespace is not provided the default namespace is used.
-  name : text;
+  Name : text;
 };
 
 // The input for searching the registry.
 type SearchRegistryInput = record {
-  // Filters are used sequentially to filter the entries in the registry.
-  filter_by : vec SearchRegistryFilter;
+  // Filters are used sequentially and are combined with an AND operation to filter the entries in the registry.
+  filter_by : vec SearchRegistryFilterKind;
   // The pagination options to use for the search.
   pagination : opt PaginationInput;
 };
@@ -425,6 +425,10 @@ type SearchRegistryInput = record {
 type SearchRegistryResponse = record {
   // The list of registry entries that match the search criteria.
   entries : vec RegistryEntry;
+  // The total number of entries that match the search criteria.
+  total : nat64;
+  // The next offset to use for pagination.
+  next_offset : opt nat64;
 };
 
 // The search registry result.
@@ -526,17 +530,39 @@ type EditRegistryEntryResult = variant {
   Err : ApiError;
 };
 
+// The input for deleting a registry entry.
+type DeleteRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+};
+
+// The response of deleting a registry entry.
+type DeleteRegistryEntryResponse = record {
+  // The registry entry that was deleted.
+  entry : RegistryEntry;
+};
+
+// The result of deleting a registry entry.
+type DeleteRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : DeleteRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
 // The control panel service definition.
 service : () -> {
   // Add a new entry to the registry.
   //
   // The caller must have the necessary permissions to add an entry to the registry.
   add_registry_entry : (AddRegistryEntryInput) -> (AddRegistryEntryResult);
-  // Edit an existing entry in the registry. 
+  // Edit an existing entry in the registry.
   // A registry entry can only be edited if it references the same kind of value.
   //
   // The caller must have the necessary permissions to edit an entry in the registry.
   edit_registry_entry : (EditRegistryEntryInput) -> (EditRegistryEntryResult);
+  // Deletes an existing entry from the registry.
+  delete_registry_entry : (DeleteRegistryEntryInput) -> (DeleteRegistryEntryResult);
   // Get the registry entry by its id.
   get_registry_entry : (GetRegistryEntryInput) -> (GetRegistryEntryResult) query;
   // Search the registry for entries.

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -341,7 +341,7 @@ type RegistryEntry = record {
   // - Names that start with `@` must have a namespace and a name separated by a `/`.
   // - Names must be between 2 and 48 characters long.
   // - Namespaces must be between 2 and 32 characters long.
-  // - Names that are not namespaced, are put in the default namespace `@a`.
+  // - Names that are not namespaced, are put in the default namespace `@default`.
   // - Namespaced names must be at most 64 characters long.
   name : text;
   // The description of the entry, which is a human-readable description of the entry.

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -21,6 +21,15 @@ type ApiError = record {
   details : opt vec record { text; text };
 };
 
+type PaginationInput = record {
+  // The offset to use for pagination.
+  offset : opt nat64;
+  // The maximum number of items to retrieve.
+  //
+  // If not set, the default limit will be used.
+  limit : opt nat16;
+};
+
 // The user user information.
 type User = record {
   // The identity associated with the user.
@@ -193,19 +202,19 @@ type DeployStationResult = variant {
   Err : ApiError;
 };
 
-/// The successful result of checking if the caller can deploy a station canister.
-/// Returns the remaining number of station canisters the caller can still deploy
-/// or a reason why the caller cannot deploy a station canister
-/// (bad subscription status or exceeded quota).
+// The successful result of checking if the caller can deploy a station canister.
+// Returns the remaining number of station canisters the caller can still deploy
+// or a reason why the caller cannot deploy a station canister
+// (bad subscription status or exceeded quota).
 type CanDeployStationResponse = variant {
   NotAllowed : UserSubscriptionStatus;
   Allowed : nat64;
   QuotaExceeded;
 };
 
-/// The input for deploying a station admin user.
-///
-/// Used to associate a user with a station canister as an admin when initializing the station.
+// The input for deploying a station admin user.
+//
+// Used to associate a user with a station canister as an admin when initializing the station.
 type DeployStationAdminUserInput = record {
   // The username to associate with the station canister as an admin.
   username : text;
@@ -213,7 +222,7 @@ type DeployStationAdminUserInput = record {
   identity : principal;
 };
 
-/// The input for deploying a station canister.
+// The input for deploying a station canister.
 type DeployStationInput = record {
   // The station name to use.
   name : text;
@@ -310,8 +319,228 @@ type GetArtifactResult = variant {
   Err : ApiError;
 };
 
+// A metadata record that contains a key and a value.
+type Metadata = record {
+  key : text;
+  value : text;
+};
+
+// An entry record, which contains information and the value stored in the registry.
+type RegistryEntry = record {
+  // The UUID that identifies the entry in the registry.
+  id : UUID;
+  // The name of the entry, which is used to identify it (e.g. station). Names that start with `@` are considered
+  // to be namespaced, and the namespace is the part of the name that comes before the `/`. Within each namespace
+  // the name should refer to the same type of entry, but many entries can exist with the same name.
+  //
+  // e.g. if the namespace is "@orbit" and the name is "station", then all the entries will refer to a wasm module.
+  //
+  // Restrictions:
+  //
+  // - Names that start with `@` are considered namespaced.
+  // - Names that start with `@` must have a namespace and a name separated by a `/`.
+  // - Names must be between 2 and 48 characters long.
+  // - Namespaces must be between 2 and 32 characters long.
+  // - Names that are not namespaced, are put in the default namespace `@a`.
+  // - Namespaced names must be at most 64 characters long.
+  name : text;
+  // The description of the entry, which is a human-readable description of the entry.
+  //
+  // Restrictions:
+  //
+  // - Descriptions must be between 24 and 512 characters long.
+  description : text;
+  // The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+  //
+  // Tags are grouped within the same `namespace/name` (e.g. "@orbit/station").
+  //
+  // Restrictions:
+  //
+  // - Tags must be between 2 and 32 characters long.
+  // - There can be up to 10 tags per entry.
+  tags : vec text;
+  // The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+  // across all the entries in the registry.
+  //
+  // Restrictions:
+  //
+  // - Categories must be between 2 and 32 characters long.
+  // - There can be up to 10 categories per entry.
+  categories : vec text;
+  // The metadata of the entry in the registry.
+  //
+  // This is a key-value map that can be used to store additional information about the entry,
+  // such as the author, license, repository, docs, etc.
+  //
+  // Restrictions:
+  //
+  // - The key must be between 1 and 32 characters long.
+  // - The value must be between 1 and 512 characters long.
+  // - There can be up to 10 metadata entries per entry in the registry.
+  metadata : vec Metadata;
+  // The content of the entry in the registry.
+  value : RegistryEntryValue;
+  // The timestamp when the entry was created.
+  created_at : TimestampRFC3339;
+  // The timestamp when the entry was last updated.
+  updated_at : TimestampRFC3339;
+};
+
+// The registry entry value.
+type RegistryEntryValue = variant {
+  WasmModule : WasmModuleRegistryEntryValue;
+};
+
+// The wasm module registry value, which is the content of the wasm module and its version.
+type WasmModuleRegistryEntryValue = record {
+  // The id of the wasm module that is stored in the artifact repository.
+  wasm_artifact_id : UUID;
+  // The version of the wasm module.
+  //
+  // Restrictions:
+  //
+  // - Versions must be between 1 and 32 characters long.
+  version : text;
+  // The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+  //
+  // This registry ids should only reference registry entries that are of type `WasmModule`, others will be ignored.
+  dependencies : vec UUID;
+};
+
+// The search registry filter options.
+type SearchRegistryFilter = variant {
+  // The name of the registry entry to find, if the namespace is not provided the default namespace is used.
+  name : text;
+};
+
+// The input for searching the registry.
+type SearchRegistryInput = record {
+  // Filters are used sequentially to filter the entries in the registry.
+  filter_by : vec SearchRegistryFilter;
+  // The pagination options to use for the search.
+  pagination : opt PaginationInput;
+};
+
+// The search registry response.
+type SearchRegistryResponse = record {
+  // The list of registry entries that match the search criteria.
+  entries : vec RegistryEntry;
+};
+
+// The search registry result.
+type SearchRegistryResult = variant {
+  // Successfull operation result.
+  Ok : SearchRegistryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The input for getting a registry entry.
+type GetRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+};
+
+// The get registry entry response.
+type GetRegistryEntryResponse = record {
+  // The registry entry that matches the provided id.
+  entry : RegistryEntry;
+};
+
+// The get registry entry result.
+type GetRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : GetRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The registry entry input.
+type RegistryEntryInput = record {
+  // The name of the entry, which is used to identify it (e.g. station).
+  name : text;
+  // The description of the entry, which is a human-readable description of the entry.
+  description : text;
+  // The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+  tags : vec text;
+  // The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+  // across all the entries in the registry.
+  categories : vec text;
+  // The metadata of the entry in the registry.
+  metadata : vec Metadata;
+  // The content of the entry in the registry.
+  value : RegistryEntryValueInput;
+};
+
+// The registry entry value input.
+type RegistryEntryValueInput = variant {
+  WasmModule : WasmModuleRegistryEntryValueInput;
+};
+
+// The wasm module registry value input, which is the content of the wasm module and its version.
+type WasmModuleRegistryEntryValueInput = record {
+  // The wasm module that should be stored in the artifact repository.
+  wasm_module : blob;
+  // The version of the wasm module.
+  version : text;
+  // The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+  dependencies : vec UUID;
+};
+
+// The input for adding a registry entry.
+type AddRegistryEntryInput = record {
+  entry : RegistryEntryInput;
+};
+
+// The response of adding a registry entry.
+type AddRegistryEntryResponse = record {
+  entry : RegistryEntry;
+};
+
+// The result of adding a registry entry.
+type AddRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : AddRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
+// The input for editing a registry entry.
+type EditRegistryEntryInput = record {
+  // The id of the registry entry.
+  id : UUID;
+  // The updated registry entry.
+  entry : RegistryEntryInput;
+};
+
+// The response of editing a registry entry.
+type EditRegistryEntryResponse = record {
+  entry : RegistryEntry;
+};
+
+// The result of editing a registry entry.
+type EditRegistryEntryResult = variant {
+  // Successfull operation result.
+  Ok : EditRegistryEntryResponse;
+  // The error that occurred during the operation.
+  Err : ApiError;
+};
+
 // The control panel service definition.
 service : () -> {
+  // Add a new entry to the registry.
+  //
+  // The caller must have the necessary permissions to add an entry to the registry.
+  add_registry_entry : (AddRegistryEntryInput) -> (AddRegistryEntryResult);
+  // Edit an existing entry in the registry. 
+  // A registry entry can only be edited if it references the same kind of value.
+  //
+  // The caller must have the necessary permissions to edit an entry in the registry.
+  edit_registry_entry : (EditRegistryEntryInput) -> (EditRegistryEntryResult);
+  // Get the registry entry by its id.
+  get_registry_entry : (GetRegistryEntryInput) -> (GetRegistryEntryResult) query;
+  // Search the registry for entries.
+  search_registry : (SearchRegistryInput) -> (SearchRegistryResult) query;
   // Enables the caller to get an artifact by its id.
   get_artifact : (GetArtifactInput) -> (GetArtifactResult) query;
   // Uploads the canister modules for the station and upgrader canisters.

--- a/core/control-panel/api/src/common.rs
+++ b/core/control-panel/api/src/common.rs
@@ -15,3 +15,15 @@ pub struct ApiErrorDTO {
     /// The error details if any.
     pub details: Option<HashMap<String, String>>,
 }
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct MetadataDTO {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct PaginationInput {
+    pub offset: Option<u64>,
+    pub limit: Option<u16>,
+}

--- a/core/control-panel/api/src/lib.rs
+++ b/core/control-panel/api/src/lib.rs
@@ -24,3 +24,7 @@ pub use manage_user::*;
 /// Canister hooks DTOs.
 mod canister;
 pub use canister::*;
+
+/// Registry DTOs.
+mod registry;
+pub use registry::*;

--- a/core/control-panel/api/src/registry.rs
+++ b/core/control-panel/api/src/registry.rs
@@ -1,0 +1,109 @@
+use crate::{MetadataDTO, PaginationInput, TimestampRfc3339, UuidDTO};
+use candid::{CandidType, Deserialize};
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct WasmModuleRegistryEntryValueDTO {
+    pub wasm_artifact_id: UuidDTO,
+    pub version: String,
+    pub dependencies: Vec<UuidDTO>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct WasmModuleRegistryEntryValueInput {
+    #[serde(with = "serde_bytes")]
+    pub wasm_module: Vec<u8>,
+    pub version: String,
+    pub dependencies: Vec<UuidDTO>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum RegistryEntryValueDTO {
+    WasmModule(WasmModuleRegistryEntryValueDTO),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum RegistryEntryValueInput {
+    WasmModule(WasmModuleRegistryEntryValueInput),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct RegistryEntryDTO {
+    pub id: UuidDTO,
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub categories: Vec<String>,
+    pub metadata: Vec<MetadataDTO>,
+    pub value: RegistryEntryValueDTO,
+    pub created_at: TimestampRfc3339,
+    pub updated_at: Option<TimestampRfc3339>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct RegistryEntryInput {
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub categories: Vec<String>,
+    pub metadata: Vec<MetadataDTO>,
+    pub value: RegistryEntryValueInput,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct GetRegistryEntryInput {
+    pub id: UuidDTO,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct GetRegistryEntryResponse {
+    pub entry: RegistryEntryDTO,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum SearchRegistryFilterKindDTO {
+    Name(String),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SearchRegistryInput {
+    pub filter_by: Vec<SearchRegistryFilterKindDTO>,
+    pub pagination: Option<PaginationInput>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SearchRegistryResponse {
+    pub entries: Vec<RegistryEntryDTO>,
+    pub total: u64,
+    pub next_offset: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct AddRegistryEntryInput {
+    pub entry: RegistryEntryInput,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct AddRegistryEntryResponse {
+    pub entry: RegistryEntryDTO,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct EditRegistryEntryInput {
+    pub id: UuidDTO,
+    pub entry: RegistryEntryInput,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct EditRegistryEntryResponse {
+    pub entry: RegistryEntryDTO,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DeleteRegistryEntryInput {
+    pub id: UuidDTO,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DeleteRegistryEntryResponse {
+    pub entry: RegistryEntryDTO,
+}

--- a/core/control-panel/impl/src/controllers/mod.rs
+++ b/core/control-panel/impl/src/controllers/mod.rs
@@ -16,6 +16,10 @@ pub use canister::*;
 mod station;
 pub use station::*;
 
+/// Registry entrypoints.
+mod registry;
+pub use registry::*;
+
 /// HTTP entrypoints.
 mod http;
 pub use http::*;

--- a/core/control-panel/impl/src/controllers/registry.rs
+++ b/core/control-panel/impl/src/controllers/registry.rs
@@ -1,0 +1,138 @@
+use crate::{
+    core::middlewares::{call_context, use_canister_call_metric, use_is_authorized_admin},
+    mappers::HelperMapper,
+    services::{RegistryService, REGISTRY_SERVICE},
+};
+use control_panel_api::{
+    AddRegistryEntryInput, AddRegistryEntryResponse, DeleteRegistryEntryInput,
+    DeleteRegistryEntryResponse, EditRegistryEntryInput, EditRegistryEntryResponse,
+    GetRegistryEntryInput, GetRegistryEntryResponse, SearchRegistryInput, SearchRegistryResponse,
+};
+use ic_cdk_macros::{query, update};
+use lazy_static::lazy_static;
+use orbit_essentials::{api::ApiResult, with_middleware};
+use std::sync::Arc;
+
+// Canister entrypoints for the controller.
+#[query(name = "get_registry_entry")]
+async fn get_registry_entry(input: GetRegistryEntryInput) -> ApiResult<GetRegistryEntryResponse> {
+    CONTROLLER.get_registry_entry(input).await
+}
+
+#[query(name = "search_registry")]
+async fn search_registry(input: SearchRegistryInput) -> ApiResult<SearchRegistryResponse> {
+    CONTROLLER.search_registry(input).await
+}
+
+#[update(name = "add_registry_entry")]
+async fn add_registry_entry(input: AddRegistryEntryInput) -> ApiResult<AddRegistryEntryResponse> {
+    CONTROLLER.add_registry_entry(input).await
+}
+
+#[update(name = "edit_registry_entry")]
+async fn edit_registry_entry(
+    input: EditRegistryEntryInput,
+) -> ApiResult<EditRegistryEntryResponse> {
+    CONTROLLER.edit_registry_entry(input).await
+}
+
+#[update(name = "delete_registry_entry")]
+async fn delete_registry_entry(
+    input: DeleteRegistryEntryInput,
+) -> ApiResult<DeleteRegistryEntryResponse> {
+    CONTROLLER.delete_registry_entry(input).await
+}
+
+// Controller initialization and implementation.
+lazy_static! {
+    static ref CONTROLLER: RegistryController =
+        RegistryController::new(Arc::clone(&REGISTRY_SERVICE));
+}
+
+#[derive(Debug)]
+pub struct RegistryController {
+    registry_service: Arc<RegistryService>,
+}
+
+impl RegistryController {
+    pub fn new(registry_service: Arc<RegistryService>) -> Self {
+        Self { registry_service }
+    }
+
+    /// Returns the registry entry by id.
+    pub async fn get_registry_entry(
+        &self,
+        input: GetRegistryEntryInput,
+    ) -> ApiResult<GetRegistryEntryResponse> {
+        let entry = self.registry_service.get(
+            HelperMapper::to_uuid(input.id)
+                .expect("Invalid registry id")
+                .as_bytes(),
+        )?;
+
+        Ok(GetRegistryEntryResponse {
+            entry: entry.into(),
+        })
+    }
+
+    /// Searches the registry for entries.
+    pub async fn search_registry(
+        &self,
+        _input: SearchRegistryInput,
+    ) -> ApiResult<SearchRegistryResponse> {
+        unimplemented!()
+    }
+
+    /// Adds a new registry entry.
+    #[with_middleware(guard = use_is_authorized_admin(&call_context()))]
+    #[with_middleware(tail = use_canister_call_metric("add_registry_entry", &result))]
+    pub async fn add_registry_entry(
+        &self,
+        _input: AddRegistryEntryInput,
+    ) -> ApiResult<AddRegistryEntryResponse> {
+        unimplemented!()
+    }
+
+    /// Edits an existing registry entry.
+    #[with_middleware(guard = use_is_authorized_admin(&call_context()))]
+    #[with_middleware(tail = use_canister_call_metric("edit_registry_entry", &result))]
+    pub async fn edit_registry_entry(
+        &self,
+        _input: EditRegistryEntryInput,
+    ) -> ApiResult<EditRegistryEntryResponse> {
+        unimplemented!()
+    }
+
+    /// Deletes an existing registry entry.
+    #[with_middleware(guard = use_is_authorized_admin(&call_context()))]
+    #[with_middleware(tail = use_canister_call_metric("delete_registry_entry", &result))]
+    pub async fn delete_registry_entry(
+        &self,
+        _input: DeleteRegistryEntryInput,
+    ) -> ApiResult<DeleteRegistryEntryResponse> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::RegistryError;
+    use orbit_essentials::api::ApiError;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn test_get_registry_entry_not_found() {
+        let entry_id = Uuid::new_v4().to_string();
+        let result = CONTROLLER
+            .get_registry_entry(GetRegistryEntryInput {
+                id: entry_id.clone(),
+            })
+            .await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            ApiError::from(RegistryError::NotFound { id: entry_id })
+        );
+    }
+}

--- a/core/control-panel/impl/src/core/memory.rs
+++ b/core/control-panel/impl/src/core/memory.rs
@@ -14,6 +14,8 @@ pub const USER_IDENTITY_INDEX_MEMORY_ID: MemoryId = MemoryId::new(2);
 pub const USER_STATUS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(3);
 pub const ARTIFACT_MEMORY_ID: MemoryId = MemoryId::new(4);
 pub const ARTIFACT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(5);
+pub const REGISTRY_MEMORY_ID: MemoryId = MemoryId::new(6);
+pub const REGISTRY_INDEX_MEMORY_ID: MemoryId = MemoryId::new(7);
 
 thread_local! {
   /// Static configuration of the canister.

--- a/core/control-panel/impl/src/core/middlewares.rs
+++ b/core/control-panel/impl/src/core/middlewares.rs
@@ -68,3 +68,12 @@ where
             .inc();
     });
 }
+
+/// Trap the execution of the canister call if the caller is not an authorized admin
+///
+/// An admin is an identity that is either the canister itself or a controller.
+pub fn use_is_authorized_admin(ctx: &CallContext) {
+    if !ctx.is_admin() {
+        ic_cdk::api::trap("You are not authorized to perform this action");
+    }
+}

--- a/core/control-panel/impl/src/errors/registry.rs
+++ b/core/control-panel/impl/src/errors/registry.rs
@@ -8,6 +8,9 @@ pub enum RegistryError {
     /// The registry entry failed validation.
     #[error(r#"The registry entry failed validation due to {info}."#)]
     ValidationError { info: String },
+    /// The registry entry was not found.
+    #[error("The registry entry with id {id} was not found.")]
+    NotFound { id: String },
 }
 
 impl DetailableError for RegistryError {
@@ -16,6 +19,10 @@ impl DetailableError for RegistryError {
         match self {
             RegistryError::ValidationError { info } => {
                 details.insert("info".to_string(), info.to_string());
+                Some(details)
+            }
+            RegistryError::NotFound { id } => {
+                details.insert("id".to_string(), id.to_string());
                 Some(details)
             }
         }

--- a/core/control-panel/impl/src/mappers/helper.rs
+++ b/core/control-panel/impl/src/mappers/helper.rs
@@ -1,5 +1,5 @@
 use crate::errors::MapperError;
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 use uuid::Uuid;
 
 #[derive(Default, Clone, Debug)]
@@ -12,6 +12,21 @@ impl HelperMapper {
         })?;
 
         Ok(uuid)
+    }
+
+    pub fn to_metadata(map: BTreeMap<String, String>) -> Vec<control_panel_api::MetadataDTO> {
+        map.into_iter()
+            .map(|(key, value)| control_panel_api::MetadataDTO { key, value })
+            .collect()
+    }
+
+    pub fn from_metadata(
+        metadata: Vec<control_panel_api::MetadataDTO>,
+    ) -> BTreeMap<String, String> {
+        metadata
+            .into_iter()
+            .map(|metadata| (metadata.key, metadata.value))
+            .collect()
     }
 }
 

--- a/core/control-panel/impl/src/mappers/mod.rs
+++ b/core/control-panel/impl/src/mappers/mod.rs
@@ -9,3 +9,5 @@ pub mod user_station;
 
 mod helper;
 pub use helper::*;
+
+mod registry;

--- a/core/control-panel/impl/src/mappers/registry.rs
+++ b/core/control-panel/impl/src/mappers/registry.rs
@@ -1,9 +1,52 @@
-use crate::models::{RegistryValue, RegistryValueKind};
+use super::HelperMapper;
+use crate::models::{Registry, RegistryValue, RegistryValueKind, WasmModuleRegistryValue};
+use orbit_essentials::utils::timestamp_to_rfc3339;
+use uuid::Uuid;
 
 impl From<&RegistryValue> for RegistryValueKind {
     fn from(value: &RegistryValue) -> Self {
         match value {
             RegistryValue::WasmModule(_) => RegistryValueKind::WasmModule,
+        }
+    }
+}
+
+impl From<WasmModuleRegistryValue> for control_panel_api::WasmModuleRegistryEntryValueDTO {
+    fn from(value: WasmModuleRegistryValue) -> Self {
+        Self {
+            wasm_artifact_id: Uuid::from_bytes(value.wasm_artifact_id).to_string(),
+            version: value.version,
+            dependencies: value
+                .dependencies
+                .into_iter()
+                .map(|dependency_id| Uuid::from_bytes(dependency_id).to_string())
+                .collect(),
+        }
+    }
+}
+
+impl From<RegistryValue> for control_panel_api::RegistryEntryValueDTO {
+    fn from(value: RegistryValue) -> Self {
+        match value {
+            RegistryValue::WasmModule(wasm_module) => {
+                control_panel_api::RegistryEntryValueDTO::WasmModule(wasm_module.into())
+            }
+        }
+    }
+}
+
+impl From<Registry> for control_panel_api::RegistryEntryDTO {
+    fn from(entry: Registry) -> Self {
+        Self {
+            id: Uuid::from_bytes(entry.id).to_string(),
+            name: entry.name,
+            description: entry.description,
+            tags: entry.tags,
+            categories: entry.categories,
+            metadata: HelperMapper::to_metadata(entry.metadata),
+            value: entry.value.into(),
+            created_at: timestamp_to_rfc3339(&entry.created_at),
+            updated_at: entry.updated_at.map(|ts| timestamp_to_rfc3339(&ts)),
         }
     }
 }

--- a/core/control-panel/impl/src/mappers/registry.rs
+++ b/core/control-panel/impl/src/mappers/registry.rs
@@ -1,5 +1,5 @@
 use super::HelperMapper;
-use crate::models::{Registry, RegistryValue, RegistryValueKind, WasmModuleRegistryValue};
+use crate::models::{RegistryEntry, RegistryValue, RegistryValueKind, WasmModuleRegistryValue};
 use orbit_essentials::utils::timestamp_to_rfc3339;
 use uuid::Uuid;
 
@@ -35,8 +35,8 @@ impl From<RegistryValue> for control_panel_api::RegistryEntryValueDTO {
     }
 }
 
-impl From<Registry> for control_panel_api::RegistryEntryDTO {
-    fn from(entry: Registry) -> Self {
+impl From<RegistryEntry> for control_panel_api::RegistryEntryDTO {
+    fn from(entry: RegistryEntry) -> Self {
         Self {
             id: Uuid::from_bytes(entry.id).to_string(),
             name: entry.name,

--- a/core/control-panel/impl/src/mappers/registry.rs
+++ b/core/control-panel/impl/src/mappers/registry.rs
@@ -1,0 +1,9 @@
+use crate::models::{RegistryValue, RegistryValueKind};
+
+impl From<&RegistryValue> for RegistryValueKind {
+    fn from(value: &RegistryValue) -> Self {
+        match value {
+            RegistryValue::WasmModule(_) => RegistryValueKind::WasmModule,
+        }
+    }
+}

--- a/core/control-panel/impl/src/models/indexes/artifact_index.rs
+++ b/core/control-panel/impl/src/models/indexes/artifact_index.rs
@@ -7,7 +7,7 @@ use orbit_essentials::storable;
 pub struct ArtifactIndex {
     /// An indexed value of the artifact.
     pub index: ArtifactIndexKind,
-    /// The user id, which is a UUID.
+    /// The artifact id, which is a UUID.
     pub artifact_id: ArtifactId,
 }
 
@@ -37,6 +37,11 @@ impl Artifact {
             index: ArtifactIndexKind::Size(self.artifact().len() as u64),
             artifact_id: *self.id(),
         }
+    }
+
+    /// Converts the artifact to a list of indexes for searching.
+    pub fn indexes(&self) -> Vec<ArtifactIndex> {
+        vec![self.to_index_by_hash(), self.to_index_by_size()]
     }
 }
 

--- a/core/control-panel/impl/src/models/indexes/mod.rs
+++ b/core/control-panel/impl/src/models/indexes/mod.rs
@@ -1,3 +1,4 @@
 pub mod artifact_index;
+pub mod registry_index;
 pub mod user_identity_index;
 pub mod user_status_index;

--- a/core/control-panel/impl/src/models/indexes/registry_index.rs
+++ b/core/control-panel/impl/src/models/indexes/registry_index.rs
@@ -137,7 +137,7 @@ mod tests {
 
         assert_eq!(
             index.index,
-            RegistryIndexKind::Namespace(entry.unnamespaced_name().to_string())
+            RegistryIndexKind::Name(entry.unnamespaced_name().to_string())
         );
         assert_eq!(index.registry_id, entry.id);
     }
@@ -171,10 +171,14 @@ mod tests {
 
     #[test]
     fn valid_to_fullname() {
-        let entry = create_registry_entry();
+        let mut entry = create_registry_entry();
+        entry.name = "@mynamespace/test".to_string();
         let index = entry.to_index_by_fullname();
 
-        assert_eq!(index.index, RegistryIndexKind::Name(entry.name.to_string()));
+        assert_eq!(
+            index.index,
+            RegistryIndexKind::Fullname(entry.name.to_string())
+        );
         assert_eq!(index.registry_id, entry.id);
     }
 

--- a/core/control-panel/impl/src/models/indexes/registry_index.rs
+++ b/core/control-panel/impl/src/models/indexes/registry_index.rs
@@ -1,4 +1,4 @@
-use crate::models::{Registry, RegistryId, RegistryValueKind};
+use crate::models::{RegistryEntry, RegistryEntryId, RegistryValueKind};
 use orbit_essentials::storable;
 
 /// The main index for registry entries.
@@ -8,7 +8,7 @@ pub struct RegistryIndex {
     /// An indexed value of the registry entry.
     pub index: RegistryIndexKind,
     /// The registry entry id, which is a UUID.
-    pub registry_id: RegistryId,
+    pub registry_entry_id: RegistryEntryId,
 }
 
 #[storable]
@@ -28,7 +28,7 @@ pub struct RegistryIndexCriteria {
     pub to: RegistryIndexKind,
 }
 
-impl Registry {
+impl RegistryEntry {
     pub fn to_index_by_fullname(&self) -> RegistryIndex {
         RegistryIndex {
             index: RegistryIndexKind::Fullname(format!(
@@ -36,21 +36,21 @@ impl Registry {
                 self.namespace(),
                 self.unnamespaced_name()
             )),
-            registry_id: self.id,
+            registry_entry_id: self.id,
         }
     }
 
     pub fn to_index_by_namespace(&self) -> RegistryIndex {
         RegistryIndex {
             index: RegistryIndexKind::Namespace(self.namespace().to_string()),
-            registry_id: self.id,
+            registry_entry_id: self.id,
         }
     }
 
     pub fn to_index_by_unnamespaced_name(&self) -> RegistryIndex {
         RegistryIndex {
             index: RegistryIndexKind::Name(self.unnamespaced_name().to_string()),
-            registry_id: self.id,
+            registry_entry_id: self.id,
         }
     }
 
@@ -59,7 +59,7 @@ impl Registry {
             .iter()
             .map(|category| RegistryIndex {
                 index: RegistryIndexKind::Category(category.to_string()),
-                registry_id: self.id,
+                registry_entry_id: self.id,
             })
             .collect()
     }
@@ -69,7 +69,7 @@ impl Registry {
             .iter()
             .map(|tag| RegistryIndex {
                 index: RegistryIndexKind::Tag(tag.to_string()),
-                registry_id: self.id,
+                registry_entry_id: self.id,
             })
             .collect()
     }
@@ -77,7 +77,7 @@ impl Registry {
     pub fn to_index_by_value_kind(&self) -> RegistryIndex {
         RegistryIndex {
             index: RegistryIndexKind::ValueKind(RegistryValueKind::from(&self.value)),
-            registry_id: self.id,
+            registry_entry_id: self.id,
         }
     }
 
@@ -104,14 +104,17 @@ mod tests {
     fn valid_model_serialization() {
         let model: RegistryIndex = RegistryIndex {
             index: RegistryIndexKind::Namespace("test".to_string()),
-            registry_id: [u8::MAX; 16],
+            registry_entry_id: [u8::MAX; 16],
         };
 
         let serialized_model = model.to_bytes();
         let deserialized_model = RegistryIndex::from_bytes(serialized_model);
 
         assert_eq!(model.index, deserialized_model.index);
-        assert_eq!(model.registry_id, deserialized_model.registry_id);
+        assert_eq!(
+            model.registry_entry_id,
+            deserialized_model.registry_entry_id
+        );
     }
 
     #[test]
@@ -125,7 +128,7 @@ mod tests {
             index.index,
             RegistryIndexKind::Namespace(entry.namespace().to_string())
         );
-        assert_eq!(index.registry_id, entry.id);
+        assert_eq!(index.registry_entry_id, entry.id);
     }
 
     #[test]
@@ -139,7 +142,7 @@ mod tests {
             index.index,
             RegistryIndexKind::Name(entry.unnamespaced_name().to_string())
         );
-        assert_eq!(index.registry_id, entry.id);
+        assert_eq!(index.registry_entry_id, entry.id);
     }
 
     #[test]
@@ -153,7 +156,7 @@ mod tests {
                 index[i].index,
                 RegistryIndexKind::Category(category.to_string())
             );
-            assert_eq!(index[i].registry_id, entry.id);
+            assert_eq!(index[i].registry_entry_id, entry.id);
         }
     }
 
@@ -165,7 +168,7 @@ mod tests {
         assert_eq!(index.len(), entry.tags.len());
         for (i, tag) in entry.tags.iter().enumerate() {
             assert_eq!(index[i].index, RegistryIndexKind::Tag(tag.to_string()));
-            assert_eq!(index[i].registry_id, entry.id);
+            assert_eq!(index[i].registry_entry_id, entry.id);
         }
     }
 
@@ -179,7 +182,7 @@ mod tests {
             index.index,
             RegistryIndexKind::Fullname(entry.name.to_string())
         );
-        assert_eq!(index.registry_id, entry.id);
+        assert_eq!(index.registry_entry_id, entry.id);
     }
 
     #[test]
@@ -191,6 +194,6 @@ mod tests {
             index.index,
             RegistryIndexKind::ValueKind(RegistryValueKind::from(&entry.value))
         );
-        assert_eq!(index.registry_id, entry.id);
+        assert_eq!(index.registry_entry_id, entry.id);
     }
 }

--- a/core/control-panel/impl/src/models/indexes/registry_index.rs
+++ b/core/control-panel/impl/src/models/indexes/registry_index.rs
@@ -1,0 +1,192 @@
+use crate::models::{Registry, RegistryId, RegistryValueKind};
+use orbit_essentials::storable;
+
+/// The main index for registry entries.
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RegistryIndex {
+    /// An indexed value of the registry entry.
+    pub index: RegistryIndexKind,
+    /// The registry entry id, which is a UUID.
+    pub registry_id: RegistryId,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RegistryIndexKind {
+    Fullname(String),
+    Namespace(String),
+    Name(String),
+    Category(String),
+    Tag(String),
+    ValueKind(RegistryValueKind),
+}
+
+#[derive(Clone, Debug)]
+pub struct RegistryIndexCriteria {
+    pub from: RegistryIndexKind,
+    pub to: RegistryIndexKind,
+}
+
+impl Registry {
+    pub fn to_index_by_fullname(&self) -> RegistryIndex {
+        RegistryIndex {
+            index: RegistryIndexKind::Fullname(format!(
+                "@{}/{}",
+                self.namespace(),
+                self.unnamespaced_name()
+            )),
+            registry_id: self.id,
+        }
+    }
+
+    pub fn to_index_by_namespace(&self) -> RegistryIndex {
+        RegistryIndex {
+            index: RegistryIndexKind::Namespace(self.namespace().to_string()),
+            registry_id: self.id,
+        }
+    }
+
+    pub fn to_index_by_unnamespaced_name(&self) -> RegistryIndex {
+        RegistryIndex {
+            index: RegistryIndexKind::Name(self.unnamespaced_name().to_string()),
+            registry_id: self.id,
+        }
+    }
+
+    pub fn to_index_by_categories(&self) -> Vec<RegistryIndex> {
+        self.categories
+            .iter()
+            .map(|category| RegistryIndex {
+                index: RegistryIndexKind::Category(category.to_string()),
+                registry_id: self.id,
+            })
+            .collect()
+    }
+
+    pub fn to_index_by_tags(&self) -> Vec<RegistryIndex> {
+        self.tags
+            .iter()
+            .map(|tag| RegistryIndex {
+                index: RegistryIndexKind::Tag(tag.to_string()),
+                registry_id: self.id,
+            })
+            .collect()
+    }
+
+    pub fn to_index_by_value_kind(&self) -> RegistryIndex {
+        RegistryIndex {
+            index: RegistryIndexKind::ValueKind(RegistryValueKind::from(&self.value)),
+            registry_id: self.id,
+        }
+    }
+
+    /// Converts the registry entry to a list of indexes for searching.
+    pub fn indexes(&self) -> Vec<RegistryIndex> {
+        let mut indexes = vec![self.to_index_by_fullname()];
+        indexes.push(self.to_index_by_namespace());
+        indexes.push(self.to_index_by_unnamespaced_name());
+        indexes.extend(self.to_index_by_categories());
+        indexes.extend(self.to_index_by_tags());
+        indexes.push(self.to_index_by_value_kind());
+
+        indexes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::registry_entry_test_utils::create_registry_entry;
+    use ic_stable_structures::Storable;
+
+    #[test]
+    fn valid_model_serialization() {
+        let model: RegistryIndex = RegistryIndex {
+            index: RegistryIndexKind::Namespace("test".to_string()),
+            registry_id: [u8::MAX; 16],
+        };
+
+        let serialized_model = model.to_bytes();
+        let deserialized_model = RegistryIndex::from_bytes(serialized_model);
+
+        assert_eq!(model.index, deserialized_model.index);
+        assert_eq!(model.registry_id, deserialized_model.registry_id);
+    }
+
+    #[test]
+    fn valid_to_namespace() {
+        let mut entry = create_registry_entry();
+        entry.name = "@mynamespace/test".to_string();
+
+        let index = entry.to_index_by_namespace();
+
+        assert_eq!(
+            index.index,
+            RegistryIndexKind::Namespace(entry.namespace().to_string())
+        );
+        assert_eq!(index.registry_id, entry.id);
+    }
+
+    #[test]
+    fn valid_to_unnamespaced_name() {
+        let mut entry = create_registry_entry();
+        entry.name = "@mynamespace/test".to_string();
+
+        let index = entry.to_index_by_unnamespaced_name();
+
+        assert_eq!(
+            index.index,
+            RegistryIndexKind::Namespace(entry.unnamespaced_name().to_string())
+        );
+        assert_eq!(index.registry_id, entry.id);
+    }
+
+    #[test]
+    fn valid_to_categories() {
+        let entry = create_registry_entry();
+        let index = entry.to_index_by_categories();
+
+        assert_eq!(index.len(), entry.categories.len());
+        for (i, category) in entry.categories.iter().enumerate() {
+            assert_eq!(
+                index[i].index,
+                RegistryIndexKind::Category(category.to_string())
+            );
+            assert_eq!(index[i].registry_id, entry.id);
+        }
+    }
+
+    #[test]
+    fn valid_to_tags() {
+        let entry = create_registry_entry();
+        let index = entry.to_index_by_tags();
+
+        assert_eq!(index.len(), entry.tags.len());
+        for (i, tag) in entry.tags.iter().enumerate() {
+            assert_eq!(index[i].index, RegistryIndexKind::Tag(tag.to_string()));
+            assert_eq!(index[i].registry_id, entry.id);
+        }
+    }
+
+    #[test]
+    fn valid_to_fullname() {
+        let entry = create_registry_entry();
+        let index = entry.to_index_by_fullname();
+
+        assert_eq!(index.index, RegistryIndexKind::Name(entry.name.to_string()));
+        assert_eq!(index.registry_id, entry.id);
+    }
+
+    #[test]
+    fn valid_to_value_kind() {
+        let entry = create_registry_entry();
+        let index = entry.to_index_by_value_kind();
+
+        assert_eq!(
+            index.index,
+            RegistryIndexKind::ValueKind(RegistryValueKind::from(&entry.value))
+        );
+        assert_eq!(index.registry_id, entry.id);
+    }
+}

--- a/core/control-panel/impl/src/models/mod.rs
+++ b/core/control-panel/impl/src/models/mod.rs
@@ -6,8 +6,8 @@ pub use user_station::*;
 mod user;
 pub use user::*;
 
-mod registry_entry;
-pub use registry_entry::*;
+mod registry;
+pub use registry::*;
 
 mod artifact;
 pub use artifact::*;

--- a/core/control-panel/impl/src/models/mod.rs
+++ b/core/control-panel/impl/src/models/mod.rs
@@ -6,8 +6,8 @@ pub use user_station::*;
 mod user;
 pub use user::*;
 
-mod registry;
-pub use registry::*;
+mod registry_entry;
+pub use registry_entry::*;
 
 mod artifact;
 pub use artifact::*;

--- a/core/control-panel/impl/src/models/registry.rs
+++ b/core/control-panel/impl/src/models/registry.rs
@@ -183,7 +183,7 @@ impl Registry {
             let parts: Vec<&str> = raw_name.split('/').collect();
             namespace = parts[0].trim_start_matches('@');
 
-            if namespace == "" {
+            if namespace.trim().is_empty() {
                 namespace = Self::DEFAULT_NAMESPACE;
             }
 

--- a/core/control-panel/impl/src/repositories/artifact.rs
+++ b/core/control-panel/impl/src/repositories/artifact.rs
@@ -46,10 +46,10 @@ impl Repository<ArtifactId, Artifact> for ArtifactRepository {
 
             self.indexes
                 .refresh_index_on_modification(RefreshIndexMode::List {
-                    previous: prev.clone().map_or(Vec::new(), |prev: Artifact| {
-                        vec![prev.to_index_by_hash(), prev.to_index_by_size()]
-                    }),
-                    current: vec![value.to_index_by_hash(), value.to_index_by_size()],
+                    previous: prev
+                        .clone()
+                        .map_or(Vec::new(), |prev: Artifact| prev.indexes()),
+                    current: value.indexes(),
                 });
 
             prev
@@ -62,9 +62,7 @@ impl Repository<ArtifactId, Artifact> for ArtifactRepository {
 
             self.indexes
                 .refresh_index_on_modification(RefreshIndexMode::CleanupList {
-                    current: prev.clone().map_or(Vec::new(), |prev| {
-                        vec![prev.to_index_by_hash(), prev.to_index_by_size()]
-                    }),
+                    current: prev.clone().map_or(Vec::new(), |prev| prev.indexes()),
                 });
 
             prev

--- a/core/control-panel/impl/src/repositories/indexes/mod.rs
+++ b/core/control-panel/impl/src/repositories/indexes/mod.rs
@@ -1,3 +1,4 @@
 pub mod artifact_index;
+pub mod registry_index;
 pub mod user_identity_index;
 pub mod user_status_index;

--- a/core/control-panel/impl/src/repositories/indexes/registry_index.rs
+++ b/core/control-panel/impl/src/repositories/indexes/registry_index.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{with_memory_manager, Memory, REGISTRY_INDEX_MEMORY_ID},
     models::{
         indexes::registry_index::{RegistryIndex, RegistryIndexCriteria},
-        RegistryId,
+        RegistryEntryId,
     },
 };
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
@@ -21,7 +21,7 @@ thread_local! {
 #[derive(Default, Debug)]
 pub struct RegistryIndexRepository {}
 
-impl IndexRepository<RegistryIndex, RegistryId> for RegistryIndexRepository {
+impl IndexRepository<RegistryIndex, RegistryEntryId> for RegistryIndexRepository {
     type FindByCriteria = RegistryIndexCriteria;
 
     fn exists(&self, index: &RegistryIndex) -> bool {
@@ -36,21 +36,21 @@ impl IndexRepository<RegistryIndex, RegistryId> for RegistryIndexRepository {
         DB.with(|m| m.borrow_mut().remove(index).is_some())
     }
 
-    fn find_by_criteria(&self, criteria: Self::FindByCriteria) -> HashSet<RegistryId> {
+    fn find_by_criteria(&self, criteria: Self::FindByCriteria) -> HashSet<RegistryEntryId> {
         DB.with(|db| {
             let start_key = RegistryIndex {
                 index: criteria.from,
-                registry_id: [u8::MIN; 16],
+                registry_entry_id: [u8::MIN; 16],
             };
             let end_key = RegistryIndex {
                 index: criteria.to,
-                registry_id: [u8::MAX; 16],
+                registry_entry_id: [u8::MAX; 16],
             };
 
             db.borrow()
                 .range(start_key..=end_key)
-                .map(|(index, _)| index.registry_id)
-                .collect::<HashSet<RegistryId>>()
+                .map(|(index, _)| index.registry_entry_id)
+                .collect::<HashSet<RegistryEntryId>>()
         })
     }
 }
@@ -76,7 +76,7 @@ mod tests {
         let repository = RegistryIndexRepository::default();
         let index = RegistryIndex {
             index: RegistryIndexKind::Fullname("test".to_string()),
-            registry_id: [1; 16],
+            registry_entry_id: [1; 16],
         };
 
         assert!(!repository.exists(&index));
@@ -94,7 +94,7 @@ mod tests {
         for i in 0..10 {
             repository.insert(RegistryIndex {
                 index: RegistryIndexKind::Name(i.to_string()),
-                registry_id: [i; 16],
+                registry_entry_id: [i; 16],
             });
         }
 
@@ -113,7 +113,7 @@ mod tests {
         for i in 0..10 {
             repository.insert(RegistryIndex {
                 index: RegistryIndexKind::Category(i.to_string()),
-                registry_id: [i; 16],
+                registry_entry_id: [i; 16],
             });
         }
 

--- a/core/control-panel/impl/src/repositories/indexes/registry_index.rs
+++ b/core/control-panel/impl/src/repositories/indexes/registry_index.rs
@@ -1,0 +1,128 @@
+use crate::{
+    core::{with_memory_manager, Memory, REGISTRY_INDEX_MEMORY_ID},
+    models::{
+        indexes::registry_index::{RegistryIndex, RegistryIndexCriteria},
+        RegistryId,
+    },
+};
+use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
+use orbit_essentials::repository::IndexRepository;
+use std::{cell::RefCell, collections::HashSet};
+
+thread_local! {
+  static DB: RefCell<StableBTreeMap<RegistryIndex, (), VirtualMemory<Memory>>> = with_memory_manager(|memory_manager| {
+    RefCell::new(
+      StableBTreeMap::init(memory_manager.get(REGISTRY_INDEX_MEMORY_ID))
+    )
+  })
+}
+
+/// A repository that holds the registry indexes, which is used to find registry entries efficiently.
+#[derive(Default, Debug)]
+pub struct RegistryIndexRepository {}
+
+impl IndexRepository<RegistryIndex, RegistryId> for RegistryIndexRepository {
+    type FindByCriteria = RegistryIndexCriteria;
+
+    fn exists(&self, index: &RegistryIndex) -> bool {
+        DB.with(|m| m.borrow().get(index).is_some())
+    }
+
+    fn insert(&self, index: RegistryIndex) {
+        DB.with(|m| m.borrow_mut().insert(index, ()));
+    }
+
+    fn remove(&self, index: &RegistryIndex) -> bool {
+        DB.with(|m| m.borrow_mut().remove(index).is_some())
+    }
+
+    fn find_by_criteria(&self, criteria: Self::FindByCriteria) -> HashSet<RegistryId> {
+        DB.with(|db| {
+            let start_key = RegistryIndex {
+                index: criteria.from,
+                registry_id: [u8::MIN; 16],
+            };
+            let end_key = RegistryIndex {
+                index: criteria.to,
+                registry_id: [u8::MAX; 16],
+            };
+
+            db.borrow()
+                .range(start_key..=end_key)
+                .map(|(index, _)| index.registry_id)
+                .collect::<HashSet<RegistryId>>()
+        })
+    }
+}
+
+impl RegistryIndexRepository {
+    pub fn len(&self) -> u64 {
+        DB.with(|m| m.borrow().len())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        DB.with(|m| m.borrow().is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::indexes::registry_index::RegistryIndexKind;
+    use orbit_essentials::repository::IndexRepository;
+
+    #[test]
+    fn test_index_repository() {
+        let repository = RegistryIndexRepository::default();
+        let index = RegistryIndex {
+            index: RegistryIndexKind::Fullname("test".to_string()),
+            registry_id: [1; 16],
+        };
+
+        assert!(!repository.exists(&index));
+
+        repository.insert(index.clone());
+
+        assert!(repository.exists(&index));
+        assert!(repository.remove(&index));
+        assert!(!repository.exists(&index));
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let repository = RegistryIndexRepository::default();
+        for i in 0..10 {
+            repository.insert(RegistryIndex {
+                index: RegistryIndexKind::Name(i.to_string()),
+                registry_id: [i; 16],
+            });
+        }
+
+        let result = repository.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Name("0".to_string()),
+            to: RegistryIndexKind::Name("2".to_string()),
+        });
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_find_by_categories() {
+        let repository = RegistryIndexRepository::default();
+        for i in 0..10 {
+            repository.insert(RegistryIndex {
+                index: RegistryIndexKind::Category(i.to_string()),
+                registry_id: [i; 16],
+            });
+        }
+
+        let result = repository.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Category("3".to_string()),
+            to: RegistryIndexKind::Category("4".to_string()),
+        });
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/core/control-panel/impl/src/repositories/mod.rs
+++ b/core/control-panel/impl/src/repositories/mod.rs
@@ -6,4 +6,7 @@ pub use artifact::*;
 mod user;
 pub use user::*;
 
+mod registry;
+pub use registry::*;
+
 pub mod indexes;

--- a/core/control-panel/impl/src/repositories/registry.rs
+++ b/core/control-panel/impl/src/repositories/registry.rs
@@ -1,0 +1,375 @@
+use super::indexes::registry_index::RegistryIndexRepository;
+use crate::{
+    core::{with_memory_manager, Memory, REGISTRY_MEMORY_ID},
+    models::{
+        indexes::registry_index::{RegistryIndexCriteria, RegistryIndexKind},
+        Registry, RegistryId, RegistryValueKind,
+    },
+};
+use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
+use lazy_static::lazy_static;
+use orbit_essentials::repository::RefreshIndexMode;
+use orbit_essentials::repository::{IndexRepository, Repository};
+use std::{cell::RefCell, sync::Arc};
+
+thread_local! {
+  static DB: RefCell<StableBTreeMap<RegistryId, Registry, VirtualMemory<Memory>>> = with_memory_manager(|memory_manager| {
+    RefCell::new(
+      StableBTreeMap::init(memory_manager.get(REGISTRY_MEMORY_ID))
+    )
+  })
+}
+
+lazy_static! {
+    pub static ref REGISTRY_REPOSITORY: Arc<RegistryRepository> =
+        Arc::new(RegistryRepository::default());
+}
+
+/// A repository that enables managing registry entries in stable memory.
+#[derive(Default, Debug)]
+pub struct RegistryRepository {
+    indexes: RegistryIndexRepository,
+}
+
+impl Repository<RegistryId, Registry> for RegistryRepository {
+    fn list(&self) -> Vec<Registry> {
+        DB.with(|m| m.borrow().iter().map(|(_, v)| v).collect())
+    }
+
+    fn get(&self, key: &RegistryId) -> Option<Registry> {
+        DB.with(|m| m.borrow().get(key))
+    }
+
+    fn insert(&self, key: RegistryId, value: Registry) -> Option<Registry> {
+        DB.with(|m| {
+            let prev = m.borrow_mut().insert(key, value.clone());
+
+            self.indexes
+                .refresh_index_on_modification(RefreshIndexMode::List {
+                    previous: prev
+                        .clone()
+                        .map_or(Vec::new(), |prev: Registry| prev.indexes()),
+                    current: value.indexes(),
+                });
+
+            prev
+        })
+    }
+
+    fn remove(&self, key: &RegistryId) -> Option<Registry> {
+        DB.with(|m| {
+            let prev = m.borrow_mut().remove(key);
+
+            self.indexes
+                .refresh_index_on_modification(RefreshIndexMode::CleanupList {
+                    current: prev.clone().map_or(Vec::new(), |prev| prev.indexes()),
+                });
+
+            prev
+        })
+    }
+
+    fn len(&self) -> usize {
+        DB.with(|m| m.borrow().len()) as usize
+    }
+}
+
+impl RegistryRepository {
+    /// Finds the ids of the registry entries by the given name.
+    pub fn find_ids_by_fullname(&self, name: &str) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Fullname(name.to_string()),
+            to: RegistryIndexKind::Fullname(name.to_string()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given name.
+    pub fn find_by_fullname(&self, name: &str) -> Vec<Registry> {
+        self.find_ids_by_fullname(name)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+
+    /// Finds the ids of the registry entries by the given namespace.
+    pub fn find_ids_by_namespace(&self, namespace: &str) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Namespace(namespace.to_string()),
+            to: RegistryIndexKind::Namespace(namespace.to_string()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given namespace.
+    pub fn find_by_namespace(&self, namespace: &str) -> Vec<Registry> {
+        self.find_ids_by_namespace(namespace)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+
+    /// Finds the ids of the registry entries by the given unnamespaced name.
+    pub fn find_ids_by_name(&self, unnamespaced_name: &str) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Name(unnamespaced_name.to_string()),
+            to: RegistryIndexKind::Name(unnamespaced_name.to_string()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given unnamespaced name.
+    pub fn find_by_name(&self, unnamespaced_name: &str) -> Vec<Registry> {
+        self.find_ids_by_name(unnamespaced_name)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+
+    /// Finds the ids of the registry entries by the given category.
+    pub fn find_ids_by_category(&self, category: &str) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Category(category.to_string()),
+            to: RegistryIndexKind::Category(category.to_string()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given category.
+    pub fn find_by_category(&self, category: &str) -> Vec<Registry> {
+        self.find_ids_by_category(category)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+
+    /// Find by tags the registry entries by the given tag.
+    pub fn find_ids_by_tag(&self, tag: &str) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::Tag(tag.to_string()),
+            to: RegistryIndexKind::Tag(tag.to_string()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given tag.
+    pub fn find_by_tag(&self, tag: &str) -> Vec<Registry> {
+        self.find_ids_by_tag(tag)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+
+    /// Finds the ids of the registry entries by the given value kind.
+    pub fn find_ids_by_kind(&self, kind: &RegistryValueKind) -> Vec<RegistryId> {
+        let entries = self.indexes.find_by_criteria(RegistryIndexCriteria {
+            from: RegistryIndexKind::ValueKind(kind.clone()),
+            to: RegistryIndexKind::ValueKind(kind.clone()),
+        });
+
+        entries.into_iter().collect()
+    }
+
+    /// Finds the registry entries by the given value kind.
+    pub fn find_by_kind(&self, kind: &RegistryValueKind) -> Vec<Registry> {
+        self.find_ids_by_kind(kind)
+            .into_iter()
+            .filter_map(|id| self.get(&id))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::registry_entry_test_utils::{
+        create_registry_entry, create_wasm_module_registry_entry_value,
+    };
+    use orbit_essentials::model::ModelValidator;
+
+    #[test]
+    fn check_crud_operations() {
+        let repository = RegistryRepository::default();
+        let entry = create_registry_entry();
+
+        assert!(repository.get(&entry.id).is_none());
+
+        repository.insert(entry.id, entry.clone());
+        assert_eq!(repository.len(), 1);
+        assert_eq!(repository.get(&entry.id), Some(entry.clone()));
+
+        repository.remove(&entry.id);
+
+        assert!(repository.get(&entry.id).is_none());
+
+        assert_eq!(repository.len(), 0);
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let repository = RegistryRepository::default();
+        for i in 0..10 {
+            let mut entry = create_registry_entry();
+            entry.name = format!("entry-{}", i);
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_name("entry-2");
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+
+        let entry = result.first().unwrap();
+
+        assert_eq!(entry.name, "entry-2");
+
+        let result = repository.find_by_name("entry-");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_namespace() {
+        let repository = RegistryRepository::default();
+        for i in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.name = format!("@orbit/entry-{}", i);
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_namespace("orbit");
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 5);
+        assert!(result.iter().any(|entry| entry.name == "@orbit/entry-0"));
+
+        let result = repository.find_by_namespace("orbi");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_fullname() {
+        let repository = RegistryRepository::default();
+        for i in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.name = format!("@orbit/entry-{}", i);
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_fullname("@orbit/entry-2");
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+
+        let entry = result.first().unwrap();
+
+        assert_eq!(entry.name, "@orbit/entry-2");
+
+        let result = repository.find_by_fullname("@orbit/entry-");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_fullname_when_namespace_not_set() {
+        let repository = RegistryRepository::default();
+        for i in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.name = format!("entry-{}", i);
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository
+            .find_by_fullname(format!("@{}/entry-2", Registry::DEFAULT_NAMESPACE).as_str());
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+
+        let entry = result.first().unwrap();
+
+        assert_eq!(entry.name, "entry-2");
+    }
+
+    #[test]
+    fn test_find_by_category() {
+        let repository = RegistryRepository::default();
+        for i in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.categories.push(format!("category-{}", i));
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_category("category-2");
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+
+        let entry = result.first().unwrap();
+
+        assert_eq!(entry.categories.len(), 1);
+        assert_eq!(entry.categories.first().unwrap(), "category-2");
+
+        let result = repository.find_by_category("category-");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_tag() {
+        let repository = RegistryRepository::default();
+        for i in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.tags.push(format!("tag-{}", i));
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_tag("tag-2");
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+
+        let entry = result.first().unwrap();
+
+        assert_eq!(entry.tags.len(), 1);
+        assert_eq!(entry.tags.first().unwrap(), "tag-2");
+
+        let result = repository.find_by_tag("tag-");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_kind() {
+        let repository = RegistryRepository::default();
+        for _ in 0..5 {
+            let mut entry = create_registry_entry();
+            entry.value = create_wasm_module_registry_entry_value();
+            entry.validate().unwrap();
+
+            repository.insert(entry.id, entry);
+        }
+
+        let result = repository.find_by_kind(&RegistryValueKind::WasmModule);
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 5);
+    }
+}

--- a/core/control-panel/impl/src/services/mod.rs
+++ b/core/control-panel/impl/src/services/mod.rs
@@ -14,3 +14,6 @@ pub use canister::*;
 
 mod deploy;
 pub use deploy::*;
+
+mod registry;
+pub use registry::*;

--- a/core/control-panel/impl/src/services/registry.rs
+++ b/core/control-panel/impl/src/services/registry.rs
@@ -1,0 +1,69 @@
+use crate::{
+    errors::RegistryError,
+    models::{Registry, RegistryId},
+    repositories::{RegistryRepository, REGISTRY_REPOSITORY},
+};
+use lazy_static::lazy_static;
+use orbit_essentials::{api::ServiceResult, repository::Repository};
+use std::sync::Arc;
+use uuid::Uuid;
+
+lazy_static! {
+    pub static ref REGISTRY_SERVICE: Arc<RegistryService> =
+        Arc::new(RegistryService::new(Arc::clone(&REGISTRY_REPOSITORY)));
+}
+
+/// The registry service provides methods to manage registry entries.
+#[derive(Default, Debug)]
+pub struct RegistryService {
+    registry_repository: Arc<RegistryRepository>,
+}
+
+impl RegistryService {
+    pub fn new(registry_repository: Arc<RegistryRepository>) -> Self {
+        Self {
+            registry_repository,
+        }
+    }
+
+    /// Returns the registry entry by id.
+    pub fn get(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
+        let entry =
+            self.registry_repository
+                .get(registry_id)
+                .ok_or_else(|| RegistryError::NotFound {
+                    id: Uuid::from_bytes(*registry_id).to_string(),
+                })?;
+
+        Ok(entry)
+    }
+
+    /// Creates a new registry entry and returns it.
+    pub fn create(&self) -> ServiceResult<Registry> {
+        todo!()
+    }
+
+    /// Updates the registry entry and returns it.
+    pub fn edit(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
+        let _entry = self.get(registry_id)?;
+
+        todo!();
+    }
+
+    /// Deletes the registry entry by id.
+    pub fn delete(&self, registry_id: &RegistryId) -> ServiceResult<()> {
+        self.registry_repository.remove(registry_id);
+
+        Ok(())
+    }
+
+    /// Returns all registry entries by the given name, if the name is not namespaced, 
+    /// the default namespace is used.
+    pub fn find_by_name(&self, name: &str) -> ServiceResult<Vec<Registry>> {
+        let entries = self
+            .registry_repository
+            .find_by_fullname(&Registry::format_fullname(name));
+
+        Ok(entries)
+    }
+}

--- a/core/control-panel/impl/src/services/registry.rs
+++ b/core/control-panel/impl/src/services/registry.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::RegistryError,
-    models::{Registry, RegistryId, RegistryValue},
+    models::{RegistryEntry, RegistryEntryId, RegistryValue},
     repositories::{
         ArtifactRepository, RegistryRepository, ARTIFACT_REPOSITORY, REGISTRY_REPOSITORY,
     },
@@ -37,7 +37,7 @@ impl RegistryService {
     }
 
     /// Returns the registry entry by id.
-    pub fn get(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
+    pub fn get(&self, registry_id: &RegistryEntryId) -> ServiceResult<RegistryEntry> {
         let entry =
             self.registry_repository
                 .get(registry_id)
@@ -49,17 +49,17 @@ impl RegistryService {
     }
 
     /// Creates a new registry entry and returns it.
-    pub fn create(&self) -> ServiceResult<Registry> {
+    pub fn create(&self) -> ServiceResult<RegistryEntry> {
         unimplemented!()
     }
 
     /// Updates the registry entry and returns it.
-    pub fn edit(&self, _registry_id: &RegistryId) -> ServiceResult<Registry> {
+    pub fn edit(&self, _registry_id: &RegistryEntryId) -> ServiceResult<RegistryEntry> {
         unimplemented!()
     }
 
     /// Deletes the registry entry by id.
-    pub fn delete(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
+    pub fn delete(&self, registry_id: &RegistryEntryId) -> ServiceResult<RegistryEntry> {
         let registry = self.get(registry_id)?;
 
         match &registry.value {
@@ -76,7 +76,10 @@ impl RegistryService {
 
     /// Returns all registry entries by the given name, if the name is not namespaced,
     /// the default namespace is used.
-    pub fn search(&self, _search: SearchRegistryInput) -> ServiceResult<PaginatedData<Registry>> {
+    pub fn search(
+        &self,
+        _search: SearchRegistryInput,
+    ) -> ServiceResult<PaginatedData<RegistryEntry>> {
         unimplemented!()
     }
 }

--- a/core/control-panel/impl/src/services/registry.rs
+++ b/core/control-panel/impl/src/services/registry.rs
@@ -1,28 +1,38 @@
 use crate::{
     errors::RegistryError,
-    models::{Registry, RegistryId},
-    repositories::{RegistryRepository, REGISTRY_REPOSITORY},
+    models::{Registry, RegistryId, RegistryValue},
+    repositories::{
+        ArtifactRepository, RegistryRepository, ARTIFACT_REPOSITORY, REGISTRY_REPOSITORY,
+    },
 };
+use control_panel_api::SearchRegistryInput;
 use lazy_static::lazy_static;
-use orbit_essentials::{api::ServiceResult, repository::Repository};
+use orbit_essentials::{api::ServiceResult, pagination::PaginatedData, repository::Repository};
 use std::sync::Arc;
 use uuid::Uuid;
 
 lazy_static! {
-    pub static ref REGISTRY_SERVICE: Arc<RegistryService> =
-        Arc::new(RegistryService::new(Arc::clone(&REGISTRY_REPOSITORY)));
+    pub static ref REGISTRY_SERVICE: Arc<RegistryService> = Arc::new(RegistryService::new(
+        Arc::clone(&REGISTRY_REPOSITORY),
+        Arc::clone(&ARTIFACT_REPOSITORY)
+    ));
 }
 
 /// The registry service provides methods to manage registry entries.
 #[derive(Default, Debug)]
 pub struct RegistryService {
     registry_repository: Arc<RegistryRepository>,
+    artifact_repository: Arc<ArtifactRepository>,
 }
 
 impl RegistryService {
-    pub fn new(registry_repository: Arc<RegistryRepository>) -> Self {
+    pub fn new(
+        registry_repository: Arc<RegistryRepository>,
+        artifact_repository: Arc<ArtifactRepository>,
+    ) -> Self {
         Self {
             registry_repository,
+            artifact_repository,
         }
     }
 
@@ -40,30 +50,33 @@ impl RegistryService {
 
     /// Creates a new registry entry and returns it.
     pub fn create(&self) -> ServiceResult<Registry> {
-        todo!()
+        unimplemented!()
     }
 
     /// Updates the registry entry and returns it.
-    pub fn edit(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
-        let _entry = self.get(registry_id)?;
-
-        todo!();
+    pub fn edit(&self, _registry_id: &RegistryId) -> ServiceResult<Registry> {
+        unimplemented!()
     }
 
     /// Deletes the registry entry by id.
-    pub fn delete(&self, registry_id: &RegistryId) -> ServiceResult<()> {
+    pub fn delete(&self, registry_id: &RegistryId) -> ServiceResult<Registry> {
+        let registry = self.get(registry_id)?;
+
+        match &registry.value {
+            RegistryValue::WasmModule(wasm_module) => {
+                self.artifact_repository
+                    .remove(&wasm_module.wasm_artifact_id);
+            }
+        };
+
         self.registry_repository.remove(registry_id);
 
-        Ok(())
+        Ok(registry)
     }
 
-    /// Returns all registry entries by the given name, if the name is not namespaced, 
+    /// Returns all registry entries by the given name, if the name is not namespaced,
     /// the default namespace is used.
-    pub fn find_by_name(&self, name: &str) -> ServiceResult<Vec<Registry>> {
-        let entries = self
-            .registry_repository
-            .find_by_fullname(&Registry::format_fullname(name));
-
-        Ok(entries)
+    pub fn search(&self, _search: SearchRegistryInput) -> ServiceResult<PaginatedData<Registry>> {
+        unimplemented!()
     }
 }

--- a/libs/orbit-essentials/src/lib.rs
+++ b/libs/orbit-essentials/src/lib.rs
@@ -15,6 +15,7 @@ pub mod model;
 pub mod repository;
 pub mod timers;
 
+pub mod pagination;
 pub mod types;
 pub mod utils;
 

--- a/libs/orbit-essentials/src/pagination.rs
+++ b/libs/orbit-essentials/src/pagination.rs
@@ -1,0 +1,141 @@
+use crate::api::DetailableError;
+use std::collections::HashMap;
+
+pub const DEFAULT_PAGINATION_LIMIT: u16 = 100;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PaginationError {
+    /// Invalid max limit.
+    #[error(r#"Invalid list limit, it cannot be more than {max}."#)]
+    MaxLimitExceeded { max: u16 },
+}
+
+impl DetailableError for PaginationError {
+    fn details(&self) -> Option<HashMap<String, String>> {
+        let mut details = HashMap::new();
+        match self {
+            PaginationError::MaxLimitExceeded { max } => {
+                details.insert("max".to_string(), max.to_string());
+                Some(details)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PaginatedData<T> {
+    pub items: Vec<T>,
+    pub next_offset: Option<u64>,
+    pub total: u64,
+}
+
+pub struct PaginatedItemsArgs<'a, T> {
+    pub offset: Option<u64>,
+    pub limit: Option<u16>,
+    pub default_limit: Option<u16>,
+    pub max_limit: Option<u16>,
+    pub items: &'a [T],
+}
+
+/// Paginates a list of items based on limit and offset.
+pub fn paginated_items<T>(
+    args: PaginatedItemsArgs<'_, T>,
+) -> Result<PaginatedData<T>, PaginationError>
+where
+    T: Clone,
+{
+    let offset = args.offset.unwrap_or(0) as usize;
+
+    if let (Some(max_limit), Some(limit)) = (args.max_limit, args.limit) {
+        if limit > max_limit {
+            Err(PaginationError::MaxLimitExceeded { max: max_limit })?;
+        }
+    }
+
+    let default_limit = args.default_limit.unwrap_or(match args.max_limit {
+        Some(max_limit) => max_limit,
+        None => DEFAULT_PAGINATION_LIMIT,
+    });
+    let limit = args.limit.unwrap_or(default_limit) as usize;
+
+    let total = args.items.len();
+
+    let next_offset = match (offset + limit) < total {
+        true => Some((offset + limit) as u64),
+        false => None,
+    };
+
+    let items = args
+        .items
+        .get(offset..std::cmp::min(offset + limit, total))
+        .unwrap_or(&[])
+        .to_vec();
+
+    Ok(PaginatedData {
+        items,
+        next_offset,
+        total: total as u64,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paginated_items_should_fail_when_limit_is_greater_than_max() {
+        let result = paginated_items(PaginatedItemsArgs {
+            offset: None,
+            limit: Some(10),
+            default_limit: None,
+            max_limit: Some(1),
+            items: &[1; 10],
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn paginated_items_should_return_max_limit_by_default() {
+        let result = paginated_items(PaginatedItemsArgs {
+            offset: None,
+            limit: None,
+            default_limit: None,
+            max_limit: Some(5),
+            items: &[1; 10],
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().items.len(), 5);
+    }
+
+    #[test]
+    fn paginated_items_should_return_next_offset_when_there_are_more_items() {
+        let result = paginated_items(PaginatedItemsArgs {
+            offset: None,
+            limit: Some(5),
+            default_limit: None,
+            max_limit: None,
+            items: &[1; 10],
+        })
+        .unwrap();
+
+        assert_eq!(result.items.len(), 5);
+        assert_eq!(result.next_offset, Some(5));
+    }
+
+    #[test]
+    fn paginated_items_should_filter_by_offset() {
+        let result = paginated_items(PaginatedItemsArgs {
+            offset: Some(6),
+            limit: Some(5),
+            default_limit: None,
+            max_limit: None,
+            items: &[1; 10],
+        })
+        .unwrap();
+
+        assert_eq!(result.items.len(), 4);
+        assert_eq!(result.next_offset, None);
+    }
+}


### PR DESCRIPTION
This PR adds the registry api interface and repositories for the registry. I've only included some of the get implementation in the service layer for now and had to move the pagination from the station canister to the common orbit_essentials lib to be reused by the control-panel. 

Also, i'll still create a follow up PR that will remove the pagination implementation from the station canister and will start to use it from the common orbit_essentials lib.