### PR TITLE
feat(wallet): add advanced and automated mode to upgrades

### DIFF
--- a/apps/wallet/src/components/change-canister/AdvancedUpdateMode.spec.ts
+++ b/apps/wallet/src/components/change-canister/AdvancedUpdateMode.spec.ts
@@ -1,0 +1,51 @@
+import { VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { ChangeCanisterFormValue } from '~/components/change-canister/change-canister.types';
+import { mount } from '~/test.utils';
+import { ChangeCanisterTargetType } from '~/types/station.types';
+import AdvancedUpdateMode from './AdvancedUpdateMode.vue';
+
+describe('AdvancedUpdateMode', () => {
+  it('renders with empty form', () => {
+    const wrapper = mount(AdvancedUpdateMode, {
+      props: {
+        modelValue: {
+          wasmInitArg: undefined,
+          target: undefined,
+          wasmModule: undefined,
+        },
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[name="target"]').exists()).toBe(true);
+    expect(wrapper.find('[name="arg"]').exists()).toBe(true);
+    expect(wrapper.find('[name="wasm"]').exists()).toBe(true);
+  });
+
+  it('when target type changes the modelValue picks up the change', async () => {
+    const wrapper = mount(AdvancedUpdateMode, {
+      props: {
+        modelValue: {
+          wasmInitArg: undefined,
+          target: undefined,
+          wasmModule: undefined,
+        },
+      },
+    }) as unknown as VueWrapper<
+      InstanceType<typeof AdvancedUpdateMode> & { upgradeTarget: ChangeCanisterTargetType }
+    >;
+
+    // picks up the change to upgrade station
+    wrapper.vm.upgradeTarget = ChangeCanisterTargetType.UpgradeStation;
+    await wrapper.vm.$nextTick();
+    const modelValue = wrapper.emitted('update:modelValue')?.[0]?.[0] as ChangeCanisterFormValue;
+    expect(modelValue.target).toEqual({ UpgradeStation: null });
+
+    // picks up the change to upgrade upgrader
+    wrapper.vm.upgradeTarget = ChangeCanisterTargetType.UpgradeUpgrader;
+    await wrapper.vm.$nextTick();
+    const modelValue2 = wrapper.emitted('update:modelValue')?.[1]?.[0] as ChangeCanisterFormValue;
+    expect(modelValue2.target).toEqual({ UpgradeUpgrader: null });
+  });
+});

--- a/apps/wallet/src/components/change-canister/AdvancedUpdateMode.vue
+++ b/apps/wallet/src/components/change-canister/AdvancedUpdateMode.vue
@@ -40,7 +40,7 @@ import { computed, ref, watch } from 'vue';
 import { VAlert, VFileInput, VSelect, VTextarea } from 'vuetify/components';
 import { ChangeCanisterFormValue } from '~/components/change-canister/change-canister.types';
 import {
-  useDefaultUpgradFormValue,
+  useDefaultUpgradeFormValue,
   useUpgradeTargets,
 } from '~/composables/change-canister.composable';
 import logger from '~/core/logger.core';
@@ -112,7 +112,7 @@ watch(
         break;
       default:
         wasmModuleFile.value = [];
-        modelValue.value = useDefaultUpgradFormValue();
+        modelValue.value = useDefaultUpgradeFormValue();
         break;
     }
   },

--- a/apps/wallet/src/components/change-canister/AdvancedUpdateMode.vue
+++ b/apps/wallet/src/components/change-canister/AdvancedUpdateMode.vue
@@ -1,0 +1,131 @@
+<template>
+  <VAlert type="warning" density="compact" variant="tonal" class="mb-4">
+    {{ $t('app.advanced_software_update_warning') }}
+  </VAlert>
+
+  <VSelect
+    v-model="upgradeTarget"
+    name="target"
+    :items="upgradeTargetItems"
+    :label="$t('app.canister_upgrade_target')"
+    :prepend-icon="mdiTarget"
+    variant="filled"
+    density="comfortable"
+  />
+
+  <VFileInput
+    v-model="wasmModuleFile"
+    name="wasm"
+    :label="$t('app.canister_wasm_module')"
+    :rules="[requiredRule]"
+    :prepend-icon="mdiCube"
+    variant="filled"
+    density="comfortable"
+  />
+
+  <VTextarea
+    v-model="wasmInitArg"
+    name="arg"
+    :label="$t(`app.canister_upgrade_args_input`)"
+    :prepend-icon="mdiCodeArray"
+    :hint="$t(`app.canister_upgrade_args_input_hint`)"
+    variant="filled"
+    density="comfortable"
+  />
+</template>
+
+<script lang="ts" setup>
+import { mdiCodeArray, mdiCube, mdiTarget } from '@mdi/js';
+import { computed, ref, watch } from 'vue';
+import { VAlert, VFileInput, VSelect, VTextarea } from 'vuetify/components';
+import { ChangeCanisterFormValue } from '~/components/change-canister/change-canister.types';
+import {
+  useDefaultUpgradFormValue,
+  useUpgradeTargets,
+} from '~/composables/change-canister.composable';
+import logger from '~/core/logger.core';
+import { ChangeCanisterTargetType } from '~/types/station.types';
+import { readFileAsArrayBuffer } from '~/utils/file.utils';
+import { requiredRule } from '~/utils/form.utils';
+
+const props = defineProps<{
+  modelValue: ChangeCanisterFormValue;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload: ChangeCanisterFormValue): void;
+}>();
+
+const modelValue = computed({
+  get: () => props.modelValue,
+  set: value => emit('update:modelValue', value),
+});
+
+const wasmModuleFile = ref<File[]>([]);
+const upgradeTargets = useUpgradeTargets();
+const upgradeTarget = ref<ChangeCanisterTargetType>(ChangeCanisterTargetType.UpgradeStation);
+const upgradeTargetItems = computed(() => Object.values(upgradeTargets.value));
+const wasmInitArg = ref<string>(props.modelValue.wasmInitArg ?? '');
+
+const updateComputedCanisterModule = async () => {
+  if (!wasmModuleFile.value || wasmModuleFile.value.length === 0) {
+    modelValue.value = {
+      ...modelValue.value,
+      wasmModule: undefined,
+    };
+
+    return;
+  }
+
+  try {
+    const wasmModule = await readFileAsArrayBuffer(wasmModuleFile.value[0]);
+    modelValue.value = {
+      ...modelValue.value,
+      wasmModule,
+    };
+  } catch (error) {
+    logger.error('Failed to read wasm module file', error);
+  }
+};
+
+watch(
+  () => wasmModuleFile.value,
+  () => updateComputedCanisterModule(),
+  { deep: true },
+);
+
+watch(
+  () => upgradeTarget.value,
+  () => {
+    switch (upgradeTarget.value) {
+      case ChangeCanisterTargetType.UpgradeStation:
+        modelValue.value = {
+          ...modelValue.value,
+          target: { UpgradeStation: null },
+        };
+        break;
+      case ChangeCanisterTargetType.UpgradeUpgrader:
+        modelValue.value = {
+          ...modelValue.value,
+          target: { UpgradeUpgrader: null },
+        };
+        break;
+      default:
+        wasmModuleFile.value = [];
+        modelValue.value = useDefaultUpgradFormValue();
+        break;
+    }
+  },
+  { immediate: true },
+);
+
+watch(
+  () => wasmInitArg.value,
+  () => {
+    modelValue.value = {
+      ...modelValue.value,
+      wasmInitArg: wasmInitArg.value?.length ? wasmInitArg.value : undefined,
+    };
+  },
+);
+</script>

--- a/apps/wallet/src/components/change-canister/ChangeCanisterActionBtn.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterActionBtn.vue
@@ -1,31 +1,69 @@
 <template>
   <ActionBtn
     v-model="upgradeModel"
-    :text="$t('app.submit_upgrade')"
-    :title="$t('app.submit_upgrade')"
+    :text="$t('app.software_update')"
+    :title="$t('app.software_update')"
     size="default"
     variant="outlined"
     density="comfortable"
     :submit="form => submitUpgrade(form.modelValue as ChangeCanisterFormProps['modelValue'])"
     data-test-id="submit-upgrade-btn"
     @opened="emit('editing', true)"
-    @closed="emit('editing', false)"
+    @closed="onClosed"
     @failed="useOnFailedOperation"
     @submitted="useOnSuccessfulOperation"
   >
-    <template #default="{ model: elem, submit }">
+    <template #default="{ model: elem }">
       <ChangeCanisterForm
+        v-show="screen === ChangeCanisterScreen.Form"
+        :mode="formMode"
         :model-value="elem.value.modelValue as ChangeCanisterFormProps['modelValue']"
         @update:model-value="elem.value.modelValue = $event"
         @valid="elem.value.valid = $event"
-        @submit="submit"
+        @submit="goToConfirmation(elem.value.modelValue)"
+      />
+
+      <ChangeCanisterConfirmationScreen
+        v-if="screen === ChangeCanisterScreen.Confirm"
+        :wasm-module-checksum="wasmChecksum"
+        :comment="elem.value.modelValue.comment"
+        @update:comment="elem.value.modelValue = {
+          ...elem.value.modelValue,
+          comment: $event,
+        }"
       />
     </template>
     <template #actions="{ submit, loading: saving, model: elem }">
+      <VBtn
+        v-if="screen === ChangeCanisterScreen.Form"
+        :disabled="saving"
+        :append-icon="
+          formMode === ChangeCanisterFormMode.Advanced ? mdiCloudDownload : mdiWrenchCog
+        "
+        variant="text"
+        @click="toggleFormMode"
+      >
+        {{
+          formMode === ChangeCanisterFormMode.Advanced
+            ? $t('terms.automated')
+            : $t('terms.advanced')
+        }}
+      </VBtn>
       <VSpacer />
       <VBtn
+        v-if="screen === ChangeCanisterScreen.Form"
         :loading="saving"
         :disabled="!elem.value.valid"
+        color="primary"
+        variant="flat"
+        @click="goToConfirmation(elem.value.modelValue)"
+      >
+        {{ $t('terms.continue') }}
+      </VBtn>
+      <VBtn
+        v-if="screen === ChangeCanisterScreen.Confirm"
+        :loading="saving"
+        :disabled="saving"
         color="primary"
         variant="flat"
         @click="submit"
@@ -37,45 +75,72 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiCloudDownload, mdiWrenchCog } from '@mdi/js';
 import { ref } from 'vue';
+import { VBtn } from 'vuetify/components';
 import ActionBtn from '~/components/buttons/ActionBtn.vue';
 import ChangeCanisterForm, {
   ChangeCanisterFormProps,
 } from '~/components/change-canister/ChangeCanisterForm.vue';
+import { useDefaultUpgradeModel } from '~/composables/change-canister.composable';
 import {
   useOnFailedOperation,
   useOnSuccessfulOperation,
 } from '~/composables/notifications.composable';
 import { Request } from '~/generated/station/station.did';
 import { useStationStore } from '~/stores/station.store';
-import { hexStringToArrayBuffer } from '~/utils/crypto.utils';
-import { readFileAsArrayBuffer } from '~/utils/file.utils';
+import { arrayBufferToHashHex, hexStringToArrayBuffer } from '~/utils/crypto.utils';
 import { assertAndReturn } from '~/utils/helper.utils';
+import { ChangeCanisterFormMode, ChangeCanisterScreen } from './change-canister.types';
+import ChangeCanisterConfirmationScreen from './ChangeCanisterConfirmationScreen.vue';
 
 const station = useStationStore();
+const upgradeModel = ref<ChangeCanisterFormProps>(useDefaultUpgradeModel());
+const screen = ref<ChangeCanisterScreen>(ChangeCanisterScreen.Form);
+const formMode = ref<ChangeCanisterFormMode>(ChangeCanisterFormMode.Registry);
+const toggleFormMode = () => {
+  upgradeModel.value = useDefaultUpgradeModel();
+  formMode.value =
+    formMode.value === ChangeCanisterFormMode.Advanced
+      ? ChangeCanisterFormMode.Registry
+      : ChangeCanisterFormMode.Advanced;
+};
+const wasmChecksum = ref<string>('');
 
-const upgradeModel = ref<ChangeCanisterFormProps>({
-  modelValue: {
-    target: null,
-    wasmModule: undefined,
-    arg: null,
-  },
-  valid: false,
-});
+const goToConfirmation = async (model: ChangeCanisterFormProps['modelValue']): Promise<void> => {
+  const wasmModule = assertAndReturn(model.wasmModule, 'model.wasmModule is required');
+  wasmChecksum.value = await arrayBufferToHashHex(wasmModule);
+
+  screen.value = ChangeCanisterScreen.Confirm;
+};
 
 const submitUpgrade = async (model: ChangeCanisterFormProps['modelValue']): Promise<Request> => {
-  const wasmModule = assertAndReturn(model.wasmModule?.[0], 'model.wasmModule is required');
-  const fileBuffer = await readFileAsArrayBuffer(wasmModule);
+  const fileBuffer = assertAndReturn(model.wasmModule, 'model.wasmModule is required');
 
-  return station.service.changeCanister({
-    arg:
-      model.arg && model.arg.length > 0 ? [new Uint8Array(hexStringToArrayBuffer(model.arg))] : [],
-    module: new Uint8Array(fileBuffer),
-    target: assertAndReturn(model.target),
-  });
+  return station.service.changeCanister(
+    {
+      arg:
+        model.wasmInitArg && model.wasmInitArg.length > 0
+          ? [new Uint8Array(hexStringToArrayBuffer(model.wasmInitArg))]
+          : [],
+      module: new Uint8Array(fileBuffer),
+      target: assertAndReturn(model.target, 'model.target is required'),
+    },
+    {
+      comment: model.comment,
+    },
+  );
 };
 
 const emit = defineEmits<{
   (event: 'editing', payload: boolean): void;
 }>();
+
+const onClosed = () => {
+  formMode.value = ChangeCanisterFormMode.Registry;
+  screen.value = ChangeCanisterScreen.Form;
+  upgradeModel.value = useDefaultUpgradeModel();
+
+  emit('editing', false);
+};
 </script>

--- a/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.spec.ts
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '~/test.utils';
+import ChangeCanisterConfirmationScreen from './ChangeCanisterConfirmationScreen.vue';
+
+describe('ChangeCanisterConfirmationScreen', () => {
+  it('confirmation screen has checksum and comment fields', () => {
+    const wrapper = mount(ChangeCanisterConfirmationScreen, {
+      props: {
+        wasmModuleChecksum: 'checksum',
+        comment: 'My test comment',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[name="wasm_checksum"]').exists()).toBe(true);
+    expect(wrapper.find('[name="comment"]').exists()).toBe(true);
+  });
+
+  it('confirmation screen shows the checksum in the field in readonly mode', () => {
+    const wrapper = mount(ChangeCanisterConfirmationScreen, {
+      props: {
+        wasmModuleChecksum: 'checksum',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+
+    const field = wrapper.find('[name="wasm_checksum"]').element as HTMLInputElement;
+    expect(field.value).toEqual('checksum');
+    expect(field.readOnly).toBe(true);
+  });
+
+  it('confirmation screen shows the comment in the field in edit mode', () => {
+    const wrapper = mount(ChangeCanisterConfirmationScreen, {
+      props: {
+        wasmModuleChecksum: 'checksum',
+        comment: 'My test comment',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+
+    const field = wrapper.find('[name="comment"]').element as HTMLInputElement;
+    expect(field.value).toEqual('My test comment');
+    expect(field.readOnly).toBe(false);
+  });
+});

--- a/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
@@ -11,7 +11,7 @@
 
   <VTextarea
     v-model="comment"
-    name="arg"
+    name="comment"
     :label="$t(`requests.comment_optional`)"
     :prepend-icon="mdiComment"
     variant="filled"

--- a/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
@@ -1,0 +1,45 @@
+<template>
+  <VTextField
+    :label="$t('terms.module_checksum')"
+    :model-value="props.wasmModuleChecksum"
+    name="wasm_checksum"
+    variant="plain"
+    density="comfortable"
+    :prepend-icon="mdiPound"
+    readonly
+  />
+
+  <VTextarea
+    v-model="comment"
+    name="arg"
+    :label="$t(`requests.comment_optional`)"
+    :prepend-icon="mdiComment"
+    variant="filled"
+    density="comfortable"
+  />
+</template>
+
+<script lang="ts" setup>
+import { mdiComment, mdiPound } from '@mdi/js';
+import { computed } from 'vue';
+import { VTextarea, VTextField } from 'vuetify/components';
+
+const props = withDefaults(
+  defineProps<{
+    wasmModuleChecksum: string;
+    comment?: string;
+  }>(),
+  {
+    comment: undefined,
+  },
+);
+
+const comment = computed({
+  get: () => props.comment,
+  set: value => emit('update:comment', value),
+});
+
+const emit = defineEmits<{
+  (event: 'update:comment', payload?: string): void;
+}>();
+</script>

--- a/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterConfirmationScreen.vue
@@ -16,6 +16,7 @@
     :prepend-icon="mdiComment"
     variant="filled"
     density="comfortable"
+    auto-grow
   />
 </template>
 

--- a/apps/wallet/src/components/change-canister/ChangeCanisterForm.spec.ts
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterForm.spec.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '~/test.utils';
 import ChangeCanisterForm from './ChangeCanisterForm.vue';
+import { ChangeCanisterFormMode } from '~/components/change-canister/change-canister.types';
 
 describe('ChangeCanisterForm', () => {
   it('renders with empty form', () => {
     const wrapper = mount(ChangeCanisterForm, {
       props: {
+        mode: ChangeCanisterFormMode.Advanced,
         modelValue: {
-          arg: null,
-          target: null,
+          wasmInitArg: undefined,
+          target: undefined,
           wasmModule: undefined,
         },
       },

--- a/apps/wallet/src/components/change-canister/ChangeCanisterForm.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterForm.vue
@@ -3,6 +3,8 @@
     <RegistryUpdateMode
       v-if="props.mode === ChangeCanisterFormMode.Registry"
       v-model="modelValue"
+      @valid="emit('valid', $event)"
+      @loading="emit('loading', $event)"
     />
     <AdvancedUpdateMode
       v-else-if="props.mode === ChangeCanisterFormMode.Advanced"
@@ -32,13 +34,14 @@ const form = ref<VFormValidation | null>(null);
 const isFormValid = computed(() => (form.value ? form.value.isValid : false));
 
 const props = withDefaults(defineProps<ChangeCanisterFormProps>(), {
-  valid: true,
+  valid: false,
   mode: ChangeCanisterFormMode.Registry,
 });
 
 const emit = defineEmits<{
   (event: 'update:modelValue', payload: ChangeCanisterFormProps['modelValue']): void;
   (event: 'valid', payload: boolean): void;
+  (event: 'loading', payload: boolean): void;
   (event: 'submit', payload: ChangeCanisterFormProps['modelValue']): void;
 }>();
 

--- a/apps/wallet/src/components/change-canister/ChangeCanisterForm.vue
+++ b/apps/wallet/src/components/change-canister/ChangeCanisterForm.vue
@@ -1,82 +1,39 @@
 <template>
   <VForm ref="form" @submit.prevent="submit">
-    <VSelect
-      v-model="upgradeTarget"
-      name="target"
-      :items="upgradeTargetItems"
-      :label="$t('app.canister_upgrade_target')"
-      :prepend-icon="mdiTarget"
-      variant="filled"
-      density="comfortable"
+    <RegistryUpdateMode
+      v-if="props.mode === ChangeCanisterFormMode.Registry"
+      v-model="modelValue"
     />
-
-    <VFileInput
-      v-model="modelValue.wasmModule"
-      name="wasm"
-      :label="$t('app.canister_wasm_module')"
-      :rules="[requiredRule]"
-      :prepend-icon="mdiCube"
-      variant="filled"
-      density="comfortable"
-    >
-      <template v-if="moduleChecksum" #counter>
-        {{ $t('terms.checksum') }}: {{ moduleChecksum }}
-      </template>
-    </VFileInput>
-
-    <VTextarea
-      v-model="modelValue.arg"
-      name="arg"
-      :label="$t(`app.canister_upgrade_args_input`)"
-      :prepend-icon="mdiMessageText"
-      :hint="$t(`app.canister_upgrade_args_input_hint`)"
-      variant="filled"
-      density="comfortable"
+    <AdvancedUpdateMode
+      v-else-if="props.mode === ChangeCanisterFormMode.Advanced"
+      v-model="modelValue"
     />
   </VForm>
 </template>
 
 <script lang="ts" setup>
-import { mdiCube, mdiMessageText, mdiTarget } from '@mdi/js';
 import { computed, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { VFileInput, VForm, VSelect, VTextarea } from 'vuetify/components';
-import { ChangeCanisterTarget } from '~/generated/station/station.did';
+import { VForm } from 'vuetify/components';
+import {
+  ChangeCanisterFormMode,
+  ChangeCanisterFormValue,
+} from '~/components/change-canister/change-canister.types';
 import { VFormValidation } from '~/types/helper.types';
-import { ChangeCanisterTargetType } from '~/types/station.types';
-import { arrayBufferToHashHex } from '~/utils/crypto.utils';
-import { readFileAsArrayBuffer } from '~/utils/file.utils';
-import { requiredRule } from '~/utils/form.utils';
+import AdvancedUpdateMode from './AdvancedUpdateMode.vue';
+import RegistryUpdateMode from './RegistryUpdateMode.vue';
 
 export type ChangeCanisterFormProps = {
-  modelValue: {
-    target: ChangeCanisterTarget | null;
-    wasmModule: File[] | undefined;
-    arg: string | null;
-  };
+  mode?: ChangeCanisterFormMode;
+  modelValue: ChangeCanisterFormValue;
   valid?: boolean;
 };
 
-const i18n = useI18n();
-
-const upgradeTarget = ref<ChangeCanisterTargetType>(ChangeCanisterTargetType.UpgradeStation);
-const upgradeTargetItems = computed(() => [
-  {
-    value: ChangeCanisterTargetType.UpgradeStation,
-    title: i18n.t('change_canister.targets.upgradestation'),
-  },
-  {
-    value: ChangeCanisterTargetType.UpgradeUpgrader,
-    title: i18n.t('change_canister.targets.upgradeupgrader'),
-  },
-]);
-
 const form = ref<VFormValidation | null>(null);
 const isFormValid = computed(() => (form.value ? form.value.isValid : false));
-const moduleChecksum = ref<string | null>(null);
 
 const props = withDefaults(defineProps<ChangeCanisterFormProps>(), {
   valid: true,
+  mode: ChangeCanisterFormMode.Registry,
 });
 
 const emit = defineEmits<{
@@ -94,47 +51,6 @@ const modelValue = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value),
 });
-
-watch(
-  () => modelValue.value,
-  () => updateComputedCanisterModule(),
-  { deep: true },
-);
-
-watch(
-  () => upgradeTarget.value,
-  () => {
-    switch (upgradeTarget.value) {
-      case ChangeCanisterTargetType.UpgradeStation:
-        modelValue.value.target = {
-          UpgradeStation: null,
-        };
-        break;
-      case ChangeCanisterTargetType.UpgradeUpgrader:
-        modelValue.value.target = {
-          UpgradeUpgrader: null,
-        };
-        break;
-      default:
-        modelValue.value.target = null;
-        break;
-    }
-  },
-  { immediate: true },
-);
-
-const updateComputedCanisterModule = async (): Promise<void> => {
-  if (modelValue.value.wasmModule && modelValue.value.wasmModule.length > 0) {
-    const file = modelValue.value.wasmModule[0];
-    const fileBuffer = await readFileAsArrayBuffer(file);
-    const hashHex = await arrayBufferToHashHex(fileBuffer);
-
-    moduleChecksum.value = hashHex;
-    return;
-  }
-
-  moduleChecksum.value = null;
-};
 
 const submit = async () => {
   const { valid } = form.value ? await form.value.validate() : { valid: false };

--- a/apps/wallet/src/components/change-canister/RegistryUpdateMode.spec.ts
+++ b/apps/wallet/src/components/change-canister/RegistryUpdateMode.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mockPinia, mount } from '~/test.utils';
+import RegistryUpdateMode from './RegistryUpdateMode.vue';
+import { useStationStore } from '~/stores/station.store';
+
+describe('RegistryUpdateMode', () => {
+  it('on mount triggers the check for new updates', () => {
+    const pinia = mockPinia({ activate: true });
+    const station = useStationStore();
+    vi.spyOn(station, 'checkVersionUpdates').mockImplementation(() => Promise.resolve());
+
+    const wrapper = mount(
+      RegistryUpdateMode,
+      { props: { modelValue: {} } },
+      { plugins: { pinia } },
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(station.checkVersionUpdates).toHaveBeenCalled();
+  });
+
+  it('shows already in latest version screen', () => {
+    const pinia = mockPinia({
+      activate: true,
+      initialState: {
+        station: {
+          versionManagement: {
+            loading: false,
+            nextStationVersion: undefined,
+            nextUpgraderVersion: undefined,
+          },
+        },
+      },
+    });
+
+    const station = useStationStore();
+    vi.spyOn(station, 'checkVersionUpdates').mockImplementation(() => Promise.resolve());
+
+    const wrapper = mount(
+      RegistryUpdateMode,
+      { props: { modelValue: {} } },
+      { plugins: { pinia } },
+    );
+
+    expect(wrapper.find('[data-test-id="latest-screen"]').exists()).toBe(true);
+  });
+
+  it('shows update available screen', () => {
+    const pinia = mockPinia({
+      activate: true,
+      initialState: {
+        station: {
+          versionManagement: {
+            loading: false,
+            nextStationVersion: '1.2.3',
+            nextUpgraderVersion: '1.2.3',
+          },
+        },
+      },
+    });
+
+    const station = useStationStore();
+    vi.spyOn(station, 'checkVersionUpdates').mockImplementation(() => Promise.resolve());
+
+    const wrapper = mount(
+      RegistryUpdateMode,
+      { props: { modelValue: {} } },
+      { plugins: { pinia } },
+    );
+
+    expect(wrapper.find('[data-test-id="update-available-screen"]').exists()).toBe(true);
+  });
+
+  it('shows loading screen while version updates is in progress', () => {
+    const pinia = mockPinia({
+      activate: true,
+      initialState: {
+        station: {
+          versionManagement: {
+            loading: true,
+          },
+        },
+      },
+    });
+
+    const station = useStationStore();
+    vi.spyOn(station, 'checkVersionUpdates').mockImplementation(() => Promise.resolve());
+
+    const wrapper = mount(
+      RegistryUpdateMode,
+      { props: { modelValue: {} } },
+      { plugins: { pinia } },
+    );
+
+    expect(station.checkVersionUpdates).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-test-id="loading-screen"]').exists()).toBe(true);
+  });
+});

--- a/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
+++ b/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
@@ -1,19 +1,160 @@
-<template>This component updates the canister from the registry.</template>
+<template>
+  <VAlert type="info" density="compact" variant="tonal" class="mb-4">
+    {{ $t('app.update_recommended_latest') }}
+  </VAlert>
+
+  <p v-if="checkingForUpdates" class="text-h6 py-3">
+    <VProgressCircular indeterminate color="primary" class="mb-1 mr-2" :size="20" :width="2" />
+    {{ $t('app.checking_for_updates') }}
+  </p>
+
+  <p v-else-if="!isUpdateAvailable" class="text-h6 py-3">
+    {{ $t('app.update_already_latest_version') }}
+  </p>
+
+  <p v-else class="text-h6 py-3">{{ $t('app.update_available') }}</p>
+</template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { VAlert, VProgressCircular } from 'vuetify/components';
+import { useDefaultUpgradeFormValue } from '~/composables/change-canister.composable';
+import logger from '~/core/logger.core';
+import { services } from '~/plugins/services.plugin';
+import { useStationStore } from '~/stores/station.store';
+import { toArrayBuffer } from '~/utils/helper.utils';
 import { ChangeCanisterFormValue } from './change-canister.types';
 
+const i18n = useI18n();
 const props = defineProps<{
   modelValue: ChangeCanisterFormValue;
 }>();
 
 const emit = defineEmits<{
   (event: 'update:modelValue', payload: ChangeCanisterFormValue): void;
+  (event: 'valid', payload: boolean): void;
+  (event: 'loading', payload: boolean): void;
 }>();
 
-const _modelValue = computed({
+const modelValue = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value),
 });
+
+const station = useStationStore();
+const preparingArtifacts = ref(false);
+
+onMounted(() => {
+  emit('valid', false);
+  if (!station.versionManagement.loading) {
+    station.checkVersionUpdates();
+  }
+});
+
+const checkingForUpdates = computed(
+  () => station.versionManagement.loading || preparingArtifacts.value,
+);
+
+const isUpdateAvailable = computed(
+  () =>
+    station.versionManagement.nextStationVersion || station.versionManagement.nextUpgraderVersion,
+);
+
+const createAutomatedComment = (input: {
+  name: string;
+  version: string;
+  repositoryUrl: string;
+}): string => {
+  const summary = i18n.t('app.update_automated_comment.summary', {
+    name: input.name,
+    version: input.version,
+  });
+
+  const verifyInstructions = i18n.t('app.update_automated_comment.verify_instructions');
+
+  return `${summary}\n\n${verifyInstructions}\n
+  1. git clone ${input.repositoryUrl}
+  2. cd orbit
+  3. git checkout @orbit/${input.name}-v${input.version}
+  4. ./scripts/docker-build.sh --${input.name}
+  5. cat ./artifacts/${input.name}/${input.name}.wasm.gz.sha256\n`;
+};
+
+const prepareUpdateWithWasmModule = async (): Promise<void> => {
+  try {
+    preparingArtifacts.value = true;
+    emit('valid', false);
+
+    modelValue.value = useDefaultUpgradeFormValue();
+    const controlPanel = services().controlPanel;
+    const { nextStationVersion, nextUpgraderVersion } = station.versionManagement;
+
+    if (!nextStationVersion && !nextUpgraderVersion) {
+      return;
+    }
+
+    // If there is a new upgrader version, it needs to be updated first
+    const registryEntry = nextUpgraderVersion
+      ? await controlPanel.findModuleVersionRegistryEntry('@orbit/upgrader', nextUpgraderVersion)
+      : await controlPanel.findModuleVersionRegistryEntry('@orbit/station', nextStationVersion!);
+
+    if (!registryEntry) {
+      logger.warn('Failed to find registry entry');
+      return;
+    }
+
+    const repositoryUrl =
+      registryEntry.metadata.find(metadata => metadata.key === 'url')?.value ??
+      'https://github.com/dfinity/orbit';
+
+    if (nextUpgraderVersion) {
+      modelValue.value.target = { UpgradeUpgrader: null };
+      modelValue.value.comment = createAutomatedComment({
+        name: 'upgrader',
+        version: nextUpgraderVersion,
+        repositoryUrl,
+      });
+    } else {
+      modelValue.value.target = { UpgradeStation: null };
+      modelValue.value.comment = createAutomatedComment({
+        name: 'station',
+        version: nextStationVersion!,
+        repositoryUrl,
+      });
+    }
+
+    // Fetch the artifact with an update call to make sure it's verified
+    const { artifact } = await controlPanel.getArtifact(
+      { artifact_id: registryEntry.value.WasmModule.wasm_artifact_id },
+      true,
+    );
+
+    modelValue.value = {
+      ...modelValue.value,
+      wasmModule: toArrayBuffer(artifact.artifact),
+      wasmInitArg: undefined,
+    };
+
+    emit('valid', true);
+  } catch (err) {
+    logger.error('Failed to prepare update with wasm module', err);
+  } finally {
+    preparingArtifacts.value = false;
+  }
+};
+
+watch(
+  () => station.versionManagement.loading,
+  checking => {
+    if (!checking) {
+      prepareUpdateWithWasmModule();
+    }
+  },
+);
+
+watch(
+  () => preparingArtifacts.value,
+  loadingArtifacts => emit('loading', loadingArtifacts),
+);
 </script>

--- a/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
+++ b/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
@@ -1,0 +1,19 @@
+<template>This component updates the canister from the registry.</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { ChangeCanisterFormValue } from './change-canister.types';
+
+const props = defineProps<{
+  modelValue: ChangeCanisterFormValue;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload: ChangeCanisterFormValue): void;
+}>();
+
+const _modelValue = computed({
+  get: () => props.modelValue,
+  set: value => emit('update:modelValue', value),
+});
+</script>

--- a/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
+++ b/apps/wallet/src/components/change-canister/RegistryUpdateMode.vue
@@ -3,16 +3,18 @@
     {{ $t('app.update_recommended_latest') }}
   </VAlert>
 
-  <p v-if="checkingForUpdates" class="text-h6 py-3">
+  <p v-if="checkingForUpdates" class="text-h6 py-3" data-test-id="loading-screen">
     <VProgressCircular indeterminate color="primary" class="mb-1 mr-2" :size="20" :width="2" />
     {{ $t('app.checking_for_updates') }}
   </p>
 
-  <p v-else-if="!isUpdateAvailable" class="text-h6 py-3">
+  <p v-else-if="!isUpdateAvailable" class="text-h6 py-3" data-test-id="latest-screen">
     {{ $t('app.update_already_latest_version') }}
   </p>
 
-  <p v-else class="text-h6 py-3">{{ $t('app.update_available') }}</p>
+  <p v-else class="text-h6 py-3" data-test-id="update-available-screen">
+    {{ $t('app.update_available') }}
+  </p>
 </template>
 
 <script lang="ts" setup>

--- a/apps/wallet/src/components/change-canister/change-canister.types.ts
+++ b/apps/wallet/src/components/change-canister/change-canister.types.ts
@@ -1,0 +1,18 @@
+import { ChangeCanisterTarget } from '~/generated/station/station.did';
+
+export interface ChangeCanisterFormValue {
+  target?: ChangeCanisterTarget;
+  wasmModule?: ArrayBuffer;
+  wasmInitArg?: string;
+  comment?: string;
+}
+
+export enum ChangeCanisterFormMode {
+  Registry = 'registry',
+  Advanced = 'advanced',
+}
+
+export enum ChangeCanisterScreen {
+  Form = 'form',
+  Confirm = 'confirm',
+}

--- a/apps/wallet/src/composables/change-canister.composable.spec.ts
+++ b/apps/wallet/src/composables/change-canister.composable.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  useDefaultUpgradeModel,
+  useUpgradeTargets,
+} from '~/composables/change-canister.composable';
+import { setupComponent } from '~/test.utils';
+import { ChangeCanisterTargetType } from '~/types/station.types';
+
+describe('change-canister.composable', () => {
+  it('should return upgrade targets with correct targets', () => {
+    const vm = setupComponent(() => ({ targets: useUpgradeTargets() }));
+
+    expect(vm.targets.station.value).toEqual(ChangeCanisterTargetType.UpgradeStation);
+    expect(vm.targets.upgrader.value).toEqual(ChangeCanisterTargetType.UpgradeUpgrader);
+  });
+
+  it('should return default form value with empty values', () => {
+    const { modelValue } = useDefaultUpgradeModel();
+
+    expect(modelValue).toEqual({
+      target: undefined,
+      wasmModule: undefined,
+      wasmInitArg: undefined,
+      comment: undefined,
+    });
+  });
+
+  it('by default upgrade form should be invalid', () => {
+    const { valid } = useDefaultUpgradeModel();
+
+    expect(valid).toBe(false);
+  });
+});

--- a/apps/wallet/src/composables/change-canister.composable.ts
+++ b/apps/wallet/src/composables/change-canister.composable.ts
@@ -1,0 +1,34 @@
+import { computed, ComputedRef } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { ChangeCanisterFormValue } from '~/components/change-canister/change-canister.types';
+import { ChangeCanisterTargetType } from '~/types/station.types';
+
+export const useUpgradeTargets = (): ComputedRef<{
+  station: { value: ChangeCanisterTargetType; title: string };
+  upgrader: { value: ChangeCanisterTargetType; title: string };
+}> => {
+  const i18n = useI18n();
+
+  return computed(() => ({
+    station: {
+      value: ChangeCanisterTargetType.UpgradeStation,
+      title: i18n.t('change_canister.targets.upgradestation'),
+    },
+    upgrader: {
+      value: ChangeCanisterTargetType.UpgradeUpgrader,
+      title: i18n.t('change_canister.targets.upgradeupgrader'),
+    },
+  }));
+};
+
+export const useDefaultUpgradFormValue = (): ChangeCanisterFormValue => ({
+  target: undefined,
+  wasmModule: undefined,
+  wasmInitArg: undefined,
+  comment: undefined,
+});
+
+export const useDefaultUpgradeModel = () => ({
+  modelValue: useDefaultUpgradFormValue(),
+  valid: false,
+});

--- a/apps/wallet/src/composables/change-canister.composable.ts
+++ b/apps/wallet/src/composables/change-canister.composable.ts
@@ -21,7 +21,7 @@ export const useUpgradeTargets = (): ComputedRef<{
   }));
 };
 
-export const useDefaultUpgradFormValue = (): ChangeCanisterFormValue => ({
+export const useDefaultUpgradeFormValue = (): ChangeCanisterFormValue => ({
   target: undefined,
   wasmModule: undefined,
   wasmInitArg: undefined,
@@ -29,6 +29,6 @@ export const useDefaultUpgradFormValue = (): ChangeCanisterFormValue => ({
 });
 
 export const useDefaultUpgradeModel = () => ({
-  modelValue: useDefaultUpgradFormValue(),
+  modelValue: useDefaultUpgradeFormValue(),
   valid: false,
 });

--- a/apps/wallet/src/core/compatibility.core.ts
+++ b/apps/wallet/src/core/compatibility.core.ts
@@ -8,25 +8,28 @@ import { isSemanticVersion } from '~/utils/helper.utils';
 import { ApiCompatibilityInfo } from '~build/types/compat.types';
 
 /**
- * Fetch the version of the station API from the canister metadata.
+ * Fetch the version of the canister from the metadata.
  *
  * This call is verified with the state tree certificate.
  */
-async function fetchStationApiVersion(agent: HttpAgent, stationId: Principal): Promise<string> {
+export async function fetchCanisterVersion(
+  agent: HttpAgent,
+  canisterId: Principal,
+): Promise<string> {
   const encoder = new TextEncoder();
   const versionPath: ArrayBuffer[] = [
     encoder.encode('canister'),
-    stationId.toUint8Array(),
+    canisterId.toUint8Array(),
     encoder.encode('metadata'),
     encoder.encode('app:version'),
   ];
 
-  const state = await agent.readState(stationId, {
+  const state = await agent.readState(canisterId, {
     paths: [versionPath],
   });
 
   const certificate = await Certificate.create({
-    canisterId: stationId,
+    canisterId,
     certificate: state.certificate,
     rootKey: agent.rootKey,
   });
@@ -123,7 +126,7 @@ export const createCompatibilityLayer = (agent: HttpAgent = icAgent.get()) => {
   return {
     redirectToURL: (url: URL) => redirectToURL(url),
     fetchCompatFile: (versionPath?: string) => fetchCompatFile(versionPath),
-    fetchStationApiVersion: (stationId: Principal) => fetchStationApiVersion(agent, stationId),
+    fetchStationApiVersion: (stationId: Principal) => fetchCanisterVersion(agent, stationId),
     async checkCompatibility(
       stationId: Principal,
       opts: { redirectIfIncompatible?: boolean } = {},

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -80,6 +80,17 @@ export default {
     request_policy_rule_builder_no_rule: 'No rule specified.',
     advanced_software_update_warning:
       'Use with caution. This is an advanced feature for updating the wallet.',
+    check_updates_btn: 'Check for updates',
+    update_recommended_latest:
+      "It's recommended to keep your software up to date to ensure the best experience.",
+    update_already_latest_version: 'You are already in the latest version.',
+    checking_for_updates: 'Checking for updates ...',
+    update_available: 'There is a new version available.',
+    update_automated_comment: {
+      summary: 'The {name} will be updated to version {version}.',
+      verify_instructions:
+        'To verify the update, open the terminal and follow the instructions bellow:',
+    },
   },
   alpha_warning: {
     version: 'This is an alpha version.',

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -39,7 +39,7 @@ export default {
       'Use with caution. The identity will be able to login as the user and perform actions on their behalf.',
     export_csv: 'Export CSV',
     params_parse_error: 'Failed to parse parameters, please try again.',
-    submit_upgrade: 'Submit upgrade',
+    software_update: 'Software Update',
     canister_upgrade_target: 'Upgrade Target',
     canister_wasm_module: 'Canister Wasm Module',
     canister_upgrade_args_input: 'Upgrade arguments (optional)',
@@ -78,6 +78,8 @@ export default {
     account_dialog_request_policy_transfer_hint:
       'The policy that needs to be approved to transfer funds.',
     request_policy_rule_builder_no_rule: 'No rule specified.',
+    advanced_software_update_warning:
+      'Use with caution. This is an advanced feature for updating the wallet.',
   },
   alpha_warning: {
     version: 'This is an alpha version.',
@@ -389,6 +391,8 @@ export default {
     summary: 'Summary',
     overriden: 'Overriden',
     metadata: 'Metadata',
+    automated: 'Automated',
+    advanced: 'Advanced',
     wasm: 'Wasm',
     arg: 'Arg',
     access: 'Access',
@@ -425,6 +429,7 @@ export default {
     requests: 'Requests',
     cancel: 'Cancel',
     checksum: 'Checksum',
+    module_checksum: 'Module Checksum',
     rejected: 'Rejected',
     edit: 'Edit',
     destination_address: 'Destination address',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -82,6 +82,17 @@ export default {
     request_policy_rule_builder_no_rule: 'Pas de critères',
     advanced_software_update_warning:
       "À utiliser avec précaution. Il s'agit d'une fonctionnalité avancée pour mettre à jour le portefeuille.",
+    check_updates_btn: 'Vérifier les mises à jour',
+    update_recommended_latest:
+      'Il est recommandé de garder votre logiciel à jour pour garantir la meilleure expérience.',
+    update_already_latest_version: 'Vous êtes déjà à la dernière version.',
+    checking_for_updates: 'Vérification des mises à jour ...',
+    update_available: 'Une nouvelle version est disponible.',
+    update_automated_comment: {
+      summary: '{name} sera mis à jour vers la version {version}.',
+      verify_instructions:
+        'Pour vérifier la mise à jour, ouvrez le terminal et suivez les instructions ci-dessous:',
+    },
   },
   alpha_warning: {
     version: 'Ceci est une version alpha.',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -40,7 +40,7 @@ export default {
       "Attention. Ce identité pourra acceder avec les permissions de l'utilisateur et prendre des actions en son nom.",
     export_csv: 'Exporter en CSV',
     params_parse_error: "Échec d'interpretation des paramètres, veuillez essayer de nouveau.",
-    submit_upgrade: 'Soumettre une mise à jour',
+    software_update: 'Mise à jour logicielle',
     canister_upgrade_target: 'Cible de mise à jour',
     canister_wasm_module: 'Wasm Module du Canister',
     canister_upgrade_args_input: 'Paramètres de la mise à jour (optionnel)',
@@ -80,6 +80,8 @@ export default {
     account_dialog_request_policy_transfer_hint:
       'La politique qui doit être approuvée pour transférer des fonds.',
     request_policy_rule_builder_no_rule: 'Pas de critères',
+    advanced_software_update_warning:
+      "À utiliser avec précaution. Il s'agit d'une fonctionnalité avancée pour mettre à jour le portefeuille.",
   },
   alpha_warning: {
     version: 'Ceci est une version alpha.',
@@ -401,6 +403,8 @@ export default {
     target: 'Cible',
     previous: 'Précédent',
     next: 'Suivant',
+    automated: 'Automatisé',
+    advanced: 'Avancé',
     back: 'Retour',
     permissions: 'Permissions',
     approval_policies: "Politiques d'approbation",
@@ -430,6 +434,7 @@ export default {
     see_all: 'Voir Tout',
     cancel: 'Annuler',
     checksum: 'Checksum',
+    module_checksum: 'Checksum du Module',
     rejected: 'Rejetté',
     edit: 'Modifier',
     destination_address: 'Adresse de destination',

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -39,7 +39,7 @@ export default {
       'Utilize com cuidado. A identidade poderá aceder à sua conta e executar ações em seu nome.',
     export_csv: 'Exportar CSV',
     params_parse_error: 'Erro ao analisar os parâmetros, por favor, tente novamente.',
-    submit_upgrade: 'Submeter atualização',
+    software_update: 'Atualização de software',
     canister_upgrade_target: 'Canister de destino',
     canister_wasm_module: 'Módulo WASM do canister',
     canister_upgrade_args_input: 'Argumentos de atualização do canister (opcional)',
@@ -79,6 +79,8 @@ export default {
     account_dialog_request_policy_transfer_hint:
       'A política que precisa ser aprovada para transferir fundos.',
     request_policy_rule_builder_no_rule: 'Nenhum critério definido.',
+    advanced_software_update_warning:
+      'Use com cuidado. Esta é uma funcionalidade avançada para atualizar a carteira.',
   },
   alpha_warning: {
     version: 'Esta é uma versão alfa.',
@@ -407,6 +409,8 @@ export default {
     approval_policies: 'Políticas de Aprovação',
     upgrader: 'Atualizador',
     resource: 'Recurso',
+    automated: 'Automatizado',
+    advanced: 'Avançado',
     submit: 'Submeter',
     save: 'Salvar',
     type: 'Tipo',
@@ -427,6 +431,7 @@ export default {
     blockchain: 'Blockchain',
     address_owner: 'Proprietário do endereço',
     checksum: 'Checksum',
+    module_checksum: 'Checksum do módulo',
     reject: 'Rejeitar',
     metadata: 'Metadados',
     none: 'Nenhum',

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -81,6 +81,17 @@ export default {
     request_policy_rule_builder_no_rule: 'Nenhum critério definido.',
     advanced_software_update_warning:
       'Use com cuidado. Esta é uma funcionalidade avançada para atualizar a carteira.',
+    check_updates_btn: 'Verificar atualizações',
+    update_recommended_latest:
+      'Recomenda-se manter o seu software atualizado para garantir a melhor experiência.',
+    update_already_latest_version: 'Você já está na última versão.',
+    checking_for_updates: 'Verificando atualizações ...',
+    update_available: 'Uma nova versão está disponível.',
+    update_automated_comment: {
+      summary: '{name} será atualizado para a versão {version}.',
+      verify_instructions:
+        'Para verificar a atualização, abra o terminal e siga as instruções abaixo:',
+    },
   },
   alpha_warning: {
     version: 'Esta é uma versão alfa.',

--- a/apps/wallet/src/services/control-panel.service.spec.ts
+++ b/apps/wallet/src/services/control-panel.service.spec.ts
@@ -1,0 +1,61 @@
+import { HttpAgent } from '@dfinity/agent';
+import { describe, expect, it, vi } from 'vitest';
+import { RegistryEntry } from '~/generated/control-panel/control_panel.did';
+import { ControlPanelService } from '~/services/control-panel.service';
+
+const mockWasmModuleEntry = (name: string, version: string): RegistryEntry => ({
+  id: '',
+  name,
+  categories: [],
+  tags: [],
+  description: 'This is a test description',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: [],
+  metadata: [],
+  value: {
+    WasmModule: {
+      dependencies: [],
+      version,
+      wasm_artifact_id: '',
+    },
+  },
+});
+
+describe('ControlPanelService', () => {
+  it('should find module of a given version', async () => {
+    const controlPanel = new ControlPanelService(new HttpAgent());
+    const firstCallEntry = mockWasmModuleEntry('test', '1.0.0');
+    const secondCallEntry = mockWasmModuleEntry('test', '1.0.1');
+
+    vi.spyOn(controlPanel, 'findRegistryEntries')
+      .mockReturnValue(Promise.resolve({ entries: [], next_offset: [], total: BigInt(0) }))
+      .mockReturnValueOnce(
+        Promise.resolve({ entries: [firstCallEntry], next_offset: [BigInt(1)], total: BigInt(2) }),
+      )
+      .mockReturnValueOnce(
+        Promise.resolve({ entries: [secondCallEntry], next_offset: [], total: BigInt(2) }),
+      );
+
+    vi.spyOn(controlPanel, 'getRegistryEntry').mockReturnValue(
+      Promise.resolve({ entry: secondCallEntry }),
+    );
+
+    const entry = await controlPanel.findModuleVersionRegistryEntry('test', '1.0.1');
+
+    expect(controlPanel.findRegistryEntries).toHaveBeenCalledTimes(2);
+    expect(controlPanel.getRegistryEntry).toHaveBeenCalledTimes(1);
+    expect(entry).toEqual(mockWasmModuleEntry('test', '1.0.1'));
+  });
+
+  it('should return null if module version is not found', async () => {
+    const controlPanel = new ControlPanelService(new HttpAgent());
+
+    vi.spyOn(controlPanel, 'findRegistryEntries').mockReturnValue(
+      Promise.resolve({ entries: [], next_offset: [], total: BigInt(0) }),
+    );
+
+    const entry = await controlPanel.findModuleVersionRegistryEntry('test', '1.0.1');
+
+    expect(entry).toBeNull();
+  });
+});

--- a/apps/wallet/src/services/control-panel.service.ts
+++ b/apps/wallet/src/services/control-panel.service.ts
@@ -5,13 +5,21 @@ import { idlFactory } from '~/generated/control-panel';
 import {
   CanDeployStationResponse,
   DeployStationInput,
+  GetArtifactInput,
+  GetArtifactResult,
+  GetRegistryEntryInput,
+  GetRegistryEntryResult,
   ListUserStationsInput,
   ManageUserStationsInput,
   RegisterUserInput,
+  RegistryEntry,
+  SearchRegistryInput,
+  SearchRegistryResult,
   User,
   UserStation,
   _SERVICE,
 } from '~/generated/control-panel/control_panel.did';
+import { ExtractOk } from '~/types/helper.types';
 import { transformIdlWithOnlyVerifiedCalls, variantIs } from '~/utils/helper.utils';
 
 export class ControlPanelService {
@@ -113,6 +121,103 @@ export class ControlPanelService {
   async canDeployStation(verifiedCall = false): Promise<CanDeployStationResponse> {
     const actor = verifiedCall ? this.verified_actor : this.actor;
     const result = await actor.can_deploy_station();
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
+  }
+
+  async findNextModuleVersion(
+    input: {
+      name: string;
+      currentVersion: string;
+    },
+    verifiedCall = false,
+  ): Promise<RegistryEntry | null> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.next_wasm_module_version({
+      name: input.name,
+      current_version: input.currentVersion,
+    });
+
+    if (variantIs(result, 'Err')) {
+      switch (result.Err?.code) {
+        case 'WASM_MODULE_NOT_FOUND':
+          // If the module is not found then there is no next version.
+          return null;
+        default:
+          throw result.Err;
+      }
+    }
+
+    return result.Ok.entry?.[0] ? result.Ok.entry[0] : null;
+  }
+
+  async findRegistryEntries(
+    input: SearchRegistryInput,
+    verifiedCall = false,
+  ): Promise<ExtractOk<SearchRegistryResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.search_registry(input);
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
+  }
+
+  async getRegistryEntry(
+    input: GetRegistryEntryInput,
+    verifiedCall = false,
+  ): Promise<ExtractOk<GetRegistryEntryResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.get_registry_entry(input);
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
+  }
+
+  async findModuleVersionRegistryEntry(
+    name: string,
+    version: string,
+  ): Promise<RegistryEntry | null> {
+    let next_offset: bigint | null = BigInt(0);
+    do {
+      const result = await this.findRegistryEntries({
+        filter_by: [{ Name: name }],
+        pagination: [{ offset: [next_offset!], limit: [100] }],
+        sort_by: [{ Version: { Desc: null } }],
+      });
+
+      if (result.entries.length === 0) {
+        return null;
+      }
+
+      for (const entry of result.entries) {
+        if (variantIs(entry.value, 'WasmModule') && entry.value.WasmModule.version === version) {
+          // If the version is found we fetch it again with an update call to ensure we get verified data.
+          return (await this.getRegistryEntry({ id: entry.id }, true)).entry;
+        }
+      }
+
+      next_offset = result.next_offset?.[0] ? result.next_offset[0] : null;
+    } while (next_offset !== null);
+
+    return null;
+  }
+
+  async getArtifact(
+    input: GetArtifactInput,
+    verifiedCall = false,
+  ): Promise<ExtractOk<GetArtifactResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.get_artifact(input);
 
     if (variantIs(result, 'Err')) {
       throw result.Err;

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -794,11 +794,14 @@ export class StationService {
     return result.Ok.request;
   }
 
-  async changeCanister(input: ChangeCanisterOperationInput): Promise<Request> {
+  async changeCanister(
+    input: ChangeCanisterOperationInput,
+    opts: { comment?: string } = {},
+  ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
       title: [],
-      summary: [],
+      summary: opts.comment ? [opts.comment] : [],
       operation: { ChangeCanister: input },
     });
 

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -51,6 +51,7 @@ import {
   RemoveUserGroupOperationInput,
   Request,
   SubmitRequestApprovalInput,
+  SystemInfoResult,
   Transfer,
   TransferListItem,
   TransferOperationInput,
@@ -359,6 +360,17 @@ export class StationService {
     }
 
     return result.Ok.capabilities;
+  }
+
+  async systemInfo(verifiedCall = false): Promise<ExtractOk<SystemInfoResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.system_info();
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
   }
 
   async listNotifications(

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -382,7 +382,10 @@ export const useStationStore = defineStore('station', {
       return upgraderVersion;
     },
     async checkVersionUpdates(): Promise<void> {
-      if (!this.privileges.some(privilege => variantIs(privilege, 'ChangeCanister'))) {
+      if (
+        !this.privileges.some(privilege => variantIs(privilege, 'ChangeCanister')) ||
+        this.versionManagement.loading
+      ) {
         // if the user does not have the privilege to change the canister, we do not need to check for updates
         return;
       }

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -24,7 +24,6 @@ import { LoadableItem } from '~/types/helper.types';
 import { computedStationName, isApiError, popRedirectToLocation } from '~/utils/app.utils';
 import { arrayBatchMaker, removeBasePathFromPathname, variantIs } from '~/utils/helper.utils';
 import { accountsWorker, startWorkers, stopWorkers } from '~/workers';
-import { compareSemanticVersions } from '~build/utils/sort.utils';
 
 export enum ConnectionStatus {
   Disconnected = 'disconnected',
@@ -419,16 +418,7 @@ export const useStationStore = defineStore('station', {
         this.versionManagement.nextStationVersion = registryEntry.value.WasmModule.version;
         for (const dependency of registryEntry.value.WasmModule.dependencies) {
           if (dependency.name === '@orbit/upgrader' && dependency.version !== upgraderVersion) {
-            // if the current upgrader version is lower than the dependency version, we need to
-            // upgrade the upgrader first
-            const sortedVersions = [upgraderVersion, dependency.version].sort(
-              compareSemanticVersions('newest'),
-            );
-
-            if (sortedVersions[0] !== upgraderVersion) {
-              this.versionManagement.nextUpgraderVersion = dependency.version;
-              break;
-            }
+            this.versionManagement.nextUpgraderVersion = dependency.version;
             break;
           }
         }

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -1,9 +1,10 @@
 import { Principal } from '@dfinity/principal';
 import { defineStore } from 'pinia';
 import { appInitConfig } from '~/configs/init.config';
-import { createCompatibilityLayer } from '~/core/compatibility.core';
+import { createCompatibilityLayer, fetchCanisterVersion } from '~/core/compatibility.core';
 import { STATION_ID_QUERY_PARAM } from '~/core/constants.core';
 import { InvalidStationError, UnregisteredUserError } from '~/core/errors.core';
+import { icAgent } from '~/core/ic-agent.core';
 import { logger } from '~/core/logger.core';
 import {
   Asset,
@@ -21,8 +22,9 @@ import { useAppStore } from '~/stores/app.store';
 import { BlockchainStandard, BlockchainType } from '~/types/chain.types';
 import { LoadableItem } from '~/types/helper.types';
 import { computedStationName, isApiError, popRedirectToLocation } from '~/utils/app.utils';
-import { arrayBatchMaker, removeBasePathFromPathname } from '~/utils/helper.utils';
+import { arrayBatchMaker, removeBasePathFromPathname, variantIs } from '~/utils/helper.utils';
 import { accountsWorker, startWorkers, stopWorkers } from '~/workers';
+import { compareSemanticVersions } from '~build/utils/sort.utils';
 
 export enum ConnectionStatus {
   Disconnected = 'disconnected',
@@ -53,6 +55,13 @@ export interface StationStoreState {
   notifications: {
     loading: boolean;
     items: LoadableItem<Notification>[];
+  };
+  versionManagement: {
+    loading: boolean;
+    stationVersion?: string;
+    upgraderVersion?: string;
+    nextStationVersion?: string;
+    nextUpgraderVersion?: string;
   };
 }
 
@@ -116,6 +125,13 @@ const initialStoreState = (): StationStoreState => {
       loading: false,
       items: [],
     },
+    versionManagement: {
+      loading: false,
+      nextStationVersion: undefined,
+      nextUpgraderVersion: undefined,
+      stationVersion: undefined,
+      upgraderVersion: undefined,
+    },
   };
 };
 
@@ -155,6 +171,7 @@ export const useStationStore = defineStore('station', {
       this.notifications = initialState.notifications;
       this.user = initialState.user;
       this.privileges = initialState.privileges;
+      this.versionManagement = initialState.versionManagement;
 
       stopWorkers();
     },
@@ -276,6 +293,9 @@ export const useStationStore = defineStore('station', {
         this.canisterId = stationId.toText();
         this.loading = false;
         app.disableBackgroundPolling = false;
+
+        // async check for version updates after the station is connected
+        this.checkVersionUpdates();
       }
 
       return this.connectionStatus;
@@ -346,6 +366,77 @@ export const useStationStore = defineStore('station', {
           accountIds,
         },
       });
+    },
+    async loadStationVersion(): Promise<string> {
+      const stationVersion = await fetchCanisterVersion(icAgent.get(), this.stationId);
+
+      this.versionManagement.stationVersion = stationVersion;
+
+      return stationVersion;
+    },
+    async loadUpgraderVersion(): Promise<string> {
+      const { system } = await services().station.systemInfo();
+      const upgraderVersion = await fetchCanisterVersion(icAgent.get(), system.upgrader_id);
+
+      this.versionManagement.upgraderVersion = upgraderVersion;
+
+      return upgraderVersion;
+    },
+    async checkVersionUpdates(): Promise<void> {
+      if (!this.privileges.some(privilege => variantIs(privilege, 'ChangeCanister'))) {
+        // if the user does not have the privilege to change the canister, we do not need to check for updates
+        return;
+      }
+
+      try {
+        const controlPanel = services().controlPanel;
+        this.versionManagement = {
+          ...initialStoreState().versionManagement,
+          loading: true,
+        };
+
+        const [stationVersion, upgraderVersion] = await Promise.all([
+          this.loadStationVersion(),
+          this.loadUpgraderVersion(),
+        ]);
+
+        const registryEntry = await controlPanel.findNextModuleVersion({
+          name: '@orbit/station',
+          currentVersion: stationVersion,
+        });
+
+        if (!registryEntry) {
+          this.versionManagement.nextStationVersion = undefined;
+          this.versionManagement.nextUpgraderVersion = undefined;
+
+          return;
+        }
+
+        if (!variantIs(registryEntry.value, 'WasmModule')) {
+          throw new Error(`Invalid next version response, expected WasmModule`);
+        }
+
+        this.versionManagement.nextStationVersion = registryEntry.value.WasmModule.version;
+        for (const dependency of registryEntry.value.WasmModule.dependencies) {
+          if (dependency.name === '@orbit/upgrader' && dependency.version !== upgraderVersion) {
+            // if the current upgrader version is lower than the dependency version, we need to
+            // upgrade the upgrader first
+            const sortedVersions = [upgraderVersion, dependency.version].sort(
+              compareSemanticVersions('newest'),
+            );
+
+            if (sortedVersions[0] !== upgraderVersion) {
+              this.versionManagement.nextUpgraderVersion = dependency.version;
+              break;
+            }
+            break;
+          }
+        }
+      } catch (err) {
+        logger.error(`Failed to check version updates`, { err });
+      } finally {
+        this.versionManagement.loading = false;
+      }
     },
   },
 });

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -383,10 +383,11 @@ export const useStationStore = defineStore('station', {
     },
     async checkVersionUpdates(): Promise<void> {
       if (
+        // if the user does not have the privilege to change the canister, we do not need to check for updates
         !this.privileges.some(privilege => variantIs(privilege, 'ChangeCanister')) ||
+        // disables checking for updates if it's already ongoing
         this.versionManagement.loading
       ) {
-        // if the user does not have the privilege to change the canister, we do not need to check for updates
         return;
       }
 

--- a/apps/wallet/src/utils/helper.utils.spec.ts
+++ b/apps/wallet/src/utils/helper.utils.spec.ts
@@ -3,6 +3,7 @@ import {
   isSemanticVersion,
   removeBasePathFromPathname,
   throttle,
+  toArrayBuffer,
   transformIdlWithOnlyVerifiedCalls,
   variantIs,
 } from './helper.utils';
@@ -138,6 +139,26 @@ describe('Url utils', () => {
       const basePath = '';
 
       expect(removeBasePathFromPathname(pathname, basePath)).toBe('/pathname');
+    });
+  });
+});
+
+describe('ArrayBuffer utils', () => {
+  describe('toArrayBuffer', () => {
+    it('converts a Uint8Array to an ArrayBuffer', () => {
+      const input = new Uint8Array([1, 2, 3, 4, 5]);
+      const output = toArrayBuffer(input);
+
+      expect(output).toBeInstanceOf(ArrayBuffer);
+      expect(new Uint8Array(output)).toEqual(input);
+    });
+
+    it('converts a number[] to an ArrayBuffer', () => {
+      const input = [1, 2, 3, 4, 5];
+      const output = toArrayBuffer(input);
+
+      expect(output).toBeInstanceOf(ArrayBuffer);
+      expect(new Uint8Array(output)).toEqual(new Uint8Array(input));
     });
   });
 });

--- a/apps/wallet/src/utils/helper.utils.ts
+++ b/apps/wallet/src/utils/helper.utils.ts
@@ -231,15 +231,5 @@ export const removeBasePathFromPathname = (pathname: string, basePath: string): 
 };
 
 export const toArrayBuffer = (input: Uint8Array | number[]): ArrayBuffer => {
-  let uint8Array;
-
-  if (input instanceof Uint8Array) {
-    uint8Array = input;
-  } else if (Array.isArray(input)) {
-    uint8Array = new Uint8Array(input);
-  } else {
-    throw new TypeError('Input must be a number[] or Uint8Array');
-  }
-
-  return uint8Array.buffer;
+  return input instanceof Uint8Array ? input.buffer : new Uint8Array(input).buffer;
 };

--- a/apps/wallet/src/utils/helper.utils.ts
+++ b/apps/wallet/src/utils/helper.utils.ts
@@ -229,3 +229,17 @@ export const removeBasePathFromPathname = (pathname: string, basePath: string): 
 
   return !updatedPath.startsWith('/') ? `/${updatedPath}` : updatedPath;
 };
+
+export const toArrayBuffer = (input: Uint8Array | number[]): ArrayBuffer => {
+  let uint8Array;
+
+  if (input instanceof Uint8Array) {
+    uint8Array = input;
+  } else if (Array.isArray(input)) {
+    uint8Array = new Uint8Array(input);
+  } else {
+    throw new TypeError('Input must be a number[] or Uint8Array');
+  }
+
+  return uint8Array.buffer;
+};


### PR DESCRIPTION
Introduces a simpler way to keep up to date with station and upgrader changes by using the control panel registry.

**Relevant changes:**

- Split the change canister component into 2 modes advanced and automated
- Advanced mode allows the user to upload any wasm with the respect optional init args
- Automated mode checks for the next version against the control panel registry
- The station store upon connecting to a station and if the user has the `ChangeCanister` permission will check if a new version of the station/upgrader is available
  - This early check will be used in a follow up PR to prompt the user to update in the toolbar of the app

**Automated mode:**  
![Screenshot 2024-07-26 at 11 58 45](https://github.com/user-attachments/assets/8ee1b728-4d22-4098-8aa6-f935e0998e57)

**Advanced mode:**
<img width="812" alt="Screenshot 2024-07-25 at 11 04 26" src="https://github.com/user-attachments/assets/a62b64a5-eabd-4a40-b6ba-b82bd1099a08">
