### PR TITLE
feat(api): Add the serde::Serialize trait to API types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 resolver = "2"
 members = [
-    "tests/integration",
     "core/control-panel/api",
     "core/control-panel/impl",
-    "core/upgrader/api",
-    "core/upgrader/impl",
     "core/station/api",
     "core/station/impl",
+    "core/upgrader/api",
+    "core/upgrader/impl",
     "libs/canfund",
     "libs/orbit-essentials",
     "libs/orbit-essentials-macros",
     "libs/orbit-essentials-macros-tests",
+    "tests/integration",
 ]
 
 [workspace.package]

--- a/core/control-panel/api/src/artifact.rs
+++ b/core/control-panel/api/src/artifact.rs
@@ -1,12 +1,12 @@
 use crate::{Sha256HashDTO, TimestampRfc3339, UuidDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetArtifactInput {
     pub artifact_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct ArtifactDTO {
     pub id: UuidDTO,
     pub size: u64,
@@ -16,7 +16,7 @@ pub struct ArtifactDTO {
     pub created_at: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetArtifactResponse {
     pub artifact: ArtifactDTO,
 }

--- a/core/control-panel/api/src/canister.rs
+++ b/core/control-panel/api/src/canister.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UploadCanisterModulesInput {
     #[serde(with = "serde_bytes")]
     pub upgrader_wasm_module: Vec<u8>,

--- a/core/control-panel/api/src/common.rs
+++ b/core/control-panel/api/src/common.rs
@@ -6,7 +6,7 @@ pub type UuidDTO = String;
 pub type Sha256HashDTO = String;
 
 /// Generic error type used for calls.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct ApiErrorDTO {
     /// The error code uppercased and underscored (e.g. `INVALID_ARGUMENT`).
     pub code: String,
@@ -16,13 +16,13 @@ pub struct ApiErrorDTO {
     pub details: Option<HashMap<String, String>>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct MetadataDTO {
     pub key: String,
     pub value: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct PaginationInput {
     pub offset: Option<u64>,
     pub limit: Option<u16>,

--- a/core/control-panel/api/src/manage_user.rs
+++ b/core/control-panel/api/src/manage_user.rs
@@ -1,17 +1,17 @@
 use super::{UserDTO, UserStationDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DeleteUserResponse {
     pub user: UserDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterUserInput {
     pub station: Option<UserStationDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterUserResponse {
     pub user: UserDTO,
 }

--- a/core/control-panel/api/src/registry.rs
+++ b/core/control-panel/api/src/registry.rs
@@ -1,14 +1,14 @@
 use crate::{MetadataDTO, PaginationInput, TimestampRfc3339, UuidDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct WasmModuleRegistryEntryValueDTO {
     pub wasm_artifact_id: UuidDTO,
     pub version: String,
     pub dependencies: Vec<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct WasmModuleRegistryEntryValueInput {
     #[serde(with = "serde_bytes")]
     pub wasm_module: Vec<u8>,
@@ -16,17 +16,17 @@ pub struct WasmModuleRegistryEntryValueInput {
     pub dependencies: Vec<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum RegistryEntryValueDTO {
     WasmModule(WasmModuleRegistryEntryValueDTO),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum RegistryEntryValueInput {
     WasmModule(WasmModuleRegistryEntryValueInput),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct RegistryEntryDTO {
     pub id: UuidDTO,
     pub name: String,
@@ -39,7 +39,7 @@ pub struct RegistryEntryDTO {
     pub updated_at: Option<TimestampRfc3339>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct RegistryEntryInput {
     pub name: String,
     pub description: String,
@@ -49,61 +49,61 @@ pub struct RegistryEntryInput {
     pub value: RegistryEntryValueInput,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetRegistryEntryInput {
     pub id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetRegistryEntryResponse {
     pub entry: RegistryEntryDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum SearchRegistryFilterKindDTO {
     Name(String),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct SearchRegistryInput {
     pub filter_by: Vec<SearchRegistryFilterKindDTO>,
     pub pagination: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct SearchRegistryResponse {
     pub entries: Vec<RegistryEntryDTO>,
     pub total: u64,
     pub next_offset: Option<u64>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct AddRegistryEntryInput {
     pub entry: RegistryEntryInput,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct AddRegistryEntryResponse {
     pub entry: RegistryEntryDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct EditRegistryEntryInput {
     pub id: UuidDTO,
     pub entry: RegistryEntryInput,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct EditRegistryEntryResponse {
     pub entry: RegistryEntryDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DeleteRegistryEntryInput {
     pub id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DeleteRegistryEntryResponse {
     pub entry: RegistryEntryDTO,
 }

--- a/core/control-panel/api/src/user.rs
+++ b/core/control-panel/api/src/user.rs
@@ -1,30 +1,30 @@
 use crate::TimestampRfc3339;
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UserDTO {
     pub identity: Principal,
     pub subscription_status: UserSubscriptionStatusDTO,
     pub last_active: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetUserResponse {
     pub user: UserDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct SubscribedUserDTO {
     pub user_principal: Principal,
     pub email: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetWaitingListResponse {
     pub subscribed_users: Vec<SubscribedUserDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum UserSubscriptionStatusDTO {
     Unsubscribed,
     Pending,
@@ -43,7 +43,7 @@ impl std::fmt::Display for UserSubscriptionStatusDTO {
     }
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UpdateWaitingListInput {
     pub users: Vec<Principal>,
     pub new_status: UserSubscriptionStatusDTO,

--- a/core/control-panel/api/src/user_station.rs
+++ b/core/control-panel/api/src/user_station.rs
@@ -1,60 +1,60 @@
 use crate::UserSubscriptionStatusDTO;
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct DeployStationAdminUserInput {
     pub username: String,
     pub identity: Principal,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AssociateWithCallerInput {
     pub labels: Vec<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct DeployStationInput {
     pub name: String,
     pub admins: Vec<DeployStationAdminUserInput>,
     pub associate_with_caller: Option<AssociateWithCallerInput>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UserStationDTO {
     pub canister_id: Principal,
     pub name: String,
     pub labels: Vec<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct UpdateUserStationInput {
     pub index: Option<u64>,
     pub station: UserStationDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub enum ManageUserStationsInput {
     Add(Vec<UserStationDTO>),
     Remove(Vec<Principal>),
     Update(Vec<UpdateUserStationInput>),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct ListUserStationsInput {
     pub filter_by_labels: Option<Vec<String>>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct ListUserStationsResponse {
     pub stations: Vec<UserStationDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DeployStationResponse {
     pub canister_id: Principal,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum CanDeployStationResponse {
     NotAllowed(UserSubscriptionStatusDTO),
     Allowed(usize),

--- a/core/station/api/src/account.rs
+++ b/core/station/api/src/account.rs
@@ -3,14 +3,14 @@ use crate::{
 };
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AccountCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_transfer: bool,
     pub can_edit: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AccountDTO {
     pub id: UuidDTO,
     pub name: String,
@@ -26,7 +26,7 @@ pub struct AccountDTO {
     pub last_modification_timestamp: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditAccountOperationInput {
     pub account_id: UuidDTO,
     pub name: Option<String>,
@@ -37,12 +37,12 @@ pub struct EditAccountOperationInput {
     pub transfer_request_policy: Option<RequestPolicyRuleInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditAccountOperationDTO {
     pub input: EditAccountOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddAccountOperationInput {
     pub name: String,
     pub blockchain: String,
@@ -55,29 +55,29 @@ pub struct AddAccountOperationInput {
     pub transfer_request_policy: Option<RequestPolicyRuleDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddAccountOperationDTO {
     pub account: Option<AccountDTO>,
     pub input: AddAccountOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetAccountInput {
     pub account_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetAccountResponse {
     pub account: AccountDTO,
     pub privileges: AccountCallerPrivilegesDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct FetchAccountBalancesInput {
     pub account_ids: Vec<String>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AccountBalanceDTO {
     pub account_id: String,
     pub balance: candid::Nat,
@@ -85,25 +85,25 @@ pub struct AccountBalanceDTO {
     pub last_update_timestamp: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AccountBalanceInfoDTO {
     pub balance: candid::Nat,
     pub decimals: u32,
     pub last_update_timestamp: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct FetchAccountBalancesResponse {
     pub balances: Vec<AccountBalanceDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAccountsInput {
     pub search_term: Option<String>,
     pub paginate: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAccountsResponse {
     pub accounts: Vec<AccountDTO>,
     pub next_offset: Option<u64>,

--- a/core/station/api/src/address_book.rs
+++ b/core/station/api/src/address_book.rs
@@ -1,7 +1,7 @@
 use crate::{ChangeMetadataDTO, MetadataDTO, PaginationInput, UuidDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AddressBookEntryDTO {
     pub id: UuidDTO,
     pub address_owner: String,
@@ -12,20 +12,20 @@ pub struct AddressBookEntryDTO {
     pub last_modification_timestamp: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddressBookEntryCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_edit: bool,
     pub can_delete: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddAddressBookEntryOperationDTO {
     pub address_book_entry: Option<AddressBookEntryDTO>,
     pub input: AddAddressBookEntryOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddAddressBookEntryOperationInput {
     pub address_owner: String,
     pub address: String,
@@ -34,46 +34,46 @@ pub struct AddAddressBookEntryOperationInput {
     pub metadata: Vec<MetadataDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditAddressBookEntryOperationDTO {
     pub input: EditAddressBookEntryOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditAddressBookEntryOperationInput {
     pub address_book_entry_id: UuidDTO,
     pub address_owner: Option<String>,
     pub change_metadata: Option<ChangeMetadataDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RemoveAddressBookEntryOperationDTO {
     pub input: RemoveAddressBookEntryOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RemoveAddressBookEntryOperationInput {
     pub address_book_entry_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetAddressBookEntryInputDTO {
     pub address_book_entry_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetAddressBookEntryResponseDTO {
     pub address_book_entry: AddressBookEntryDTO,
     pub privileges: AddressBookEntryCallerPrivilegesDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddressChainInput {
     pub blockchain: String,
     pub standard: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAddressBookEntriesInputDTO {
     pub ids: Option<Vec<UuidDTO>>,
     pub addresses: Option<Vec<String>>,
@@ -81,7 +81,7 @@ pub struct ListAddressBookEntriesInputDTO {
     pub paginate: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAddressBookEntriesResponseDTO {
     pub address_book_entries: Vec<AddressBookEntryDTO>,
     pub next_offset: Option<u64>,

--- a/core/station/api/src/capabilities.rs
+++ b/core/station/api/src/capabilities.rs
@@ -1,7 +1,7 @@
 use crate::MetadataDTO;
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AssetDTO {
     /// The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
     pub blockchain: String,
@@ -19,7 +19,7 @@ pub struct AssetDTO {
 }
 
 /// The capabilities of the canister.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct CapabilitiesDTO {
     /// The name of the canister.
     pub name: String,
@@ -29,7 +29,7 @@ pub struct CapabilitiesDTO {
     pub supported_assets: Vec<AssetDTO>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct CapabilitiesResponse {
     pub capabilities: CapabilitiesDTO,
 }

--- a/core/station/api/src/change_canister.rs
+++ b/core/station/api/src/change_canister.rs
@@ -2,7 +2,7 @@ use candid::{CandidType, Deserialize, Principal};
 
 use crate::Sha256HashDTO;
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum CanisterInstallMode {
     #[serde(rename = "install")]
     Install = 1,
@@ -12,13 +12,13 @@ pub enum CanisterInstallMode {
     Upgrade = 3,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ChangeCanisterTargetDTO {
     UpgradeStation,
     UpgradeUpgrader,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ChangeCanisterOperationInput {
     pub target: ChangeCanisterTargetDTO,
     #[serde(with = "serde_bytes")]
@@ -27,14 +27,14 @@ pub struct ChangeCanisterOperationInput {
     pub arg: Option<Vec<u8>>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ChangeCanisterOperationDTO {
     pub target: ChangeCanisterTargetDTO,
     pub module_checksum: Sha256HashDTO,
     pub arg_checksum: Option<Sha256HashDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ChangeExternalCanisterOperationInput {
     pub canister_id: Principal,
     pub mode: CanisterInstallMode,
@@ -44,7 +44,7 @@ pub struct ChangeExternalCanisterOperationInput {
     pub arg: Option<Vec<u8>>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ChangeExternalCanisterOperationDTO {
     pub canister_id: Principal,
     pub mode: CanisterInstallMode,

--- a/core/station/api/src/common.rs
+++ b/core/station/api/src/common.rs
@@ -6,7 +6,7 @@ pub type UuidDTO = String;
 pub type Sha256HashDTO = String;
 
 /// Generic error type used for calls.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct ApiErrorDTO {
     /// The error code uppercased and underscored (e.g. `INVALID_ARGUMENT`).
     pub code: String,
@@ -16,13 +16,13 @@ pub struct ApiErrorDTO {
     pub details: Option<HashMap<String, String>>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct PaginationInput {
     pub offset: Option<u64>,
     pub limit: Option<u16>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum SortDirection {
     Asc,
     Desc,

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -1,21 +1,21 @@
 use crate::Sha256HashDTO;
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateExternalCanisterOperationInput {}
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateExternalCanisterOperationDTO {
     pub canister_id: Option<Principal>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CanisterMethodDTO {
     pub canister_id: Principal,
     pub method_name: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CallExternalCanisterOperationInput {
     pub validation_method: Option<CanisterMethodDTO>,
     pub execution_method: CanisterMethodDTO,
@@ -24,7 +24,7 @@ pub struct CallExternalCanisterOperationInput {
     pub execution_method_cycles: Option<u64>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CallExternalCanisterOperationDTO {
     pub validation_method: Option<CanisterMethodDTO>,
     pub execution_method: CanisterMethodDTO,

--- a/core/station/api/src/metadata.rs
+++ b/core/station/api/src/metadata.rs
@@ -1,12 +1,16 @@
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord,
+)]
 pub struct MetadataDTO {
     pub key: String,
     pub value: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord,
+)]
 pub enum ChangeMetadataDTO {
     ReplaceAllBy(Vec<MetadataDTO>),
     OverrideSpecifiedBy(Vec<MetadataDTO>),

--- a/core/station/api/src/notification.rs
+++ b/core/station/api/src/notification.rs
@@ -8,13 +8,13 @@ pub const REQUEST_CREATED_NOTIFICATION_TYPE: &str = "request-created";
 pub const REQUEST_FAILED_NOTIFICATION_TYPE: &str = "request-failed";
 pub const REQUEST_REJECTED_NOTIFICATION_TYPE: &str = "request-rejected";
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum NotificationStatusDTO {
     Sent,
     Read,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum NotificationTypeDTO {
     SystemMessage,
     RequestCreated(RequestCreatedNotificationDTO),
@@ -22,7 +22,7 @@ pub enum NotificationTypeDTO {
     RequestRejected(RequestRejectedNotificationDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestCreatedNotificationDTO {
     pub request_id: UuidDTO,
     pub operation_type: RequestOperationTypeDTO,
@@ -30,21 +30,21 @@ pub struct RequestCreatedNotificationDTO {
     pub user_id: Option<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestFailedNotificationDTO {
     pub request_id: UuidDTO,
     pub operation_type: RequestOperationTypeDTO,
     pub reason: Option<String>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestRejectedNotificationDTO {
     pub request_id: UuidDTO,
     pub operation_type: RequestOperationTypeDTO,
     pub reasons: Option<Vec<EvaluationSummaryReasonDTO>>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum NotificationTypeInput {
     SystemMessage,
     RequestCreated,
@@ -63,7 +63,7 @@ impl Display for NotificationTypeInput {
     }
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct NotificationDTO {
     pub id: UuidDTO,
     pub status: NotificationStatusDTO,
@@ -74,7 +74,7 @@ pub struct NotificationDTO {
     pub created_at: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListNotificationsInput {
     pub status: Option<NotificationStatusDTO>,
     pub notification_type: Option<NotificationTypeInput>,
@@ -82,12 +82,12 @@ pub struct ListNotificationsInput {
     pub to_dt: Option<TimestampRfc3339>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListNotificationsResponse {
     pub notifications: Vec<NotificationDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct MarkNotificationsReadInput {
     pub notification_ids: Vec<UuidDTO>,
     pub read: bool,

--- a/core/station/api/src/permission.rs
+++ b/core/station/api/src/permission.rs
@@ -1,39 +1,39 @@
 use crate::{BasicUserDTO, PaginationInput, ResourceDTO, UserGroupDTO, UuidDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct PermissionCallerPrivilegesDTO {
     pub resource: ResourceDTO,
     pub can_edit: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct PermissionDTO {
     pub allow: AllowDTO,
     pub resource: ResourceDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AllowDTO {
     pub auth_scope: AuthScopeDTO,
     pub users: Vec<UuidDTO>,
     pub user_groups: Vec<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum AuthScopeDTO {
     Public = 1,
     Authenticated = 2,
     Restricted = 3,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListPermissionsInput {
     pub resources: Option<Vec<ResourceDTO>>,
     pub paginate: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListPermissionsResponse {
     pub permissions: Vec<PermissionDTO>,
     pub user_groups: Vec<UserGroupDTO>,
@@ -43,23 +43,23 @@ pub struct ListPermissionsResponse {
     pub privileges: Vec<PermissionCallerPrivilegesDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetPermissionInput {
     pub resource: ResourceDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetPermissionResponse {
     pub permission: PermissionDTO,
     pub privileges: PermissionCallerPrivilegesDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditPermissionOperationDTO {
     pub input: EditPermissionOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditPermissionOperationInput {
     pub resource: ResourceDTO,
     pub auth_scope: Option<AuthScopeDTO>,

--- a/core/station/api/src/request.rs
+++ b/core/station/api/src/request.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestStatusDTO {
     Created,
     Approved,
@@ -30,7 +30,7 @@ pub enum RequestStatusDTO {
     Failed { reason: Option<String> },
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RequestStatusCodeDTO {
     Created = 0,
     Approved = 1,
@@ -42,19 +42,19 @@ pub enum RequestStatusCodeDTO {
     Failed = 7,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestApprovalStatusDTO {
     Approved,
     Rejected,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestExecutionScheduleDTO {
     Immediate,
     Scheduled { execution_time: TimestampRfc3339 },
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestOperationDTO {
     Transfer(Box<TransferOperationDTO>),
     AddAccount(Box<AddAccountOperationDTO>),
@@ -78,7 +78,7 @@ pub enum RequestOperationDTO {
     ManageSystemInfo(Box<ManageSystemInfoOperationDTO>),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestOperationInput {
     Transfer(TransferOperationInput),
     AddAccount(AddAccountOperationInput),
@@ -102,7 +102,7 @@ pub enum RequestOperationInput {
     ManageSystemInfo(ManageSystemInfoOperationInput),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestOperationTypeDTO {
     Transfer,
     AddAccount,
@@ -126,7 +126,7 @@ pub enum RequestOperationTypeDTO {
     ManageSystemInfo,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ListRequestsOperationTypeDTO {
     Transfer(Option<UuidDTO>),
     AddAccount,
@@ -150,7 +150,7 @@ pub enum ListRequestsOperationTypeDTO {
     ManageSystemInfo,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestApprovalDTO {
     pub approver_id: UuidDTO,
     pub status: RequestApprovalStatusDTO,
@@ -158,7 +158,7 @@ pub struct RequestApprovalDTO {
     pub decided_at: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestDTO {
     pub id: UuidDTO,
     pub title: String,
@@ -172,13 +172,13 @@ pub struct RequestDTO {
     pub execution_plan: RequestExecutionScheduleDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_approve: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestAdditionalInfoDTO {
     pub id: UuidDTO,
     pub requester_name: String,
@@ -186,7 +186,7 @@ pub struct RequestAdditionalInfoDTO {
     pub evaluation_result: Option<RequestEvaluationResultDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateRequestInput {
     pub operation: RequestOperationInput,
     pub title: Option<String>,
@@ -194,40 +194,40 @@ pub struct CreateRequestInput {
     pub execution_plan: Option<RequestExecutionScheduleDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct SubmitRequestApprovalInput {
     pub decision: RequestApprovalStatusDTO,
     pub request_id: UuidDTO,
     pub reason: Option<String>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct SubmitRequestApprovalResponse {
     pub request: RequestDTO,
     pub privileges: RequestCallerPrivilegesDTO,
     pub additional_info: RequestAdditionalInfoDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetRequestInput {
     pub request_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetRequestResponse {
     pub request: RequestDTO,
     pub privileges: RequestCallerPrivilegesDTO,
     pub additional_info: RequestAdditionalInfoDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ListRequestsSortBy {
     CreatedAt(SortDirection),
     ExpirationDt(SortDirection),
     LastModificationDt(SortDirection),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListRequestsInput {
     pub requester_ids: Option<Vec<UuidDTO>>,
     pub approver_ids: Option<Vec<UuidDTO>>,
@@ -243,7 +243,7 @@ pub struct ListRequestsInput {
     pub with_evaluation_results: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListRequestsResponse {
     pub requests: Vec<RequestDTO>,
     pub next_offset: Option<u64>,
@@ -252,7 +252,7 @@ pub struct ListRequestsResponse {
     pub additional_info: Vec<RequestAdditionalInfoDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetNextApprovableRequestInput {
     pub excluded_request_ids: Vec<UuidDTO>,
     pub operation_types: Option<Vec<ListRequestsOperationTypeDTO>>,
@@ -260,43 +260,43 @@ pub struct GetNextApprovableRequestInput {
 
 pub type GetNextApprovableRequestResponse = Option<GetRequestResponse>;
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateRequestResponse {
     pub request: RequestDTO,
     pub privileges: RequestCallerPrivilegesDTO,
     pub additional_info: RequestAdditionalInfoDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddRequestPolicyOperationInput {
     pub specifier: RequestSpecifierDTO,
     pub rule: RequestPolicyRuleDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddRequestPolicyOperationDTO {
     pub policy_id: Option<UuidDTO>,
     pub input: AddRequestPolicyOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditRequestPolicyOperationInput {
     pub policy_id: UuidDTO,
     pub specifier: Option<RequestSpecifierDTO>,
     pub rule: Option<RequestPolicyRuleDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditRequestPolicyOperationDTO {
     pub input: EditRequestPolicyOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RemoveRequestPolicyOperationInput {
     pub policy_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RemoveRequestPolicyOperationDTO {
     pub input: RemoveRequestPolicyOperationInput,
 }

--- a/core/station/api/src/request_policy.rs
+++ b/core/station/api/src/request_policy.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestSpecifierDTO {
     AddAccount,
     AddUser,
@@ -29,45 +29,45 @@ pub enum RequestSpecifierDTO {
     ManageSystemInfo,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum UserSpecifierDTO {
     Any,
     Group(Vec<UuidDTO>),
     Id(Vec<UuidDTO>),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ResourceSpecifierDTO {
     Any,
     Resource(ResourceDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct QuorumPercentageDTO {
     pub approvers: UserSpecifierDTO,
     pub min_approved: u16,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct QuorumDTO {
     pub approvers: UserSpecifierDTO,
     pub min_approved: u16,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestPolicyRuleInput {
     Remove,
     Set(RequestPolicyRuleDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum EvaluationStatusDTO {
     Approved,
     Rejected,
     Pending,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestPolicyRuleDTO {
     AutoApproved,
     QuorumPercentage(QuorumPercentageDTO),
@@ -79,7 +79,7 @@ pub enum RequestPolicyRuleDTO {
     Not(Box<RequestPolicyRuleDTO>),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum EvaluatedRequestPolicyRuleDTO {
     AutoApproved,
     QuorumPercentage {
@@ -101,13 +101,13 @@ pub enum EvaluatedRequestPolicyRuleDTO {
     Not(Box<RequestPolicyRuleResultDTO>),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestPolicyRuleResultDTO {
     pub status: EvaluationStatusDTO,
     pub evaluated_rule: EvaluatedRequestPolicyRuleDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub enum EvaluationSummaryReasonDTO {
     ApprovalQuorum,
     AllowList,
@@ -115,7 +115,7 @@ pub enum EvaluationSummaryReasonDTO {
     AutoApproved,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestEvaluationResultDTO {
     pub request_id: UuidDTO,
     pub status: EvaluationStatusDTO,
@@ -123,26 +123,26 @@ pub struct RequestEvaluationResultDTO {
     pub result_reasons: Option<Vec<EvaluationSummaryReasonDTO>>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestPolicyCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_edit: bool,
     pub can_delete: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct RequestPolicyDTO {
     pub id: UuidDTO,
     pub specifier: RequestSpecifierDTO,
     pub rule: RequestPolicyRuleDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetRequestPolicyInput {
     pub id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetRequestPolicyResponse {
     pub policy: RequestPolicyDTO,
     pub privileges: RequestPolicyCallerPrivilegesDTO,
@@ -150,7 +150,7 @@ pub struct GetRequestPolicyResponse {
 
 pub type ListRequestPoliciesInput = PaginationInput;
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListRequestPoliciesResponse {
     pub policies: Vec<RequestPolicyDTO>,
     pub next_offset: Option<u64>,

--- a/core/station/api/src/resource.rs
+++ b/core/station/api/src/resource.rs
@@ -1,7 +1,7 @@
 use crate::{CanisterMethodDTO, UuidDTO};
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ResourceDTO {
     Permission(PermissionResourceActionDTO),
     Account(AccountResourceActionDTO),
@@ -15,19 +15,19 @@ pub enum ResourceDTO {
     UserGroup(ResourceActionDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ResourceIdDTO {
     Any,
     Id(UuidDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ResourceIdsDTO {
     Any,
     Ids(Vec<UuidDTO>),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ResourceActionDTO {
     List,
     Create,
@@ -36,13 +36,13 @@ pub enum ResourceActionDTO {
     Delete(ResourceIdDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum PermissionResourceActionDTO {
     Read,
     Update,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum UserResourceActionDTO {
     List,
     Create,
@@ -50,7 +50,7 @@ pub enum UserResourceActionDTO {
     Update(ResourceIdDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum AccountResourceActionDTO {
     List,
     Create,
@@ -59,36 +59,36 @@ pub enum AccountResourceActionDTO {
     Update(ResourceIdDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum SystemResourceActionDTO {
     SystemInfo,
     Capabilities,
     ManageSystemInfo,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ChangeCanisterResourceActionDTO {
     Create,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum CreateExternalCanisterResourceTargetDTO {
     Any,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ChangeExternalCanisterResourceTargetDTO {
     Any,
     Canister(Principal),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ReadExternalCanisterResourceTargetDTO {
     Any,
     Canister(Principal),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ExternalCanisterResourceActionDTO {
     Create(CreateExternalCanisterResourceTargetDTO),
     Change(ChangeExternalCanisterResourceTargetDTO),
@@ -96,25 +96,25 @@ pub enum ExternalCanisterResourceActionDTO {
     Read(ReadExternalCanisterResourceTargetDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ValidationMethodResourceTargetDTO {
     No,
     ValidationMethod(CanisterMethodDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ExecutionMethodResourceTargetDTO {
     Any,
     ExecutionMethod(CanisterMethodDTO),
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CallExternalCanisterResourceTargetDTO {
     pub validation_method: ValidationMethodResourceTargetDTO,
     pub execution_method: ExecutionMethodResourceTargetDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum RequestResourceActionDTO {
     List,
     Read(ResourceIdDTO),

--- a/core/station/api/src/system.rs
+++ b/core/station/api/src/system.rs
@@ -1,7 +1,7 @@
 use super::TimestampRfc3339;
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct SystemInfoDTO {
     pub name: String,
     pub version: String,
@@ -11,28 +11,28 @@ pub struct SystemInfoDTO {
     pub raw_rand_successful: bool,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ManageSystemInfoOperationDTO {
     pub input: ManageSystemInfoOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ManageSystemInfoOperationInput {
     pub name: Option<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct SystemInfoResponse {
     pub system: SystemInfoDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AdminInitInput {
     pub name: String,
     pub identity: Principal,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct SystemInit {
     pub name: String,
     pub admins: Vec<AdminInitInput>,
@@ -40,18 +40,18 @@ pub struct SystemInit {
     pub upgrader_wasm_module: Vec<u8>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct SystemUpgrade {
     pub name: Option<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub enum SystemInstall {
     Init(SystemInit),
     Upgrade(SystemUpgrade),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum HealthStatus {
     Healthy,
     Uninitialized,

--- a/core/station/api/src/transfer.rs
+++ b/core/station/api/src/transfer.rs
@@ -4,13 +4,13 @@ use candid::{CandidType, Deserialize};
 
 pub type NetworkIdDTO = String;
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct NetworkDTO {
     pub id: NetworkIdDTO,
     pub name: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct TransferOperationInput {
     pub from_account_id: UuidDTO,
     pub to: String,
@@ -20,7 +20,7 @@ pub struct TransferOperationInput {
     pub network: Option<NetworkDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct TransferOperationDTO {
     pub from_account: Option<AccountDTO>,
     pub network: NetworkDTO,
@@ -28,7 +28,7 @@ pub struct TransferOperationDTO {
     pub transfer_id: Option<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum TransferStatusDTO {
     Created,
     Processing {
@@ -44,7 +44,7 @@ pub enum TransferStatusDTO {
     },
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum TransferStatusTypeDTO {
     Created,
     Processing,
@@ -52,7 +52,7 @@ pub enum TransferStatusTypeDTO {
     Failed,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct TransferDTO {
     pub id: UuidDTO,
     pub request_id: UuidDTO,
@@ -65,22 +65,22 @@ pub struct TransferDTO {
     pub metadata: Vec<MetadataDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct TransferResponse {
     pub transfer: TransferDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetTransfersInput {
     pub transfer_ids: Vec<UuidDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetTransfersResponse {
     pub transfers: Vec<TransferDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAccountTransfersInput {
     pub status: Option<TransferStatusTypeDTO>,
     pub to_dt: Option<TimestampRfc3339>,
@@ -88,7 +88,7 @@ pub struct ListAccountTransfersInput {
     pub account_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct TransferListItemDTO {
     pub transfer_id: UuidDTO,
     pub request_id: UuidDTO,
@@ -98,7 +98,7 @@ pub struct TransferListItemDTO {
     pub created_at: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListAccountTransfersResponse {
     pub transfers: Vec<TransferListItemDTO>,
 }

--- a/core/station/api/src/user.rs
+++ b/core/station/api/src/user.rs
@@ -2,19 +2,19 @@ use super::TimestampRfc3339;
 use crate::{PaginationInput, UserGroupDTO, UuidDTO};
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct UserCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_edit: bool,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub enum UserStatusDTO {
     Active,
     Inactive,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct UserDTO {
     pub id: UuidDTO,
     pub identities: Vec<Principal>,
@@ -24,31 +24,31 @@ pub struct UserDTO {
     pub last_modification_timestamp: TimestampRfc3339,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct BasicUserDTO {
     pub id: UuidDTO,
     pub name: String,
     pub status: UserStatusDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct DisplayUserDTO {
     pub id: UuidDTO,
     pub name: String,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetUserInput {
     pub user_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetUserResponse {
     pub user: UserDTO,
     pub privileges: UserCallerPrivilegesDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddUserOperationInput {
     pub name: String,
     pub identities: Vec<Principal>,
@@ -56,13 +56,13 @@ pub struct AddUserOperationInput {
     pub status: UserStatusDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AddUserOperationDTO {
     pub user: Option<UserDTO>,
     pub input: AddUserOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditUserOperationInput {
     pub id: UuidDTO,
     pub name: Option<String>,
@@ -71,19 +71,19 @@ pub struct EditUserOperationInput {
     pub status: Option<UserStatusDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct EditUserOperationDTO {
     pub input: EditUserOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListUsersInput {
     pub search_term: Option<String>,
     pub statuses: Option<Vec<UserStatusDTO>>,
     pub paginate: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListUsersResponse {
     pub users: Vec<UserDTO>,
     pub next_offset: Option<u64>,
@@ -91,7 +91,7 @@ pub struct ListUsersResponse {
     pub privileges: Vec<UserCallerPrivilegesDTO>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum UserPrivilege {
     Capabilities,
     SystemInfo,
@@ -111,7 +111,7 @@ pub enum UserPrivilege {
     ListRequests,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct MeResponse {
     pub me: UserDTO,
     pub privileges: Vec<UserPrivilege>,

--- a/core/station/api/src/user_group.rs
+++ b/core/station/api/src/user_group.rs
@@ -1,69 +1,69 @@
 use crate::{PaginationInput, UuidDTO};
 use candid::{CandidType, Deserialize};
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct UserGroupCallerPrivilegesDTO {
     pub id: UuidDTO,
     pub can_edit: bool,
     pub can_delete: bool,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct UserGroupDTO {
     pub id: UuidDTO,
     pub name: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AddUserGroupOperationInput {
     pub name: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AddUserGroupOperationDTO {
     pub user_group: Option<UserGroupDTO>,
     pub input: AddUserGroupOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct EditUserGroupOperationInput {
     pub user_group_id: UuidDTO,
     pub name: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct EditUserGroupOperationDTO {
     pub input: EditUserGroupOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct RemoveUserGroupOperationInput {
     pub user_group_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct RemoveUserGroupOperationDTO {
     pub input: RemoveUserGroupOperationInput,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetUserGroupInput {
     pub user_group_id: UuidDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetUserGroupResponse {
     pub user_group: UserGroupDTO,
     pub privileges: UserGroupCallerPrivilegesDTO,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListUserGroupsInput {
     pub search_term: Option<String>,
     pub paginate: Option<PaginationInput>,
 }
 
-#[derive(CandidType, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListUserGroupsResponse {
     pub user_groups: Vec<UserGroupDTO>,
     pub next_offset: Option<u64>,

--- a/core/upgrader/api/src/lib.rs
+++ b/core/upgrader/api/src/lib.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Deserialize, Principal};
 
-#[derive(Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize, PartialEq)]
 pub struct UpgradeParams {
     #[serde(with = "serde_bytes")]
     pub module: Vec<u8>,
@@ -8,19 +8,19 @@ pub struct UpgradeParams {
     pub arg: Vec<u8>,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize)]
 pub struct InitArg {
     pub target_canister: Principal,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize)]
 pub enum TriggerUpgradeError {
     NotController,
     Unauthorized,
     UnexpectedError(String),
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize)]
 pub enum TriggerUpgradeResponse {
     Ok,
     Err(TriggerUpgradeError),


### PR DESCRIPTION
# Motivation
The types defined in the API are for external use.  These types would be considerably more useful if they were to implement `serde` serialize and deserialize traits.  An example use is the equivalent of `dfx canister call --output json` in the upcoming Orbit command line tool.

The `serde::Deserialize` trait is already derived for use with candid.  Only the `serde::Serialize` trait needs to be added.

Possible counterarguments:

- The Wasm sizes may increase.
  - I tested the station canister, as that has the largest number of changed types.  The Wasm size is unchanged, even the sha256sum of the compiled Wasm is unchanged:
    - Current main:

          max@sinkpad:~/dfn/orbit (2:21)$ ls -lh wasms/station.wasm.gz 
          -rw-rw-r-- 1 max max 1,5M Jun 18 11:20 wasms/station.wasm.gz

          max@sinkpad:~/dfn/orbit (2:27)$ ls -l wasms/station.wasm.gz 
          -rw-rw-r-- 1 max max 1549782 Jun 18 11:20 wasms/station.wasm.gz

          max@sinkpad:~/dfn/orbit (5:27)$ sha256sum wasms/station.wasm.gz
          25b027994ae7c0c267cd8cae442b5571820c25bc5dfc9d15fa16783204c45782  wasms/station.wasm.gz
    - This PR:

          max@sinkpad:~/dfn/orbit/branches/serde (6:56)$ ls -lh wasms/station.wasm.gz
          -rw-rw-r-- 1 max max 1,5M Jun 18 11:24 wasms/station.wasm.gz

          max@sinkpad:~/dfn/orbit/branches/serde (6:59)$ ls -l wasms/station.wasm.gz
          -rw-rw-r-- 1 max max 1549782 Jun 18 11:24 wasms/station.wasm.gz

          max@sinkpad:~/dfn/orbit/branches/serde (7:38)$ sha256sum wasms/station.wasm.gz
          25b027994ae7c0c267cd8cae442b5571820c25bc5dfc9d15fa16783204c45782  wasms/station.wasm.gz

- Third parties will always want some trait.  We cannot cater for them all.  If they want to add a trait, let them clone the type and add the trait.
  - True, but here Orbit is not adding any third party libraries not already used by Orbit.  Likewise third parties using this API already need serde for the candid trait.  No `Cargo.lock` will need to be updated as a result of this PR (unless we bump the semantic version).  Accommodating serde usage is not an imposition either on Orbit or users of the Orbit API.

# Changes
- Add the `serde::Serialize` trait to every `CandidType` in `core/*/api/`
- Formatting: `cargo sort` sorted the root `Cargo.toml`

# Tests
By the fact that the code compiles I believe that we can be confident that `serde::Serialize` is indeed available on these types.