### PR TITLE
feat(upgrader): disaster recovery recreates accounts

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1994,7 +1994,7 @@ type SystemUpgraderInput = variant {
   WasmModule : blob;
 };
 
-// The initial accounts to create when initializing the canister for the first time.
+// The initial accounts to create when initializing the canister for the first time, e.g., after disaster recovery.
 type InitAccountInput = record {
   // The UUID of the account, if not provided a new UUID will be generated.
   id : opt UUID;

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1994,6 +1994,20 @@ type SystemUpgraderInput = variant {
   WasmModule : blob;
 };
 
+// The initial accounts to create when initializing the canister for the first time.
+type InitAccountInput = record {
+  // The UUID of the account, if not provided a new UUID will be generated.
+  id : opt UUID;
+  // A friendly name for the account (e.g. "My Account").
+  name : text;
+  // The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+  blockchain : text;
+  // The asset standard for this account (e.g. `native`, `erc20`, etc.).
+  standard : text;
+  // Metadata associated with the account (e.g. `{"contract": "0x1234", "symbol": "ANY"}`).
+  metadata : vec AccountMetadata;
+};
+
 // The init configuration for the canister.
 //
 // Only used when installing the canister for the first time.
@@ -2008,6 +2022,8 @@ type SystemInit = record {
   upgrader : SystemUpgraderInput;
   // An optional additional controller of the station and upgrader canisters.
   fallback_controller : opt principal;
+  // Optional initial accounts to create.
+  accounts : opt vec InitAccountInput;
 };
 
 // The upgrade configuration for the canister.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -410,6 +410,13 @@ export interface HttpResponse {
   'headers' : Array<HeaderField>,
   'status_code' : number,
 }
+export interface InitAccountInput {
+  'id' : [] | [UUID],
+  'metadata' : Array<AccountMetadata>,
+  'name' : string,
+  'blockchain' : string,
+  'standard' : string,
+}
 export interface ListAccountTransfersInput {
   'account_id' : UUID,
   'status' : [] | [TransferStatusType],
@@ -866,6 +873,7 @@ export interface SystemInit {
   'name' : string,
   'fallback_controller' : [] | [Principal],
   'upgrader' : SystemUpgraderInput,
+  'accounts' : [] | [Array<InitAccountInput>],
   'admins' : Array<AdminInitInput>,
   'quorum' : [] | [number],
 }

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -6,6 +6,15 @@ export const idlFactory = ({ IDL }) => {
     'Id' : IDL.Principal,
     'WasmModule' : IDL.Vec(IDL.Nat8),
   });
+  const UUID = IDL.Text;
+  const AccountMetadata = IDL.Record({ 'key' : IDL.Text, 'value' : IDL.Text });
+  const InitAccountInput = IDL.Record({
+    'id' : IDL.Opt(UUID),
+    'metadata' : IDL.Vec(AccountMetadata),
+    'name' : IDL.Text,
+    'blockchain' : IDL.Text,
+    'standard' : IDL.Text,
+  });
   const AdminInitInput = IDL.Record({
     'name' : IDL.Text,
     'identity' : IDL.Principal,
@@ -14,6 +23,7 @@ export const idlFactory = ({ IDL }) => {
     'name' : IDL.Text,
     'fallback_controller' : IDL.Opt(IDL.Principal),
     'upgrader' : SystemUpgraderInput,
+    'accounts' : IDL.Opt(IDL.Vec(InitAccountInput)),
     'admins' : IDL.Vec(AdminInitInput),
     'quorum' : IDL.Opt(IDL.Nat16),
   });
@@ -81,7 +91,6 @@ export const idlFactory = ({ IDL }) => {
     'Scheduled' : IDL.Record({ 'execution_time' : TimestampRFC3339 }),
   });
   const AddUserGroupOperationInput = IDL.Record({ 'name' : IDL.Text });
-  const UUID = IDL.Text;
   const ResourceId = IDL.Variant({ 'Id' : UUID, 'Any' : IDL.Null });
   const RequestResourceAction = IDL.Variant({
     'List' : IDL.Null,
@@ -348,7 +357,6 @@ export const idlFactory = ({ IDL }) => {
     'validation_method' : IDL.Opt(CanisterMethod),
     'execution_method_cycles' : IDL.Opt(IDL.Nat64),
   });
-  const AccountMetadata = IDL.Record({ 'key' : IDL.Text, 'value' : IDL.Text });
   const AddAccountOperationInput = IDL.Record({
     'configs_request_policy' : IDL.Opt(RequestPolicyRule),
     'read_permission' : Allow,
@@ -1191,6 +1199,15 @@ export const init = ({ IDL }) => {
     'Id' : IDL.Principal,
     'WasmModule' : IDL.Vec(IDL.Nat8),
   });
+  const UUID = IDL.Text;
+  const AccountMetadata = IDL.Record({ 'key' : IDL.Text, 'value' : IDL.Text });
+  const InitAccountInput = IDL.Record({
+    'id' : IDL.Opt(UUID),
+    'metadata' : IDL.Vec(AccountMetadata),
+    'name' : IDL.Text,
+    'blockchain' : IDL.Text,
+    'standard' : IDL.Text,
+  });
   const AdminInitInput = IDL.Record({
     'name' : IDL.Text,
     'identity' : IDL.Principal,
@@ -1199,6 +1216,7 @@ export const init = ({ IDL }) => {
     'name' : IDL.Text,
     'fallback_controller' : IDL.Opt(IDL.Principal),
     'upgrader' : SystemUpgraderInput,
+    'accounts' : IDL.Opt(IDL.Vec(InitAccountInput)),
     'admins' : IDL.Vec(AdminInitInput),
     'quorum' : IDL.Opt(IDL.Nat16),
   });

--- a/core/control-panel/impl/src/services/deploy.rs
+++ b/core/control-panel/impl/src/services/deploy.rs
@@ -107,6 +107,7 @@ impl DeployService {
                 upgrader: station_api::SystemUpgraderInput::WasmModule(upgrader_wasm_module),
                 quorum: Some(1),
                 fallback_controller: Some(NNS_ROOT_CANISTER_ID),
+                accounts: None,
             }))
             .map_err(|err| DeployError::Failed {
                 reason: err.to_string(),

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1994,7 +1994,7 @@ type SystemUpgraderInput = variant {
   WasmModule : blob;
 };
 
-// The initial accounts to create when initializing the canister for the first time.
+// The initial accounts to create when initializing the canister for the first time, e.g., after disaster recovery.
 type InitAccountInput = record {
   // The UUID of the account, if not provided a new UUID will be generated.
   id : opt UUID;

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1994,6 +1994,20 @@ type SystemUpgraderInput = variant {
   WasmModule : blob;
 };
 
+// The initial accounts to create when initializing the canister for the first time.
+type InitAccountInput = record {
+  // The UUID of the account, if not provided a new UUID will be generated.
+  id : opt UUID;
+  // A friendly name for the account (e.g. "My Account").
+  name : text;
+  // The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+  blockchain : text;
+  // The asset standard for this account (e.g. `native`, `erc20`, etc.).
+  standard : text;
+  // Metadata associated with the account (e.g. `{"contract": "0x1234", "symbol": "ANY"}`).
+  metadata : vec AccountMetadata;
+};
+
 // The init configuration for the canister.
 //
 // Only used when installing the canister for the first time.
@@ -2008,6 +2022,8 @@ type SystemInit = record {
   upgrader : SystemUpgraderInput;
   // An optional additional controller of the station and upgrader canisters.
   fallback_controller : opt principal;
+  // Optional initial accounts to create.
+  accounts : opt vec InitAccountInput;
 };
 
 // The upgrade configuration for the canister.

--- a/core/station/api/src/system.rs
+++ b/core/station/api/src/system.rs
@@ -1,3 +1,5 @@
+use crate::{MetadataDTO, UuidDTO};
+
 use super::TimestampRfc3339;
 use candid::{CandidType, Deserialize, Principal};
 
@@ -39,6 +41,15 @@ pub enum SystemUpgraderInput {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
+pub struct InitAccountInput {
+    pub id: Option<UuidDTO>,
+    pub name: String,
+    pub blockchain: String,
+    pub standard: String,
+    pub metadata: Vec<MetadataDTO>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct SystemInit {
     /// The station name.
     pub name: String,
@@ -48,7 +59,10 @@ pub struct SystemInit {
     pub quorum: Option<u16>,
     /// The upgrader configuration.
     pub upgrader: SystemUpgraderInput,
+    /// Optional fallback controller for the station and upgrader canisters.
     pub fallback_controller: Option<Principal>,
+    /// Optionally set the initial accounts.
+    pub accounts: Option<Vec<InitAccountInput>>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]

--- a/core/station/impl/src/errors/system.rs
+++ b/core/station/impl/src/errors/system.rs
@@ -10,8 +10,8 @@ pub enum SystemError {
     InitFailed { reason: String },
     #[error(r#"The canister needs at least one admin"#)]
     NoAdminsSpecified,
-    #[error(r#"There are too many admins defined, max is 255."#)]
-    TooManyAdminsSpecified,
+    #[error(r#"There are too many admins defined, max allowed is {max}."#)]
+    TooManyAdminsSpecified { max: usize },
 }
 
 impl DetailableError for SystemError {

--- a/core/station/impl/src/errors/system.rs
+++ b/core/station/impl/src/errors/system.rs
@@ -10,6 +10,8 @@ pub enum SystemError {
     InitFailed { reason: String },
     #[error(r#"The canister needs at least one admin"#)]
     NoAdminsSpecified,
+    #[error(r#"There are too many admins defined, max is 255."#)]
+    TooManyAdminsSpecified,
 }
 
 impl DetailableError for SystemError {

--- a/core/station/impl/src/factories/requests/add_account.rs
+++ b/core/station/impl/src/factories/requests/add_account.rs
@@ -61,7 +61,7 @@ impl Execute for AddAccountRequestExecute<'_, '_> {
     async fn execute(&self) -> Result<RequestExecuteStage, RequestExecuteError> {
         let account = self
             .account_service
-            .create_account(self.operation.input.to_owned())
+            .create_account(self.operation.input.to_owned(), None)
             .await
             .map_err(|e| RequestExecuteError::Failed {
                 reason: format!("Failed to create account: {}", e),

--- a/core/station/impl/src/models/request.rs
+++ b/core/station/impl/src/models/request.rs
@@ -430,17 +430,20 @@ mod tests {
 
         let account_service = AccountService::default();
         let account = account_service
-            .create_account(AddAccountOperationInput {
-                name: "a".to_owned(),
-                blockchain: crate::models::Blockchain::InternetComputer,
-                standard: crate::models::BlockchainStandard::Native,
-                metadata: Metadata::default(),
-                read_permission: Allow::default(),
-                configs_permission: Allow::default(),
-                transfer_permission: Allow::default(),
-                configs_request_policy: None,
-                transfer_request_policy: None,
-            })
+            .create_account(
+                AddAccountOperationInput {
+                    name: "a".to_owned(),
+                    blockchain: crate::models::Blockchain::InternetComputer,
+                    standard: crate::models::BlockchainStandard::Native,
+                    metadata: Metadata::default(),
+                    read_permission: Allow::default(),
+                    configs_permission: Allow::default(),
+                    transfer_permission: Allow::default(),
+                    configs_request_policy: None,
+                    transfer_request_policy: None,
+                },
+                None,
+            )
             .await
             .expect("Failed to create account");
 

--- a/core/station/impl/src/services/account.rs
+++ b/core/station/impl/src/services/account.rs
@@ -610,7 +610,7 @@ mod tests {
         ctx.repository.insert(account.to_key(), account.clone());
 
         let input = AddAccountOperationInput {
-            name: "foo".to_string(),
+            name: "foo2".to_string(),
             blockchain: Blockchain::InternetComputer,
             standard: BlockchainStandard::Native,
             metadata: Metadata::default(),
@@ -624,6 +624,10 @@ mod tests {
         let result = ctx.service.create_account(input, Some(account.id)).await;
 
         assert!(result.is_err());
+        assert!(result.unwrap_err().to_json_string().contains(&format!(
+            "Account with id {} already exists",
+            Uuid::from_bytes(account.id).hyphenated()
+        )));
     }
 
     #[tokio::test]

--- a/core/station/impl/src/services/account.rs
+++ b/core/station/impl/src/services/account.rs
@@ -603,6 +603,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_account_with_same_id_should_fail() {
+        let ctx = setup();
+        let account = mock_account();
+
+        ctx.repository.insert(account.to_key(), account.clone());
+
+        let input = AddAccountOperationInput {
+            name: "foo".to_string(),
+            blockchain: Blockchain::InternetComputer,
+            standard: BlockchainStandard::Native,
+            metadata: Metadata::default(),
+            read_permission: Allow::users(vec![ctx.caller_user.id]),
+            configs_permission: Allow::users(vec![ctx.caller_user.id]),
+            transfer_permission: Allow::users(vec![ctx.caller_user.id]),
+            configs_request_policy: Some(RequestPolicyRule::AutoApproved),
+            transfer_request_policy: Some(RequestPolicyRule::AutoApproved),
+        };
+
+        let result = ctx.service.create_account(input, Some(account.id)).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn edit_account() {
         let ctx = setup();
         let account = mock_account();

--- a/core/station/impl/src/services/request.rs
+++ b/core/station/impl/src/services/request.rs
@@ -773,20 +773,23 @@ mod tests {
         let account_owners = vec![ctx.caller_user.id, transfer_requester_user.id];
         let account = ctx
             .account_service
-            .create_account(AddAccountOperationInput {
-                name: "foo".to_string(),
-                blockchain: Blockchain::InternetComputer,
-                standard: BlockchainStandard::Native,
-                metadata: Metadata::default(),
-                transfer_request_policy: Some(RequestPolicyRule::QuorumPercentage(
-                    UserSpecifier::Id(vec![ctx.caller_user.id, transfer_requester_user.id]),
-                    Percentage(100),
-                )),
-                configs_request_policy: Some(RequestPolicyRule::AutoApproved),
-                read_permission: Allow::users(account_owners.clone()),
-                configs_permission: Allow::users(account_owners.clone()),
-                transfer_permission: Allow::users(account_owners.clone()),
-            })
+            .create_account(
+                AddAccountOperationInput {
+                    name: "foo".to_string(),
+                    blockchain: Blockchain::InternetComputer,
+                    standard: BlockchainStandard::Native,
+                    metadata: Metadata::default(),
+                    transfer_request_policy: Some(RequestPolicyRule::QuorumPercentage(
+                        UserSpecifier::Id(vec![ctx.caller_user.id, transfer_requester_user.id]),
+                        Percentage(100),
+                    )),
+                    configs_request_policy: Some(RequestPolicyRule::AutoApproved),
+                    read_permission: Allow::users(account_owners.clone()),
+                    configs_permission: Allow::users(account_owners.clone()),
+                    transfer_permission: Allow::users(account_owners.clone()),
+                },
+                None,
+            )
             .await
             .expect("Failed to create account");
 

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -172,7 +172,7 @@ impl SystemService {
             install_canister_handlers::set_controllers(station_controllers).await?;
 
             // calculates the initial quorum based on the number of admins and the provided quorum
-            let admin_count = u16::try_from(init.admins.len()).unwrap_or(u16::MAX);
+            let admin_count = init.admins.len() as u16;
             let quorum = calc_initial_quorum(admin_count, init.quorum);
 
             // if provided, creates the initial accounts
@@ -235,6 +235,10 @@ impl SystemService {
 
         if input.admins.is_empty() {
             return Err(SystemError::NoAdminsSpecified)?;
+        }
+
+        if input.admins.len() > u16::MAX as usize {
+            return Err(SystemError::TooManyAdminsSpecified)?;
         }
 
         // adds the default admin group
@@ -395,10 +399,7 @@ mod install_canister_handlers {
 
     /// Registers the default configurations for the canister.
     pub async fn init_post_process(init: &SystemInit) -> Result<(), String> {
-        let admin_quorum = super::calc_initial_quorum(
-            u16::try_from(init.admins.len()).unwrap_or(u16::MAX),
-            init.quorum,
-        );
+        let admin_quorum = super::calc_initial_quorum(init.admins.len() as u16, init.quorum);
 
         let policies_to_create = default_policies(admin_quorum);
 

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -1,3 +1,4 @@
+use super::DISASTER_RECOVERY_SERVICE;
 use crate::{
     core::{
         ic_cdk::{
@@ -21,8 +22,6 @@ use orbit_essentials::repository::Repository;
 use station_api::{HealthStatus, SystemInit, SystemInstall, SystemUpgrade};
 use std::sync::Arc;
 use uuid::Uuid;
-
-use super::DISASTER_RECOVERY_SERVICE;
 
 lazy_static! {
     pub static ref SYSTEM_SERVICE: Arc<SystemService> =
@@ -172,18 +171,24 @@ impl SystemService {
             }
             install_canister_handlers::set_controllers(station_controllers).await?;
 
+            // calculates the initial quorum based on the number of admins and the provided quorum
+            let admin_count = u16::try_from(init.admins.len()).unwrap_or(u16::MAX);
+            let quorum = install_canister_handlers::calc_initial_quorum(admin_count, init.quorum);
+
+            // if provided, creates the initial accounts
+            if let Some(accounts) = init.accounts {
+                print("Adding initial accounts");
+                install_canister_handlers::set_initial_accounts(accounts, quorum).await?;
+            }
+
             if SYSTEM_SERVICE.is_healthy() {
                 print("canister reports healthy already before its initialization has finished!");
             }
 
             install_canister_post_process_finish(system_info);
 
-            let admin_count = u16::try_from(init.admins.len()).unwrap_or(u16::MAX);
             SystemService::set_disaster_recovery_committee(Some(DisasterRecoveryCommittee {
-                quorum: init
-                    .quorum
-                    .unwrap_or(admin_count / 2 + 1)
-                    .clamp(1, admin_count),
+                quorum,
                 user_group_id: *crate::models::ADMIN_GROUP_ID,
             }));
 
@@ -356,15 +361,24 @@ mod install_canister_handlers {
     use crate::core::ic_cdk::api::{id as self_canister_id, print};
     use crate::core::init::{default_policies, DEFAULT_PERMISSIONS};
     use crate::core::INITIAL_UPGRADER_CYCLES;
-    use crate::models::{AddRequestPolicyOperationInput, EditPermissionOperationInput};
+    use crate::mappers::blockchain::BlockchainMapper;
+    use crate::mappers::HelperMapper;
+    use crate::models::permission::Allow;
+    use crate::models::request_specifier::UserSpecifier;
+    use crate::models::{
+        AddAccountOperationInput, AddRequestPolicyOperationInput, EditPermissionOperationInput,
+        RequestPolicyRule, ADMIN_GROUP_ID,
+    };
     use crate::services::permission::PERMISSION_SERVICE;
+    use crate::services::ACCOUNT_SERVICE;
     use crate::services::REQUEST_POLICY_SERVICE;
     use candid::{Encode, Principal};
     use canfund::fetch::cycles::FetchCyclesBalanceFromCanisterStatus;
     use canfund::manager::options::{EstimatedRuntime, FundManagerOptions, FundStrategy};
     use canfund::FundManager;
     use ic_cdk::api::management_canister::main::{self as mgmt};
-    use station_api::SystemInit;
+    use orbit_essentials::types::UUID;
+    use station_api::{InitAccountInput, SystemInit};
     use std::cell::RefCell;
     use std::sync::Arc;
 
@@ -372,14 +386,18 @@ mod install_canister_handlers {
         pub static FUND_MANAGER: RefCell<FundManager> = RefCell::new(FundManager::new());
     }
 
+    // Calculates the initial quorum based on the number of admins and the provided quorum, if not provided
+    // the quorum is set to the majority of the admins.
+    pub fn calc_initial_quorum(admin_count: u16, quorum: Option<u16>) -> u16 {
+        quorum.unwrap_or(admin_count / 2 + 1).clamp(1, admin_count)
+    }
+
     /// Registers the default configurations for the canister.
     pub async fn init_post_process(init: &SystemInit) -> Result<(), String> {
-        let admin_count = u16::try_from(init.admins.len()).unwrap_or(u16::MAX);
-
-        let admin_quorum = init
-            .quorum
-            .unwrap_or(admin_count / 2 + 1)
-            .clamp(1, admin_count);
+        let admin_quorum = self::calc_initial_quorum(
+            u16::try_from(init.admins.len()).unwrap_or(u16::MAX),
+            init.quorum,
+        );
 
         let policies_to_create = default_policies(admin_quorum);
 
@@ -406,6 +424,53 @@ mod install_canister_handlers {
                 })
                 .await
                 .map_err(|e| format!("Failed to add default permission: {:?}", e))?;
+        }
+
+        Ok(())
+    }
+
+    // Registers the initial accounts of the canister during the canister initialization.
+    pub async fn set_initial_accounts(
+        accounts: Vec<InitAccountInput>,
+        quorum: u16,
+    ) -> Result<(), String> {
+        let add_accounts = accounts
+            .into_iter()
+            .map(|account| {
+                let input = AddAccountOperationInput {
+                    name: account.name,
+                    blockchain: BlockchainMapper::to_blockchain(account.blockchain.clone())
+                        .expect("Invalid blockchain"),
+                    standard: BlockchainMapper::to_blockchain_standard(account.standard)
+                        .expect("Invalid blockchain standard"),
+                    metadata: account.metadata.into(),
+                    transfer_request_policy: Some(RequestPolicyRule::Quorum(
+                        UserSpecifier::Group(vec![*ADMIN_GROUP_ID]),
+                        quorum,
+                    )),
+                    configs_request_policy: Some(RequestPolicyRule::Quorum(
+                        UserSpecifier::Group(vec![*ADMIN_GROUP_ID]),
+                        quorum,
+                    )),
+                    read_permission: Allow::user_groups(vec![*ADMIN_GROUP_ID]),
+                    configs_permission: Allow::user_groups(vec![*ADMIN_GROUP_ID]),
+                    transfer_permission: Allow::user_groups(vec![*ADMIN_GROUP_ID]),
+                };
+
+                (
+                    input,
+                    account
+                        .id
+                        .map(|id| *HelperMapper::to_uuid(id).expect("Invalid UUID").as_bytes()),
+                )
+            })
+            .collect::<Vec<(AddAccountOperationInput, Option<UUID>)>>();
+
+        for (new_account, with_account_id) in add_accounts {
+            ACCOUNT_SERVICE
+                .create_account(new_account, with_account_id)
+                .await
+                .map_err(|e| format!("Failed to add account: {:?}", e))?;
         }
 
         Ok(())

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -238,7 +238,9 @@ impl SystemService {
         }
 
         if input.admins.len() > u16::MAX as usize {
-            return Err(SystemError::TooManyAdminsSpecified)?;
+            return Err(SystemError::TooManyAdminsSpecified {
+                max: u16::MAX as usize,
+            })?;
         }
 
         // adds the default admin group
@@ -651,21 +653,13 @@ mod tests {
 
     #[test]
     fn test_initial_quorum_is_custom() {
-        assert_eq!(calc_initial_quorum(1, Some(1)), 1);
-        assert_eq!(calc_initial_quorum(2, Some(2)), 2);
-        assert_eq!(calc_initial_quorum(3, Some(2)), 2);
-        assert_eq!(calc_initial_quorum(4, Some(3)), 3);
-        assert_eq!(calc_initial_quorum(5, Some(3)), 3);
-        assert_eq!(calc_initial_quorum(6, Some(4)), 4);
-        assert_eq!(calc_initial_quorum(7, Some(4)), 4);
-        assert_eq!(calc_initial_quorum(8, Some(5)), 5);
-        assert_eq!(calc_initial_quorum(9, Some(5)), 5);
-        assert_eq!(calc_initial_quorum(10, Some(6)), 6);
-        assert_eq!(calc_initial_quorum(11, Some(6)), 6);
-        assert_eq!(calc_initial_quorum(12, Some(7)), 7);
-        assert_eq!(calc_initial_quorum(13, Some(7)), 7);
-        assert_eq!(calc_initial_quorum(14, Some(8)), 8);
-        assert_eq!(calc_initial_quorum(15, Some(8)), 8);
-        assert_eq!(calc_initial_quorum(16, Some(9)), 9);
+        // smaller than the number of admins
+        assert_eq!(calc_initial_quorum(4, Some(1)), 1);
+        // half of the number of admins
+        assert_eq!(calc_initial_quorum(4, Some(2)), 2);
+        // equal to the number of admins
+        assert_eq!(calc_initial_quorum(4, Some(4)), 4);
+        // larger than the number of admins
+        assert_eq!(calc_initial_quorum(4, Some(5)), 4);
     }
 }

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -529,6 +529,7 @@ mod tests {
                 quorum: Some(1),
                 upgrader: station_api::SystemUpgraderInput::WasmModule(vec![]),
                 fallback_controller: None,
+                accounts: None,
             })
             .await;
 

--- a/tests/integration/src/disaster_recovery_tests.rs
+++ b/tests/integration/src/disaster_recovery_tests.rs
@@ -477,16 +477,17 @@ fn test_disaster_recovery_flow_recreates_same_accounts() {
                 newly_added_account.id,
                 (newly_added_account.name, newly_added_account.address),
             );
+        } else {
+            panic!("Unexpected request operation found");
         }
     }
 
     // 3. perform a reinstall disaster recovery request
     let init_accounts_input = initial_accounts
-        .clone()
-        .into_iter()
+        .iter()
         .map(|(id, (name, _))| station_api::InitAccountInput {
-            id: Some(id),
-            name,
+            id: Some(id.to_string()),
+            name: name.to_string(),
             blockchain: "icp".to_string(),
             standard: "native".to_string(),
             metadata: vec![],

--- a/tests/integration/src/disaster_recovery_tests.rs
+++ b/tests/integration/src/disaster_recovery_tests.rs
@@ -576,7 +576,7 @@ fn test_disaster_recovery_flow_recreates_same_accounts() {
                 }
             }
             _ => {
-                panic!("Unexpected transfer policy found");
+                panic!("Unexpected request policy found");
             }
         }
     }

--- a/tests/integration/src/setup.rs
+++ b/tests/integration/src/setup.rs
@@ -193,6 +193,7 @@ fn install_canisters(
         quorum: Some(1),
         upgrader: station_api::SystemUpgraderInput::WasmModule(upgrader_wasm),
         fallback_controller: config.fallback_controller,
+        accounts: None,
     });
     env.install_canister(
         station,

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -5,11 +5,12 @@ use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::api::management_canister::main::CanisterId;
 use pocket_ic::{query_candid_as, update_candid_as, CallError, PocketIc, UserError, WasmResult};
 use station_api::{
-    AddUserOperationInput, ApiErrorDTO, CreateRequestInput, CreateRequestResponse, GetRequestInput,
-    GetRequestResponse, HealthStatus, MeResponse, RequestApprovalStatusDTO, RequestDTO,
-    RequestExecutionScheduleDTO, RequestOperationDTO, RequestOperationInput, RequestStatusDTO,
-    SetDisasterRecoveryOperationDTO, SetDisasterRecoveryOperationInput, SubmitRequestApprovalInput,
-    SubmitRequestApprovalResponse, SystemInfoDTO, SystemInfoResponse, UserDTO, UserStatusDTO,
+    AddUserOperationInput, AllowDTO, ApiErrorDTO, CreateRequestInput, CreateRequestResponse,
+    GetPermissionResponse, GetRequestInput, GetRequestResponse, HealthStatus, MeResponse,
+    RequestApprovalStatusDTO, RequestDTO, RequestExecutionScheduleDTO, RequestOperationDTO,
+    RequestOperationInput, RequestStatusDTO, ResourceIdDTO, SetDisasterRecoveryOperationDTO,
+    SetDisasterRecoveryOperationInput, SubmitRequestApprovalInput, SubmitRequestApprovalResponse,
+    SystemInfoDTO, SystemInfoResponse, UserDTO, UserStatusDTO,
 };
 use std::time::Duration;
 use upgrader_api::{GetDisasterRecoveryStateResponse, GetLogsInput, GetLogsResponse};
@@ -466,4 +467,79 @@ pub fn get_upgrader_logs(
     .expect("Failed query call to get disaster recovery logs");
 
     res.0.expect("Failed to get disaster recovery logs")
+}
+
+pub fn get_account_read_permission(
+    env: &PocketIc,
+    sender: Principal,
+    station_canister_id: Principal,
+    account_id: String,
+) -> AllowDTO {
+    let res: (ApiResult<GetPermissionResponse>,) = update_candid_as(
+        env,
+        station_canister_id,
+        sender,
+        "get_permission",
+        (station_api::GetPermissionInput {
+            resource: station_api::ResourceDTO::Account(
+                station_api::AccountResourceActionDTO::Read(ResourceIdDTO::Id(account_id)),
+            ),
+        },),
+    )
+    .expect("Failed to get account read permission");
+
+    res.0
+        .expect("Failed to get account read permission")
+        .permission
+        .allow
+}
+
+pub fn get_account_update_permission(
+    env: &PocketIc,
+    sender: Principal,
+    station_canister_id: Principal,
+    account_id: String,
+) -> AllowDTO {
+    let res: (ApiResult<GetPermissionResponse>,) = update_candid_as(
+        env,
+        station_canister_id,
+        sender,
+        "get_permission",
+        (station_api::GetPermissionInput {
+            resource: station_api::ResourceDTO::Account(
+                station_api::AccountResourceActionDTO::Update(ResourceIdDTO::Id(account_id)),
+            ),
+        },),
+    )
+    .expect("Failed to get account update permission");
+
+    res.0
+        .expect("Failed to get account update permission")
+        .permission
+        .allow
+}
+
+pub fn get_account_transfer_permission(
+    env: &PocketIc,
+    sender: Principal,
+    station_canister_id: Principal,
+    account_id: String,
+) -> AllowDTO {
+    let res: (ApiResult<GetPermissionResponse>,) = update_candid_as(
+        env,
+        station_canister_id,
+        sender,
+        "get_permission",
+        (station_api::GetPermissionInput {
+            resource: station_api::ResourceDTO::Account(
+                station_api::AccountResourceActionDTO::Transfer(ResourceIdDTO::Id(account_id)),
+            ),
+        },),
+    )
+    .expect("Failed to get account transfer permission");
+
+    res.0
+        .expect("Failed to get account transfer permission")
+        .permission
+        .allow
 }


### PR DESCRIPTION
This PR adds the optional functionality of providing an initial set of accounts to the init args of the station canister. This feature enables the disaster recovery to restore accounts in case of `(re)install`.