### PR TITLE
feat(station): optional fallback controller

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1968,6 +1968,8 @@ type SystemInit = record {
   admins : vec AdminInitInput;
   // The wasm module of the station upgrader canister.
   upgrader_wasm_module : blob;
+  // An optional additional controller of the station and upgrader canisters.
+  fallback_controller : opt principal;
 };
 
 // The upgrade configuration for the canister.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -848,6 +848,7 @@ export type SystemInfoResult = { 'Ok' : { 'system' : SystemInfo } } |
   { 'Err' : Error };
 export interface SystemInit {
   'name' : string,
+  'fallback_controller' : [] | [Principal],
   'admins' : Array<AdminInitInput>,
   'upgrader_wasm_module' : Uint8Array | number[],
 }

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -8,6 +8,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const SystemInit = IDL.Record({
     'name' : IDL.Text,
+    'fallback_controller' : IDL.Opt(IDL.Principal),
     'admins' : IDL.Vec(AdminInitInput),
     'upgrader_wasm_module' : IDL.Vec(IDL.Nat8),
   });
@@ -1171,6 +1172,7 @@ export const init = ({ IDL }) => {
   });
   const SystemInit = IDL.Record({
     'name' : IDL.Text,
+    'fallback_controller' : IDL.Opt(IDL.Principal),
     'admins' : IDL.Vec(AdminInitInput),
     'upgrader_wasm_module' : IDL.Vec(IDL.Nat8),
   });

--- a/core/control-panel/impl/src/core/constants.rs
+++ b/core/control-panel/impl/src/core/constants.rs
@@ -38,3 +38,19 @@ pub const ONE_WEEK_NS: u64 = 7 * ONE_DAY_NS;
 
 /// The nanoseconds equivalent of 30 days.
 pub const ONE_MONTH_NS: u64 = 30 * ONE_DAY_NS;
+
+/// The NNS Root canister id added to station and upgrader canisters as a recovery method.
+pub const NNS_ROOT_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 3, 1, 1]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn nns_root_canister_id_match_string_representation() {
+        let nns_text_canister_id = Principal::from_str("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
+
+        assert_eq!(NNS_ROOT_CANISTER_ID, nns_text_canister_id);
+    }
+}

--- a/core/control-panel/impl/src/services/deploy.rs
+++ b/core/control-panel/impl/src/services/deploy.rs
@@ -1,6 +1,6 @@
 use super::{UserService, UserStationService};
 use crate::{
-    core::{canister_config, CallContext, INITIAL_STATION_CYCLES},
+    core::{canister_config, CallContext, INITIAL_STATION_CYCLES, NNS_ROOT_CANISTER_ID},
     errors::{DeployError, UserError},
     models::{CanDeployStation, UserStation},
     services::{USER_SERVICE, USER_STATION_SERVICE},
@@ -105,6 +105,7 @@ impl DeployService {
                 name: input.name.clone(),
                 admins,
                 upgrader_wasm_module,
+                fallback_controller: Some(NNS_ROOT_CANISTER_ID),
             }))
             .map_err(|err| DeployError::Failed {
                 reason: err.to_string(),

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1968,6 +1968,8 @@ type SystemInit = record {
   admins : vec AdminInitInput;
   // The wasm module of the station upgrader canister.
   upgrader_wasm_module : blob;
+  // An optional additional controller of the station and upgrader canisters.
+  fallback_controller : opt principal;
 };
 
 // The upgrade configuration for the canister.

--- a/core/station/api/src/system.rs
+++ b/core/station/api/src/system.rs
@@ -38,6 +38,7 @@ pub struct SystemInit {
     pub admins: Vec<AdminInitInput>,
     #[serde(with = "serde_bytes")]
     pub upgrader_wasm_module: Vec<u8>,
+    pub fallback_controller: Option<Principal>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]

--- a/core/station/impl/src/core/constants.rs
+++ b/core/station/impl/src/core/constants.rs
@@ -42,19 +42,3 @@ pub const ACCOUNT_BALANCE_FRESHNESS_IN_MS: u64 = 3000;
 
 /// The initial cycles balance to use when creating the upgrader canister.
 pub const INITIAL_UPGRADER_CYCLES: u128 = 250_000_000_000;
-
-/// The NNS Root canister id added to station and upgrader canisters as a recovery method.
-pub const NNS_ROOT_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 3, 1, 1]);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn nns_root_canister_id_match_string_representation() {
-        let nns_text_canister_id = Principal::from_str("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
-
-        assert_eq!(NNS_ROOT_CANISTER_ID, nns_text_canister_id);
-    }
-}

--- a/tests/integration/src/setup.rs
+++ b/tests/integration/src/setup.rs
@@ -1,7 +1,7 @@
 use crate::interfaces::{
     NnsIndexCanisterInitPayload, NnsLedgerCanisterInitPayload, NnsLedgerCanisterPayload,
 };
-use crate::utils::{controller_test_id, minter_test_id, set_controllers};
+use crate::utils::{controller_test_id, minter_test_id, set_controllers, NNS_ROOT_CANISTER_ID};
 use crate::{CanisterIds, TestEnv};
 use candid::{Encode, Principal};
 use control_panel_api::UploadCanisterModulesInput;
@@ -22,12 +22,14 @@ pub static WALLET_ADMIN_USER: Principal = Principal::from_slice(&[1; 29]);
 #[derive(Clone)]
 pub struct SetupConfig {
     pub upload_canister_modules: bool,
+    pub fallback_controller: Option<Principal>,
 }
 
 impl Default for SetupConfig {
     fn default() -> Self {
         Self {
             upload_canister_modules: true,
+            fallback_controller: Some(NNS_ROOT_CANISTER_ID),
         }
     }
 }
@@ -170,6 +172,7 @@ fn install_canisters(
             name: "station-admin".to_string(),
         }],
         upgrader_wasm_module: upgrader_wasm,
+        fallback_controller: config.fallback_controller,
     });
     env.install_canister(
         station,


### PR DESCRIPTION
This PR adds an optional fallback controller to the station's initial arguments (used when installing/reinstalling the station).  The control panel sets the NNS root canister as the fallback controller.