### PR TITLE
chore(station): make request creation asynchronous

### DIFF
--- a/core/station/impl/src/factories/requests/add_account.rs
+++ b/core/station/impl/src/factories/requests/add_account.rs
@@ -12,6 +12,7 @@ pub struct AddAccountRequestCreate {}
 #[async_trait]
 impl Create<station_api::AddAccountOperationInput> for AddAccountRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_account.rs
+++ b/core/station/impl/src/factories/requests/add_account.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct AddAccountRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::AddAccountOperationInput> for AddAccountRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/add_address_book_entry.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct AddAddressBookEntryRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::AddAddressBookEntryOperationInput> for AddAddressBookEntryRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/add_address_book_entry.rs
@@ -12,6 +12,7 @@ pub struct AddAddressBookEntryRequestCreate {}
 #[async_trait]
 impl Create<station_api::AddAddressBookEntryOperationInput> for AddAddressBookEntryRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_request_policy.rs
+++ b/core/station/impl/src/factories/requests/add_request_policy.rs
@@ -14,6 +14,7 @@ pub struct AddRequestPolicyRequestCreate {}
 #[async_trait]
 impl Create<station_api::AddRequestPolicyOperationInput> for AddRequestPolicyRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -97,14 +98,16 @@ mod tests {
         request_input.operation =
             station_api::RequestOperationInput::AddRequestPolicy(operation_input.clone());
 
-        let request = AddRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(AddRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
@@ -120,14 +123,16 @@ mod tests {
         request_input.operation =
             station_api::RequestOperationInput::AddRequestPolicy(operation_input.clone());
 
-        let request = AddRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(AddRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
 

--- a/core/station/impl/src/factories/requests/add_request_policy.rs
+++ b/core/station/impl/src/factories/requests/add_request_policy.rs
@@ -11,8 +11,9 @@ use orbit_essentials::types::UUID;
 
 pub struct AddRequestPolicyRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::AddRequestPolicyOperationInput> for AddRequestPolicyRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -87,8 +88,8 @@ mod tests {
     use crate::{repositories::REQUEST_REPOSITORY, services::REQUEST_POLICY_SERVICE};
     use orbit_essentials::repository::Repository;
 
-    #[test]
-    fn test_create_request() {
+    #[tokio::test]
+    async fn test_create_request() {
         let request_id = [0u8; 16];
         let requested_by_user = [1u8; 16];
         let operation_input = add_request_policy_test_utils::mock_add_request_policy_api_input();
@@ -102,6 +103,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         assert_eq!(request.id, request_id);
@@ -124,6 +126,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());

--- a/core/station/impl/src/factories/requests/add_user.rs
+++ b/core/station/impl/src/factories/requests/add_user.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct AddUserRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::AddUserOperationInput> for AddUserRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_user.rs
+++ b/core/station/impl/src/factories/requests/add_user.rs
@@ -12,6 +12,7 @@ pub struct AddUserRequestCreate {}
 #[async_trait]
 impl Create<station_api::AddUserOperationInput> for AddUserRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_user_group.rs
+++ b/core/station/impl/src/factories/requests/add_user_group.rs
@@ -12,6 +12,7 @@ pub struct AddUserGroupRequestCreate {}
 #[async_trait]
 impl Create<station_api::AddUserGroupOperationInput> for AddUserGroupRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/add_user_group.rs
+++ b/core/station/impl/src/factories/requests/add_user_group.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct AddUserGroupRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::AddUserGroupOperationInput> for AddUserGroupRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/change_canister.rs
+++ b/core/station/impl/src/factories/requests/change_canister.rs
@@ -18,8 +18,9 @@ use std::sync::Arc;
 
 pub struct ChangeCanisterRequestCreate;
 
+#[async_trait]
 impl Create<ChangeCanisterOperationInput> for ChangeCanisterRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,
@@ -127,8 +128,9 @@ impl Execute for ChangeCanisterRequestExecute<'_, '_> {
 
 pub struct ChangeManagedCanisterRequestCreate;
 
+#[async_trait]
 impl Create<ChangeManagedCanisterOperationInput> for ChangeManagedCanisterRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,

--- a/core/station/impl/src/factories/requests/change_canister.rs
+++ b/core/station/impl/src/factories/requests/change_canister.rs
@@ -21,6 +21,7 @@ pub struct ChangeCanisterRequestCreate;
 #[async_trait]
 impl Create<ChangeCanisterOperationInput> for ChangeCanisterRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,
@@ -131,6 +132,7 @@ pub struct ChangeManagedCanisterRequestCreate;
 #[async_trait]
 impl Create<ChangeManagedCanisterOperationInput> for ChangeManagedCanisterRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,

--- a/core/station/impl/src/factories/requests/create_canister.rs
+++ b/core/station/impl/src/factories/requests/create_canister.rs
@@ -11,8 +11,9 @@ use std::sync::Arc;
 
 pub struct CreateManagedCanisterRequestCreate;
 
+#[async_trait]
 impl Create<CreateManagedCanisterOperationInput> for CreateManagedCanisterRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,

--- a/core/station/impl/src/factories/requests/create_canister.rs
+++ b/core/station/impl/src/factories/requests/create_canister.rs
@@ -14,6 +14,7 @@ pub struct CreateManagedCanisterRequestCreate;
 #[async_trait]
 impl Create<CreateManagedCanisterOperationInput> for CreateManagedCanisterRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_account.rs
+++ b/core/station/impl/src/factories/requests/edit_account.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct EditAccountRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditAccountOperationInput> for EditAccountRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_account.rs
+++ b/core/station/impl/src/factories/requests/edit_account.rs
@@ -12,6 +12,7 @@ pub struct EditAccountRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditAccountOperationInput> for EditAccountRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/edit_address_book_entry.rs
@@ -16,6 +16,7 @@ pub struct EditAddressBookEntryRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditAddressBookEntryOperationInput> for EditAddressBookEntryRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/edit_address_book_entry.rs
@@ -13,8 +13,9 @@ use orbit_essentials::types::UUID;
 
 pub struct EditAddressBookEntryRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditAddressBookEntryOperationInput> for EditAddressBookEntryRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_permission.rs
+++ b/core/station/impl/src/factories/requests/edit_permission.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 
 pub struct EditPermissionRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditPermissionOperationInput> for EditPermissionRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -84,8 +85,8 @@ mod tests {
     };
     use orbit_essentials::{model::ModelKey, repository::Repository};
 
-    #[test]
-    fn test_create_request() {
+    #[tokio::test]
+    async fn test_create_request() {
         let request_id = [0u8; 16];
         let requested_by_user = [1u8; 16];
         let operation_input = edit_permission_test_utils::mock_edit_permission_api_input();
@@ -99,6 +100,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         assert_eq!(request.id, request_id);
@@ -121,6 +123,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());

--- a/core/station/impl/src/factories/requests/edit_permission.rs
+++ b/core/station/impl/src/factories/requests/edit_permission.rs
@@ -13,6 +13,7 @@ pub struct EditPermissionRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditPermissionOperationInput> for EditPermissionRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -94,14 +95,16 @@ mod tests {
         request_input.operation =
             station_api::RequestOperationInput::EditPermission(operation_input.clone());
 
-        let request = EditPermissionRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(EditPermissionRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
@@ -117,14 +120,16 @@ mod tests {
         request_input.operation =
             station_api::RequestOperationInput::EditPermission(operation_input.clone());
 
-        let request = EditPermissionRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(EditPermissionRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
 

--- a/core/station/impl/src/factories/requests/edit_request_policy.rs
+++ b/core/station/impl/src/factories/requests/edit_request_policy.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
 
 pub struct EditRequestPolicyRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditRequestPolicyOperationInput> for EditRequestPolicyRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -98,8 +99,8 @@ mod tests {
     use orbit_essentials::repository::Repository;
     use std::str::FromStr;
 
-    #[test]
-    fn test_create_request() {
+    #[tokio::test]
+    async fn test_create_request() {
         let request_id = [0u8; 16];
         let requested_by_user = [1u8; 16];
         let operation_input = edit_request_policy_test_utils::mock_edit_request_policy_api_input();
@@ -119,6 +120,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         assert_eq!(request.id, request_id);
@@ -147,6 +149,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
@@ -198,6 +201,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_POLICY_REPOSITORY.remove(&policy.id);

--- a/core/station/impl/src/factories/requests/edit_request_policy.rs
+++ b/core/station/impl/src/factories/requests/edit_request_policy.rs
@@ -17,6 +17,7 @@ pub struct EditRequestPolicyRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditRequestPolicyOperationInput> for EditRequestPolicyRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -114,14 +115,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = EditRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(EditRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
@@ -143,14 +146,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = EditRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(EditRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
 
@@ -195,14 +200,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = EditRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(EditRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_POLICY_REPOSITORY.remove(&policy.id);
 

--- a/core/station/impl/src/factories/requests/edit_user.rs
+++ b/core/station/impl/src/factories/requests/edit_user.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct EditUserRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditUserOperationInput> for EditUserRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_user.rs
+++ b/core/station/impl/src/factories/requests/edit_user.rs
@@ -12,6 +12,7 @@ pub struct EditUserRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditUserOperationInput> for EditUserRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_user_group.rs
+++ b/core/station/impl/src/factories/requests/edit_user_group.rs
@@ -12,6 +12,7 @@ pub struct EditUserGroupRequestCreate {}
 #[async_trait]
 impl Create<station_api::EditUserGroupOperationInput> for EditUserGroupRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/edit_user_group.rs
+++ b/core/station/impl/src/factories/requests/edit_user_group.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct EditUserGroupRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::EditUserGroupOperationInput> for EditUserGroupRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/manage_system_info.rs
+++ b/core/station/impl/src/factories/requests/manage_system_info.rs
@@ -12,6 +12,7 @@ pub struct ManageSystemInfoRequestCreate {}
 #[async_trait]
 impl Create<station_api::ManageSystemInfoOperationInput> for ManageSystemInfoRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -82,14 +83,11 @@ mod tests {
         create_request.operation =
             station_api::RequestOperationInput::ManageSystemInfo(input.clone());
 
-        let request = ManageSystemInfoRequestCreate::create(
-            request_id,
-            requested_by_user,
-            create_request,
-            input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(ManageSystemInfoRequestCreate {});
+        let request = creator
+            .create(request_id, requested_by_user, create_request, input)
+            .await
+            .unwrap();
 
         assert_eq!(request.requested_by, requested_by_user);
         assert_eq!(
@@ -117,14 +115,11 @@ mod tests {
         create_request.operation =
             station_api::RequestOperationInput::ManageSystemInfo(input.clone());
 
-        let request = ManageSystemInfoRequestCreate::create(
-            request_id,
-            requested_by_user,
-            create_request,
-            input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(ManageSystemInfoRequestCreate {});
+        let request = creator
+            .create(request_id, requested_by_user, create_request, input)
+            .await
+            .unwrap();
 
         let operation = match &request.operation {
             RequestOperation::ManageSystemInfo(operation) => operation,

--- a/core/station/impl/src/factories/requests/manage_system_info.rs
+++ b/core/station/impl/src/factories/requests/manage_system_info.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct ManageSystemInfoRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::ManageSystemInfoOperationInput> for ManageSystemInfoRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -71,8 +72,8 @@ mod tests {
     };
     use uuid::Uuid;
 
-    #[test]
-    fn test_create_request() {
+    #[tokio::test]
+    async fn test_create_request() {
         let request_id = *Uuid::new_v4().as_bytes();
         let requested_by_user = *Uuid::new_v4().as_bytes();
         let mut create_request = mock_request_api_operation();
@@ -87,6 +88,7 @@ mod tests {
             create_request,
             input,
         )
+        .await
         .unwrap();
 
         assert_eq!(request.requested_by, requested_by_user);
@@ -121,6 +123,7 @@ mod tests {
             create_request,
             input,
         )
+        .await
         .unwrap();
 
         let operation = match &request.operation {

--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -72,9 +72,10 @@ pub trait Execute: Send + Sync {
     async fn execute(&self) -> Result<RequestExecuteStage, RequestExecuteError>;
 }
 
+#[async_trait]
 pub trait Create<T>: Send + Sync {
     /// Creates a new request for the operation but does not save it.
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,
@@ -84,13 +85,13 @@ pub trait Create<T>: Send + Sync {
         Self: Sized;
 }
 
-fn create_request<OperationInput, Creator: Create<OperationInput>>(
+async fn create_request<OperationInput, Creator: Create<OperationInput>>(
     request_id: UUID,
     requested_by_user: UUID,
     input: CreateRequestInput,
     operation_input: OperationInput,
 ) -> Result<Request, RequestError> {
-    Creator::create(request_id, requested_by_user, input, operation_input)
+    Creator::create(request_id, requested_by_user, input, operation_input).await
 }
 
 #[derive(Debug)]
@@ -110,6 +111,7 @@ impl RequestFactory {
                     input.clone(),
                     operation.clone(),
                 )
+                .await
             }
             RequestOperationInput::AddAccount(operation) => {
                 create_request::<station_api::AddAccountOperationInput, AddAccountRequestCreate>(
@@ -118,6 +120,7 @@ impl RequestFactory {
                     input.clone(),
                     operation.clone(),
                 )
+                .await
             }
             RequestOperationInput::EditAccount(operation) => {
                 create_request::<station_api::EditAccountOperationInput, EditAccountRequestCreate>(
@@ -126,46 +129,55 @@ impl RequestFactory {
                     input.clone(),
                     operation.clone(),
                 )
+                .await
             }
             RequestOperationInput::AddAddressBookEntry(operation) => {
                 create_request::<
                     station_api::AddAddressBookEntryOperationInput,
                     AddAddressBookEntryRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::EditAddressBookEntry(operation) => {
                 create_request::<
                     station_api::EditAddressBookEntryOperationInput,
                     EditAddressBookEntryRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::RemoveAddressBookEntry(operation) => {
                 create_request::<
                     station_api::RemoveAddressBookEntryOperationInput,
                     RemoveAddressBookEntryRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
-            RequestOperationInput::AddUserGroup(operation) => {
-                create_request::<station_api::AddUserGroupOperationInput, AddUserGroupRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-            }
-            RequestOperationInput::EditUserGroup(operation) => {
-                create_request::<station_api::EditUserGroupOperationInput, EditUserGroupRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-            }
+            RequestOperationInput::AddUserGroup(operation) => create_request::<
+                station_api::AddUserGroupOperationInput,
+                AddUserGroupRequestCreate,
+            >(
+                id,
+                requested_by_user,
+                input.clone(),
+                operation.clone(),
+            )
+            .await,
+            RequestOperationInput::EditUserGroup(operation) => create_request::<
+                station_api::EditUserGroupOperationInput,
+                EditUserGroupRequestCreate,
+            >(
+                id,
+                requested_by_user,
+                input.clone(),
+                operation.clone(),
+            )
+            .await,
             RequestOperationInput::RemoveUserGroup(operation) => {
                 create_request::<
                     station_api::RemoveUserGroupOperationInput,
                     RemoveUserGroupRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::AddUser(operation) => {
                 create_request::<station_api::AddUserOperationInput, AddUserRequestCreate>(
@@ -174,6 +186,7 @@ impl RequestFactory {
                     input.clone(),
                     operation.clone(),
                 )
+                .await
             }
             RequestOperationInput::EditUser(operation) => {
                 create_request::<station_api::EditUserOperationInput, EditUserRequestCreate>(
@@ -182,54 +195,63 @@ impl RequestFactory {
                     input.clone(),
                     operation.clone(),
                 )
+                .await
             }
             RequestOperationInput::ChangeCanister(operation) => {
                 create_request::<
                     station_api::ChangeCanisterOperationInput,
                     ChangeCanisterRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::ChangeManagedCanister(operation) => {
                 create_request::<
                     station_api::ChangeManagedCanisterOperationInput,
                     ChangeManagedCanisterRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::CreateManagedCanister(operation) => {
                 create_request::<
                     station_api::CreateManagedCanisterOperationInput,
                     CreateManagedCanisterRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::EditPermission(operation) => {
                 create_request::<
                     station_api::EditPermissionOperationInput,
                     EditPermissionRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::AddRequestPolicy(operation) => {
                 create_request::<
                     station_api::AddRequestPolicyOperationInput,
                     AddRequestPolicyRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::EditRequestPolicy(operation) => {
                 create_request::<
                     station_api::EditRequestPolicyOperationInput,
                     EditRequestPolicyRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::RemoveRequestPolicy(operation) => {
                 create_request::<
                     station_api::RemoveRequestPolicyOperationInput,
                     RemoveRequestPolicyRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
             RequestOperationInput::ManageSystemInfo(operation) => {
                 create_request::<
                     station_api::ManageSystemInfoOperationInput,
                     manage_system_info::ManageSystemInfoRequestCreate,
                 >(id, requested_by_user, input.clone(), operation.clone())
+                .await
             }
         }
     }

--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -76,22 +76,12 @@ pub trait Execute: Send + Sync {
 pub trait Create<T>: Send + Sync {
     /// Creates a new request for the operation but does not save it.
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: CreateRequestInput,
         operation_input: T,
-    ) -> Result<Request, RequestError>
-    where
-        Self: Sized;
-}
-
-async fn create_request<OperationInput, Creator: Create<OperationInput>>(
-    request_id: UUID,
-    requested_by_user: UUID,
-    input: CreateRequestInput,
-    operation_input: OperationInput,
-) -> Result<Request, RequestError> {
-    Creator::create(request_id, requested_by_user, input, operation_input).await
+    ) -> Result<Request, RequestError>;
 }
 
 #[derive(Debug)]
@@ -105,153 +95,118 @@ impl RequestFactory {
         let id = *generate_uuid_v4().await.as_bytes();
         match &input.operation {
             RequestOperationInput::Transfer(operation) => {
-                create_request::<station_api::TransferOperationInput, TransferRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-                .await
+                let creator = Box::new(TransferRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::AddAccount(operation) => {
-                create_request::<station_api::AddAccountOperationInput, AddAccountRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-                .await
+                let creator = Box::new(AddAccountRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::EditAccount(operation) => {
-                create_request::<station_api::EditAccountOperationInput, EditAccountRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-                .await
+                let creator = Box::new(EditAccountRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::AddAddressBookEntry(operation) => {
-                create_request::<
-                    station_api::AddAddressBookEntryOperationInput,
-                    AddAddressBookEntryRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(AddAddressBookEntryRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::EditAddressBookEntry(operation) => {
-                create_request::<
-                    station_api::EditAddressBookEntryOperationInput,
-                    EditAddressBookEntryRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(EditAddressBookEntryRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::RemoveAddressBookEntry(operation) => {
-                create_request::<
-                    station_api::RemoveAddressBookEntryOperationInput,
-                    RemoveAddressBookEntryRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(RemoveAddressBookEntryRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
-            RequestOperationInput::AddUserGroup(operation) => create_request::<
-                station_api::AddUserGroupOperationInput,
-                AddUserGroupRequestCreate,
-            >(
-                id,
-                requested_by_user,
-                input.clone(),
-                operation.clone(),
-            )
-            .await,
-            RequestOperationInput::EditUserGroup(operation) => create_request::<
-                station_api::EditUserGroupOperationInput,
-                EditUserGroupRequestCreate,
-            >(
-                id,
-                requested_by_user,
-                input.clone(),
-                operation.clone(),
-            )
-            .await,
+            RequestOperationInput::AddUserGroup(operation) => {
+                let creator = Box::new(AddUserGroupRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
+            }
+            RequestOperationInput::EditUserGroup(operation) => {
+                let creator = Box::new(EditUserGroupRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
+            }
             RequestOperationInput::RemoveUserGroup(operation) => {
-                create_request::<
-                    station_api::RemoveUserGroupOperationInput,
-                    RemoveUserGroupRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(RemoveUserGroupRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::AddUser(operation) => {
-                create_request::<station_api::AddUserOperationInput, AddUserRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-                .await
+                let creator = Box::new(AddUserRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::EditUser(operation) => {
-                create_request::<station_api::EditUserOperationInput, EditUserRequestCreate>(
-                    id,
-                    requested_by_user,
-                    input.clone(),
-                    operation.clone(),
-                )
-                .await
+                let creator = Box::new(EditUserRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::ChangeCanister(operation) => {
-                create_request::<
-                    station_api::ChangeCanisterOperationInput,
-                    ChangeCanisterRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(ChangeCanisterRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::ChangeManagedCanister(operation) => {
-                create_request::<
-                    station_api::ChangeManagedCanisterOperationInput,
-                    ChangeManagedCanisterRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(ChangeManagedCanisterRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::CreateManagedCanister(operation) => {
-                create_request::<
-                    station_api::CreateManagedCanisterOperationInput,
-                    CreateManagedCanisterRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(CreateManagedCanisterRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::EditPermission(operation) => {
-                create_request::<
-                    station_api::EditPermissionOperationInput,
-                    EditPermissionRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(EditPermissionRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::AddRequestPolicy(operation) => {
-                create_request::<
-                    station_api::AddRequestPolicyOperationInput,
-                    AddRequestPolicyRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(AddRequestPolicyRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::EditRequestPolicy(operation) => {
-                create_request::<
-                    station_api::EditRequestPolicyOperationInput,
-                    EditRequestPolicyRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(EditRequestPolicyRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::RemoveRequestPolicy(operation) => {
-                create_request::<
-                    station_api::RemoveRequestPolicyOperationInput,
-                    RemoveRequestPolicyRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(RemoveRequestPolicyRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::ManageSystemInfo(operation) => {
-                create_request::<
-                    station_api::ManageSystemInfoOperationInput,
-                    manage_system_info::ManageSystemInfoRequestCreate,
-                >(id, requested_by_user, input.clone(), operation.clone())
-                .await
+                let creator = Box::new(manage_system_info::ManageSystemInfoRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
         }
     }

--- a/core/station/impl/src/factories/requests/remove_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/remove_address_book_entry.rs
@@ -18,6 +18,7 @@ impl Create<station_api::RemoveAddressBookEntryOperationInput>
     for RemoveAddressBookEntryRequestCreate
 {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/remove_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/remove_address_book_entry.rs
@@ -13,10 +13,11 @@ use orbit_essentials::types::UUID;
 
 pub struct RemoveAddressBookEntryRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::RemoveAddressBookEntryOperationInput>
     for RemoveAddressBookEntryRequestCreate
 {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/remove_request_policy.rs
+++ b/core/station/impl/src/factories/requests/remove_request_policy.rs
@@ -17,6 +17,7 @@ pub struct RemoveRequestPolicyRequestCreate {}
 #[async_trait]
 impl Create<station_api::RemoveRequestPolicyOperationInput> for RemoveRequestPolicyRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -115,14 +116,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = RemoveRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(RemoveRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
@@ -145,14 +148,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = RemoveRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(RemoveRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
 
@@ -198,14 +203,16 @@ mod tests {
             .as_bytes();
         REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.to_owned());
 
-        let request = RemoveRequestPolicyRequestCreate::create(
-            request_id,
-            requested_by_user,
-            request_input,
-            operation_input,
-        )
-        .await
-        .unwrap();
+        let creator = Box::new(RemoveRequestPolicyRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
 
         REQUEST_POLICY_REPOSITORY.remove(&policy.id);
 

--- a/core/station/impl/src/factories/requests/remove_request_policy.rs
+++ b/core/station/impl/src/factories/requests/remove_request_policy.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
 
 pub struct RemoveRequestPolicyRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::RemoveRequestPolicyOperationInput> for RemoveRequestPolicyRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,
@@ -98,8 +99,8 @@ mod tests {
     use orbit_essentials::repository::Repository;
     use std::str::FromStr;
 
-    #[test]
-    fn test_create_request() {
+    #[tokio::test]
+    async fn test_create_request() {
         let request_id = [0u8; 16];
         let requested_by_user = [1u8; 16];
         let operation_input =
@@ -120,6 +121,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         assert_eq!(request.id, request_id);
@@ -149,6 +151,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
@@ -201,6 +204,7 @@ mod tests {
             request_input,
             operation_input,
         )
+        .await
         .unwrap();
 
         REQUEST_POLICY_REPOSITORY.remove(&policy.id);

--- a/core/station/impl/src/factories/requests/remove_user_group.rs
+++ b/core/station/impl/src/factories/requests/remove_user_group.rs
@@ -12,6 +12,7 @@ pub struct RemoveUserGroupRequestCreate {}
 #[async_trait]
 impl Create<station_api::RemoveUserGroupOperationInput> for RemoveUserGroupRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/remove_user_group.rs
+++ b/core/station/impl/src/factories/requests/remove_user_group.rs
@@ -9,8 +9,9 @@ use orbit_essentials::types::UUID;
 
 pub struct RemoveUserGroupRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::RemoveUserGroupOperationInput> for RemoveUserGroupRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/transfer.rs
+++ b/core/station/impl/src/factories/requests/transfer.rs
@@ -26,6 +26,7 @@ pub struct TransferRequestCreate {}
 #[async_trait]
 impl Create<station_api::TransferOperationInput> for TransferRequestCreate {
     async fn create(
+        &self,
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,

--- a/core/station/impl/src/factories/requests/transfer.rs
+++ b/core/station/impl/src/factories/requests/transfer.rs
@@ -23,8 +23,9 @@ fn get_account(from_account_id: &UUID) -> Option<Account> {
 
 pub struct TransferRequestCreate {}
 
+#[async_trait]
 impl Create<station_api::TransferOperationInput> for TransferRequestCreate {
-    fn create(
+    async fn create(
         request_id: UUID,
         requested_by_user: UUID,
         input: station_api::CreateRequestInput,


### PR DESCRIPTION
This PR makes request creation asynchronous which is necessary for validation of call canister requests (to be added in a follow-up PR).