### PR TITLE
feat(wallet): remove unsafe-eval csp by bumping the agent

### DIFF
--- a/apps/wallet/build/main.build.ts
+++ b/apps/wallet/build/main.build.ts
@@ -10,11 +10,11 @@ import {
   STATION_API_VERSION,
   SUPPORTED_LOCALES,
 } from './core/configs.core';
+import { withCanisterIds } from './plugins/with-canister-ids';
 import { withApiCompatibilityFile } from './plugins/with-compatibility-file.plugin';
 import { withIcAssetsFile } from './plugins/with-ic-assets.plugin';
 import { withVersionedEntrypoint } from './plugins/with-versioned-entrypoint.plugin';
 import { getCommitHash } from './utils/git.utils';
-import { withCanisterIds } from './plugins/with-canister-ids';
 
 // https://vitejs.dev/config/
 export default defineConfig(_ => {
@@ -136,6 +136,13 @@ export default defineConfig(_ => {
       'import.meta.env.APP_BUILD_MODE': JSON.stringify(mode),
       'import.meta.env.APP_BUILD_VERSION': JSON.stringify(process.env.npm_package_version),
       'import.meta.env.APP_BUILD_HASH': JSON.stringify(commitHash),
+      // This enables the JIT compilation for the vue-i18n plugin as specified in their documentation
+      // https://vue-i18n.intlify.dev/guide/advanced/optimization#jit-compilation, it is required to skip
+      // the compilation of the locales at runtime which needs unsafe-eval to be enabled in the CSP.
+      //
+      // Version 10 which is still in beta has this feature enabled by default, once it is stable we can bump and
+      // remove this define.
+      __INTLIFY_JIT_COMPILATION__: true,
     },
     resolve: {
       alias: {

--- a/apps/wallet/build/plugins/with-ic-assets.plugin.ts
+++ b/apps/wallet/build/plugins/with-ic-assets.plugin.ts
@@ -10,7 +10,7 @@ const getContentSecurityPolicy = (
 ): string => {
   const csp: Record<string, string[]> = {
     'default-src': ["'none'"],
-    'script-src': ["'self'", "'unsafe-eval'"],
+    'script-src': ["'self'"],
     'connect-src': ["'self'", 'https://icp-api.io', 'https://ic0.app', 'https://icp0.io'],
     'img-src': ["'self'", 'data:'],
     'font-src': ["'self'"],

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -24,11 +24,11 @@
     "format": "concurrently -n prettier,eslint -c auto \"prettier --ignore-path ../../.prettierignore --write .\" \"eslint --ext .js,.vue,.ts,.cjs --fix .\""
   },
   "dependencies": {
-    "@dfinity/agent": "1.3.0",
-    "@dfinity/auth-client": "1.3.0",
-    "@dfinity/candid": "1.3.0",
-    "@dfinity/identity": "1.3.0",
-    "@dfinity/principal": "1.3.0",
+    "@dfinity/agent": "1.4.0",
+    "@dfinity/auth-client": "1.4.0",
+    "@dfinity/candid": "1.4.0",
+    "@dfinity/identity": "1.4.0",
+    "@dfinity/principal": "1.4.0",
     "@mdi/font": "7.4.47",
     "@mdi/js": "7.4.47",
     "buffer": "6.0.3",

--- a/apps/wallet/src/core/compatibility.core.ts
+++ b/apps/wallet/src/core/compatibility.core.ts
@@ -1,4 +1,4 @@
-import { Certificate, HttpAgent } from '@dfinity/agent';
+import { Certificate, HttpAgent, LookupStatus } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { appInitConfig } from '~/configs/init.config';
 import { icAgent } from '~/core/ic-agent.core';
@@ -33,12 +33,16 @@ async function fetchStationApiVersion(agent: HttpAgent, stationId: Principal): P
 
   const version = certificate.lookup(versionPath);
 
-  if (!version) {
+  if (version.status !== LookupStatus.Found) {
     throw new Error('Version not found');
   }
 
+  if (!(version.value instanceof ArrayBuffer)) {
+    throw new Error('Version value is not an ArrayBuffer');
+  }
+
   const decoder = new TextDecoder();
-  const decodedVersion = decoder.decode(version);
+  const decodedVersion = decoder.decode(version.value);
 
   if (!isSemanticVersion(decodedVersion)) {
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,20 +69,20 @@ importers:
   apps/wallet:
     dependencies:
       '@dfinity/agent':
-        specifier: 1.3.0
-        version: 1.3.0(@dfinity/candid@1.3.0)(@dfinity/principal@1.3.0)
+        specifier: 1.4.0
+        version: 1.4.0(@dfinity/candid@1.4.0)(@dfinity/principal@1.4.0)
       '@dfinity/auth-client':
-        specifier: 1.3.0
-        version: 1.3.0(@dfinity/agent@1.3.0)(@dfinity/identity@1.3.0)(@dfinity/principal@1.3.0)
+        specifier: 1.4.0
+        version: 1.4.0(@dfinity/agent@1.4.0)(@dfinity/identity@1.4.0)(@dfinity/principal@1.4.0)
       '@dfinity/candid':
-        specifier: 1.3.0
-        version: 1.3.0(@dfinity/principal@1.3.0)
+        specifier: 1.4.0
+        version: 1.4.0(@dfinity/principal@1.4.0)
       '@dfinity/identity':
-        specifier: 1.3.0
-        version: 1.3.0(@dfinity/agent@1.3.0)(@dfinity/principal@1.3.0)(@peculiar/webcrypto@1.4.3)
+        specifier: 1.4.0
+        version: 1.4.0(@dfinity/agent@1.4.0)(@dfinity/principal@1.4.0)(@peculiar/webcrypto@1.4.3)
       '@dfinity/principal':
-        specifier: 1.3.0
-        version: 1.3.0
+        specifier: 1.4.0
+        version: 1.4.0
       '@mdi/font':
         specifier: 7.4.47
         version: 7.4.47
@@ -1448,22 +1448,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@dfinity/agent@1.3.0(@dfinity/candid@1.3.0)(@dfinity/principal@1.3.0):
-    resolution: {integrity: sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==}
-    peerDependencies:
-      '@dfinity/candid': ^1.3.0
-      '@dfinity/principal': ^1.3.0
-    dependencies:
-      '@dfinity/candid': 1.3.0(@dfinity/principal@1.3.0)
-      '@dfinity/principal': 1.3.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      base64-arraybuffer: 0.2.0
-      borc: 2.1.2
-      buffer: 6.0.3
-      simple-cbor: 0.4.1
-    dev: false
-
   /@dfinity/agent@1.4.0(@dfinity/candid@1.4.0)(@dfinity/principal@1.4.0):
     resolution: {integrity: sha512-/zgGajZpxtbu+kLXtFx2e9V2+HbMUjrtGWx9ZEwtVwhVxKgVi/2kGQpFRPEDFJ461V7wdTwCig4OkMxVU4shTw==}
     peerDependencies:
@@ -1478,27 +1462,18 @@ packages:
       borc: 2.1.2
       buffer: 6.0.3
       simple-cbor: 0.4.1
-    dev: true
 
-  /@dfinity/auth-client@1.3.0(@dfinity/agent@1.3.0)(@dfinity/identity@1.3.0)(@dfinity/principal@1.3.0):
-    resolution: {integrity: sha512-/1Xn+acHckLh9GlImBRsIEjej0nbD+B0hsoOM8gyimrRrcoxqlSwn+rzjlR2fbVf++rTRRwsQgShG/gfCEXJig==}
+  /@dfinity/auth-client@1.4.0(@dfinity/agent@1.4.0)(@dfinity/identity@1.4.0)(@dfinity/principal@1.4.0):
+    resolution: {integrity: sha512-9ImeOAw61SQvHJ+w4RHIuKKUL2xAQDLoce+JhmH3DbJuVvNbZIM5xMW8gHTZVlXaMw3Vhip+a1DPJIGy95r9pA==}
     peerDependencies:
-      '@dfinity/agent': ^1.3.0
-      '@dfinity/identity': ^1.3.0
-      '@dfinity/principal': ^1.3.0
+      '@dfinity/agent': ^1.4.0
+      '@dfinity/identity': ^1.4.0
+      '@dfinity/principal': ^1.4.0
     dependencies:
-      '@dfinity/agent': 1.3.0(@dfinity/candid@1.3.0)(@dfinity/principal@1.3.0)
-      '@dfinity/identity': 1.3.0(@dfinity/agent@1.3.0)(@dfinity/principal@1.3.0)(@peculiar/webcrypto@1.4.3)
-      '@dfinity/principal': 1.3.0
+      '@dfinity/agent': 1.4.0(@dfinity/candid@1.4.0)(@dfinity/principal@1.4.0)
+      '@dfinity/identity': 1.4.0(@dfinity/agent@1.4.0)(@dfinity/principal@1.4.0)(@peculiar/webcrypto@1.4.3)
+      '@dfinity/principal': 1.4.0
       idb: 7.1.1
-    dev: false
-
-  /@dfinity/candid@1.3.0(@dfinity/principal@1.3.0):
-    resolution: {integrity: sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==}
-    peerDependencies:
-      '@dfinity/principal': ^1.3.0
-    dependencies:
-      '@dfinity/principal': 1.3.0
     dev: false
 
   /@dfinity/candid@1.4.0(@dfinity/principal@1.4.0):
@@ -1507,22 +1482,6 @@ packages:
       '@dfinity/principal': ^1.4.0
     dependencies:
       '@dfinity/principal': 1.4.0
-    dev: true
-
-  /@dfinity/identity@1.3.0(@dfinity/agent@1.3.0)(@dfinity/principal@1.3.0)(@peculiar/webcrypto@1.4.3):
-    resolution: {integrity: sha512-DAqb+dYV20wqJBfMv6RFEyDNPg8FSUVPjK3kXP/gXEDM+w2Viq4/oQdMqm0lWTK8t4+TuxvUS74ULAS7wCYuVQ==}
-    peerDependencies:
-      '@dfinity/agent': ^1.3.0
-      '@dfinity/principal': ^1.3.0
-      '@peculiar/webcrypto': ^1.4.0
-    dependencies:
-      '@dfinity/agent': 1.3.0(@dfinity/candid@1.3.0)(@dfinity/principal@1.3.0)
-      '@dfinity/principal': 1.3.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@peculiar/webcrypto': 1.4.3
-      borc: 2.1.2
-    dev: false
 
   /@dfinity/identity@1.4.0(@dfinity/agent@1.4.0)(@dfinity/principal@1.4.0)(@peculiar/webcrypto@1.4.3):
     resolution: {integrity: sha512-4WmMsQSuzfWXmm4s+0FYGbFiQcMGE88Ztg6yFq7aTMtRWuAjhz66Dy1+jRCrXxsoxvDdUvPzsyjkOSpr1AuUYQ==}
@@ -1537,19 +1496,11 @@ packages:
       '@noble/hashes': 1.4.0
       '@peculiar/webcrypto': 1.4.3
       borc: 2.1.2
-    dev: true
-
-  /@dfinity/principal@1.3.0:
-    resolution: {integrity: sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==}
-    dependencies:
-      '@noble/hashes': 1.4.0
-    dev: false
 
   /@dfinity/principal@1.4.0:
     resolution: {integrity: sha512-SuTBVlc71ub89ji0WN5/T100zUG2uIMn5x4+We4vS4nJ0R3/Xt89XJsHepjd5SQTSQPOvP7eQ+S8cQKWRz/RkA==}
     dependencies:
       '@noble/hashes': 1.4.0
-    dev: true
 
   /@esbuild/aix-ppc64@0.20.2:
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}


### PR DESCRIPTION
Removes the need for `unsafe-eval` in the CSP headers.
