### PR TITLE
feat(station): add external canister management

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -650,6 +650,8 @@ type ConfigureExternalCanisterSettingsInput = record {
   permissions : opt ExternalCanisterPermissionsInput;
   // The request policies for the canister.
   request_policies : opt ExternalCanisterRequestPoliciesInput;
+  // The state of the external canister.
+  state : opt ExternalCanisterState;
 };
 
 // The input type for configuring an external canister in the station.
@@ -672,7 +674,7 @@ type ConfigureExternalCanisterOperationInput = record {
   // The canister to update.
   canister_id : principal;
   // The kind of operation to perform.
-  operation : ConfigureExternalCanisterOperationKind;
+  kind : ConfigureExternalCanisterOperationKind;
 };
 
 type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -665,7 +665,7 @@ type ConfigureExternalCanisterOperationKind = variant {
   // Caution: This operation is irreversible.
   Delete;
   // The Internet Computer canister settings to configure for the external canister.
-  NativeSettings : DefiniteCanisterSettings;
+  NativeSettings : DefiniteCanisterSettingsInput;
 };
 
 type ConfigureExternalCanisterOperationInput = record {
@@ -679,6 +679,7 @@ type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInpu
 
 type CreateExternalCanisterOperation = record {
   canister_id : opt principal;
+  input : CreateExternalCanisterOperationInput;
 };
 
 type CanisterMethod = record {
@@ -2148,6 +2149,14 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
 };
 
+type DefiniteCanisterSettingsInput = record {
+  controllers : opt vec principal;
+  compute_allocation : opt nat;
+  memory_allocation : opt nat;
+  freezing_threshold : opt nat;
+  reserved_cycles_limit : opt nat;
+};
+
 type CanisterStatusResponse = record {
   status : variant { running; stopping; stopped };
   settings : DefiniteCanisterSettings;
@@ -2227,6 +2236,8 @@ type ExternalCanister = record {
   description : opt text;
   // The labels that can be used to categorize the canister.
   labels : vec text;
+  // The current state of the record (e.g. `Active`).
+  state : ExternalCanisterState;
   // The permissions that are set for who can interact with the canister.
   permissions : ExternalCanisterPermissions;
   // The request policies that are associated with the canister.
@@ -2235,6 +2246,14 @@ type ExternalCanister = record {
   created_at : TimestampRFC3339;
   // The time at which the canister was last modified, if available.
   modified_at : opt TimestampRFC3339;
+};
+
+// The state of the external canister.
+type ExternalCanisterState = variant {
+  // The record is active and can be interacted with.
+  Active;
+  // The record is archived and can no longer be interacted with.
+  Archived;
 };
 
 // Input type for getting a external canister.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -211,8 +211,8 @@ export type ChangeExternalCanisterResourceTarget = { 'Any' : null } |
   { 'Canister' : Principal };
 export type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
 export interface ConfigureExternalCanisterOperationInput {
+  'kind' : ConfigureExternalCanisterOperationKind,
   'canister_id' : Principal,
-  'operation' : ConfigureExternalCanisterOperationKind,
 }
 export type ConfigureExternalCanisterOperationKind = { 'SoftDelete' : null } |
   { 'Settings' : ConfigureExternalCanisterSettingsInput } |
@@ -225,6 +225,7 @@ export interface ConfigureExternalCanisterSettingsInput {
   'labels' : [] | [Array<string>],
   'description' : [] | [string],
   'request_policies' : [] | [ExternalCanisterRequestPoliciesInput],
+  'state' : [] | [ExternalCanisterState],
 }
 export interface CreateExternalCanisterOperation {
   'canister_id' : [] | [Principal],

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -217,7 +217,7 @@ export interface ConfigureExternalCanisterOperationInput {
 export type ConfigureExternalCanisterOperationKind = { 'SoftDelete' : null } |
   { 'Settings' : ConfigureExternalCanisterSettingsInput } |
   { 'Delete' : null } |
-  { 'NativeSettings' : DefiniteCanisterSettings } |
+  { 'NativeSettings' : DefiniteCanisterSettingsInput } |
   { 'TopUp' : bigint };
 export interface ConfigureExternalCanisterSettingsInput {
   'permissions' : [] | [ExternalCanisterPermissionsInput],
@@ -228,6 +228,7 @@ export interface ConfigureExternalCanisterSettingsInput {
 }
 export interface CreateExternalCanisterOperation {
   'canister_id' : [] | [Principal],
+  'input' : CreateExternalCanisterOperationInput,
 }
 export interface CreateExternalCanisterOperationInput {
   'permissions' : ExternalCanisterPermissionsInput,
@@ -268,6 +269,13 @@ export interface DefiniteCanisterSettings {
   'reserved_cycles_limit' : bigint,
   'memory_allocation' : bigint,
   'compute_allocation' : bigint,
+}
+export interface DefiniteCanisterSettingsInput {
+  'freezing_threshold' : [] | [bigint],
+  'controllers' : [] | [Array<Principal>],
+  'reserved_cycles_limit' : [] | [bigint],
+  'memory_allocation' : [] | [bigint],
+  'compute_allocation' : [] | [bigint],
 }
 export interface DisasterRecovery {
   'user_group_name' : [] | [string],
@@ -372,6 +380,7 @@ export interface ExternalCanister {
   'description' : [] | [string],
   'created_at' : TimestampRFC3339,
   'request_policies' : ExternalCanisterRequestPolicies,
+  'state' : ExternalCanisterState,
 }
 export interface ExternalCanisterCallPermission {
   'execution_method' : string,
@@ -410,6 +419,8 @@ export type ExternalCanisterResourceAction = {
   { 'Read' : ReadExternalCanisterResourceTarget } |
   { 'Create' : CreateExternalCanisterResourceTarget } |
   { 'Change' : ChangeExternalCanisterResourceTarget };
+export type ExternalCanisterState = { 'Active' : null } |
+  { 'Archived' : null };
 export interface FetchAccountBalancesInput { 'account_ids' : Array<UUID> }
 export type FetchAccountBalancesResult = {
     'Ok' : { 'balances' : Array<AccountBalance> }

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -245,11 +245,18 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'request_policies' : IDL.Opt(ExternalCanisterRequestPoliciesInput),
   });
+  const DefiniteCanisterSettingsInput = IDL.Record({
+    'freezing_threshold' : IDL.Opt(IDL.Nat),
+    'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
+    'memory_allocation' : IDL.Opt(IDL.Nat),
+    'compute_allocation' : IDL.Opt(IDL.Nat),
+  });
   const ConfigureExternalCanisterOperationKind = IDL.Variant({
     'SoftDelete' : IDL.Null,
     'Settings' : ConfigureExternalCanisterSettingsInput,
     'Delete' : IDL.Null,
-    'NativeSettings' : DefiniteCanisterSettings,
+    'NativeSettings' : DefiniteCanisterSettingsInput,
     'TopUp' : IDL.Nat64,
   });
   const ConfigureExternalCanisterOperationInput = IDL.Record({
@@ -514,6 +521,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const CreateExternalCanisterOperation = IDL.Record({
     'canister_id' : IDL.Opt(IDL.Principal),
+    'input' : CreateExternalCanisterOperationInput,
   });
   const EditAddressBookEntryOperation = IDL.Record({
     'input' : EditAddressBookEntryOperationInput,
@@ -742,6 +750,10 @@ export const idlFactory = ({ IDL }) => {
     'can_change' : IDL.Bool,
     'can_call' : IDL.Vec(ExternalCanisterCallerMethodsPrivileges),
   });
+  const ExternalCanisterState = IDL.Variant({
+    'Active' : IDL.Null,
+    'Archived' : IDL.Null,
+  });
   const ExternalCanister = IDL.Record({
     'id' : UUID,
     'permissions' : ExternalCanisterPermissions,
@@ -752,6 +764,7 @@ export const idlFactory = ({ IDL }) => {
     'description' : IDL.Opt(IDL.Text),
     'created_at' : TimestampRFC3339,
     'request_policies' : ExternalCanisterRequestPolicies,
+    'state' : ExternalCanisterState,
   });
   const GetExternalCanisterResult = IDL.Variant({
     'Ok' : IDL.Record({

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -238,12 +238,17 @@ export const idlFactory = ({ IDL }) => {
     'change' : IDL.Opt(RequestPolicyRule),
   });
   const ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
+  const ExternalCanisterState = IDL.Variant({
+    'Active' : IDL.Null,
+    'Archived' : IDL.Null,
+  });
   const ConfigureExternalCanisterSettingsInput = IDL.Record({
     'permissions' : IDL.Opt(ExternalCanisterPermissionsInput),
     'name' : IDL.Opt(IDL.Text),
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),
     'description' : IDL.Opt(IDL.Text),
     'request_policies' : IDL.Opt(ExternalCanisterRequestPoliciesInput),
+    'state' : IDL.Opt(ExternalCanisterState),
   });
   const DefiniteCanisterSettingsInput = IDL.Record({
     'freezing_threshold' : IDL.Opt(IDL.Nat),
@@ -260,8 +265,8 @@ export const idlFactory = ({ IDL }) => {
     'TopUp' : IDL.Nat64,
   });
   const ConfigureExternalCanisterOperationInput = IDL.Record({
+    'kind' : ConfigureExternalCanisterOperationKind,
     'canister_id' : IDL.Principal,
-    'operation' : ConfigureExternalCanisterOperationKind,
   });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,
@@ -749,10 +754,6 @@ export const idlFactory = ({ IDL }) => {
     'id' : UUID,
     'can_change' : IDL.Bool,
     'can_call' : IDL.Vec(ExternalCanisterCallerMethodsPrivileges),
-  });
-  const ExternalCanisterState = IDL.Variant({
-    'Active' : IDL.Null,
-    'Archived' : IDL.Null,
   });
   const ExternalCanister = IDL.Record({
     'id' : UUID,

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -650,6 +650,8 @@ type ConfigureExternalCanisterSettingsInput = record {
   permissions : opt ExternalCanisterPermissionsInput;
   // The request policies for the canister.
   request_policies : opt ExternalCanisterRequestPoliciesInput;
+  // The state of the external canister.
+  state : opt ExternalCanisterState;
 };
 
 // The input type for configuring an external canister in the station.
@@ -672,7 +674,7 @@ type ConfigureExternalCanisterOperationInput = record {
   // The canister to update.
   canister_id : principal;
   // The kind of operation to perform.
-  operation : ConfigureExternalCanisterOperationKind;
+  kind : ConfigureExternalCanisterOperationKind;
 };
 
 type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -665,7 +665,7 @@ type ConfigureExternalCanisterOperationKind = variant {
   // Caution: This operation is irreversible.
   Delete;
   // The Internet Computer canister settings to configure for the external canister.
-  NativeSettings : DefiniteCanisterSettings;
+  NativeSettings : DefiniteCanisterSettingsInput;
 };
 
 type ConfigureExternalCanisterOperationInput = record {
@@ -679,6 +679,7 @@ type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInpu
 
 type CreateExternalCanisterOperation = record {
   canister_id : opt principal;
+  input : CreateExternalCanisterOperationInput;
 };
 
 type CanisterMethod = record {
@@ -2148,6 +2149,14 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
 };
 
+type DefiniteCanisterSettingsInput = record {
+  controllers : opt vec principal;
+  compute_allocation : opt nat;
+  memory_allocation : opt nat;
+  freezing_threshold : opt nat;
+  reserved_cycles_limit : opt nat;
+};
+
 type CanisterStatusResponse = record {
   status : variant { running; stopping; stopped };
   settings : DefiniteCanisterSettings;
@@ -2227,6 +2236,8 @@ type ExternalCanister = record {
   description : opt text;
   // The labels that can be used to categorize the canister.
   labels : vec text;
+  // The current state of the record (e.g. `Active`).
+  state : ExternalCanisterState;
   // The permissions that are set for who can interact with the canister.
   permissions : ExternalCanisterPermissions;
   // The request policies that are associated with the canister.
@@ -2235,6 +2246,14 @@ type ExternalCanister = record {
   created_at : TimestampRFC3339;
   // The time at which the canister was last modified, if available.
   modified_at : opt TimestampRFC3339;
+};
+
+// The state of the external canister.
+type ExternalCanisterState = variant {
+  // The record is active and can be interacted with.
+  Active;
+  // The record is archived and can no longer be interacted with.
+  Archived;
 };
 
 // Input type for getting a external canister.

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -76,7 +76,7 @@ pub struct ChangeExternalCanisterOperationDTO {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ConfigureExternalCanisterOperationInput {
     pub canister_id: Principal,
-    pub operation: ConfigureExternalCanisterOperationKindDTO,
+    pub kind: ConfigureExternalCanisterOperationKindDTO,
 }
 
 pub type ConfigureExternalCanisterOperationDTO = ConfigureExternalCanisterOperationInput;
@@ -86,6 +86,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub name: Option<String>,
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
+    pub state: Option<ExternalCanisterStateDTO>,
     pub permissions: Option<ExternalCanisterPermissionsInput>,
     pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
 }

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -52,6 +52,7 @@ pub struct CreateExternalCanisterOperationInput {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateExternalCanisterOperationDTO {
     pub canister_id: Option<Principal>,
+    pub input: CreateExternalCanisterOperationInput,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -12,15 +12,15 @@ pub type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPoliciesD
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct DefiniteCanisterSettingsInput {
     /// Controllers of the canister.
-    pub controllers: Vec<Principal>,
+    pub controllers: Option<Vec<Principal>>,
     /// Compute allocation.
-    pub compute_allocation: Nat,
+    pub compute_allocation: Option<Nat>,
     /// Memory allocation.
-    pub memory_allocation: Nat,
+    pub memory_allocation: Option<Nat>,
     /// Freezing threshold.
-    pub freezing_threshold: Nat,
+    pub freezing_threshold: Option<Nat>,
     /// Reserved cycles limit.
-    pub reserved_cycles_limit: Nat,
+    pub reserved_cycles_limit: Option<Nat>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -158,10 +158,17 @@ pub struct ExternalCanisterDTO {
     pub name: String,
     pub description: Option<String>,
     pub labels: Vec<String>,
+    pub state: ExternalCanisterStateDTO,
     pub permissions: ExternalCanisterPermissionsDTO,
     pub request_policies: ExternalCanisterRequestPoliciesDTO,
     pub created_at: TimestampRfc3339,
     pub modified_at: Option<TimestampRfc3339>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub enum ExternalCanisterStateDTO {
+    Active,
+    Archived,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/results.yml
+++ b/core/station/impl/results.yml
@@ -1,31 +1,31 @@
 benches:
   repository_batch_insert_100_requests:
     total:
-      instructions: 490151641
+      instructions: 490228420
       heap_increase: 0
       stable_memory_increase: 241
     scopes: {}
   repository_filter_all_request_ids_by_default_filters:
     total:
-      instructions: 466415778
+      instructions: 466321334
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   repository_list_all_requests:
     total:
-      instructions: 96655649
-      heap_increase: 9
+      instructions: 98801149
+      heap_increase: 12
       stable_memory_increase: 0
     scopes: {}
   service_filter_all_requests_with_creation_time_filters:
     total:
-      instructions: 1151510595
+      instructions: 1151410169
       heap_increase: 0
       stable_memory_increase: 16
     scopes: {}
   service_filter_all_requests_with_default_filters:
     total:
-      instructions: 6016695260
+      instructions: 6015873885
       heap_increase: 3
       stable_memory_increase: 16
     scopes: {}

--- a/core/station/impl/src/core/memory.rs
+++ b/core/station/impl/src/core/memory.rs
@@ -41,6 +41,8 @@ pub const OPERATION_TYPE_TO_REQUEST_ID_INDEX_MEMORY_ID: MemoryId = MemoryId::new
 pub const REQUEST_RESOURCE_INDEX_MEMORY_ID: MemoryId = MemoryId::new(30);
 pub const POLICY_RESOURCE_INDEX_MEMORY_ID: MemoryId = MemoryId::new(31);
 pub const REQUEST_EVALUATION_RESULT_MEMORY_ID: MemoryId = MemoryId::new(32);
+pub const EXTERNAL_CANISTER_MEMORY_ID: MemoryId = MemoryId::new(33);
+pub const EXTERNAL_CANISTER_INDEX_MEMORY_ID: MemoryId = MemoryId::new(34);
 
 thread_local! {
   /// Static configuration of the canister.

--- a/core/station/impl/src/core/mod.rs
+++ b/core/station/impl/src/core/mod.rs
@@ -45,9 +45,15 @@ pub mod utils;
 pub mod test_utils {
     use crate::core::write_system_info;
     use crate::models::system::SystemInfo;
+    use candid::Principal;
+
+    pub const UPGRADER_CANISTER_ID: [u8; 29] = [25; 29];
 
     pub fn init_canister_system() -> SystemInfo {
-        let system = SystemInfo::default();
+        let mut system = SystemInfo::default();
+        system
+            .set_upgrader_canister_id(Principal::from_slice(self::UPGRADER_CANISTER_ID.as_slice()));
+
         write_system_info(system.clone());
 
         system

--- a/core/station/impl/src/errors/external_canister.rs
+++ b/core/station/impl/src/errors/external_canister.rs
@@ -7,7 +7,10 @@ use thiserror::Error;
 /// Container for external canister errors.
 #[derive(Error, Debug, Eq, PartialEq, Clone)]
 pub enum ExternalCanisterError {
-    /// The external canister operation failed in validation.
+    /// The external canister was not found.
+    #[error(r#"The external canister with id '{id}' was not found."#)]
+    NotFound { id: String },
+    /// The canister id is not a valid external canister.
     #[error(r#"The principal {principal} is an invalid external canister."#)]
     InvalidExternalCanister { principal: Principal },
     /// The external canister operation failed in execution.
@@ -23,6 +26,9 @@ impl DetailableError for ExternalCanisterError {
         let mut details = HashMap::new();
 
         match self {
+            ExternalCanisterError::NotFound { id } => {
+                details.insert("id".to_string(), id.to_string());
+            }
             ExternalCanisterError::InvalidExternalCanister { principal } => {
                 details.insert("principal".to_string(), principal.to_string());
             }

--- a/core/station/impl/src/errors/external_canister.rs
+++ b/core/station/impl/src/errors/external_canister.rs
@@ -13,6 +13,9 @@ pub enum ExternalCanisterError {
     /// The external canister operation failed in execution.
     #[error(r#"The external canister operation failed due to {reason}"#)]
     Failed { reason: String },
+    /// The external canister has failed validation.
+    #[error(r#"The external canister has failed validation."#)]
+    ValidationError { info: String },
 }
 
 impl DetailableError for ExternalCanisterError {
@@ -25,6 +28,9 @@ impl DetailableError for ExternalCanisterError {
             }
             ExternalCanisterError::Failed { reason } => {
                 details.insert("reason".to_string(), reason.to_string());
+            }
+            ExternalCanisterError::ValidationError { info } => {
+                details.insert("info".to_string(), info.to_string());
             }
         }
 

--- a/core/station/impl/src/factories/requests/configure_external_canister.rs
+++ b/core/station/impl/src/factories/requests/configure_external_canister.rs
@@ -1,0 +1,120 @@
+use super::{Create, Execute, RequestExecuteStage};
+use crate::{
+    errors::{RequestError, RequestExecuteError},
+    models::{
+        ConfigureExternalCanisterOperation, ConfigureExternalCanisterOperationKind, Request,
+        RequestExecutionPlan, RequestOperation,
+    },
+    services::ExternalCanisterService,
+};
+use async_trait::async_trait;
+use orbit_essentials::types::UUID;
+use station_api::{ConfigureExternalCanisterOperationInput, CreateRequestInput};
+use std::sync::Arc;
+
+pub struct ConfigureExternalCanisterRequestCreate;
+
+#[async_trait]
+impl Create<ConfigureExternalCanisterOperationInput> for ConfigureExternalCanisterRequestCreate {
+    async fn create(
+        &self,
+        request_id: UUID,
+        requested_by_user: UUID,
+        input: CreateRequestInput,
+        operation_input: ConfigureExternalCanisterOperationInput,
+    ) -> Result<Request, RequestError> {
+        let request = Request::new(
+            request_id,
+            requested_by_user,
+            Request::default_expiration_dt_ns(),
+            RequestOperation::ConfigureExternalCanister(operation_input.into()),
+            input
+                .execution_plan
+                .map(Into::into)
+                .unwrap_or(RequestExecutionPlan::Immediate),
+            input
+                .title
+                .unwrap_or_else(|| "Configure canister".to_string()),
+            input.summary,
+        );
+
+        Ok(request)
+    }
+}
+
+pub struct ConfigureExternalCanisterRequestExecute<'p, 'o> {
+    request: &'p Request,
+    operation: &'o ConfigureExternalCanisterOperation,
+    external_canister_service: Arc<ExternalCanisterService>,
+}
+
+impl<'p, 'o> ConfigureExternalCanisterRequestExecute<'p, 'o> {
+    pub fn new(
+        request: &'p Request,
+        operation: &'o ConfigureExternalCanisterOperation,
+        external_canister_service: Arc<ExternalCanisterService>,
+    ) -> Self {
+        Self {
+            request,
+            operation,
+            external_canister_service,
+        }
+    }
+}
+
+#[async_trait]
+impl Execute for ConfigureExternalCanisterRequestExecute<'_, '_> {
+    async fn execute(&self) -> Result<RequestExecuteStage, RequestExecuteError> {
+        let external_canister = self
+            .external_canister_service
+            .get_external_canister_by_canister_id(&self.operation.canister_id)
+            .map_err(|e| RequestExecuteError::Failed {
+                reason: format!("External canister not found: {}", e),
+            })?;
+
+        match &self.operation.operation {
+            ConfigureExternalCanisterOperationKind::Delete => {
+                self.external_canister_service
+                    .hard_delete_external_canister(&external_canister.id)
+                    .await
+                    .map_err(|e| RequestExecuteError::Failed {
+                        reason: format!("Failed to delete canister: {}", e),
+                    })?;
+            }
+            ConfigureExternalCanisterOperationKind::SoftDelete => {
+                self.external_canister_service
+                    .soft_delete_external_canister(&external_canister.id)
+                    .map_err(|e| RequestExecuteError::Failed {
+                        reason: format!("Failed to soft delete canister: {}", e),
+                    })?;
+            }
+            ConfigureExternalCanisterOperationKind::TopUp(cycles) => {
+                self.external_canister_service
+                    .top_up_canister(external_canister.canister_id, *cycles as u128)
+                    .await
+                    .map_err(|e| RequestExecuteError::Failed {
+                        reason: format!("Failed to top up canister: {}", e),
+                    })?;
+            }
+            ConfigureExternalCanisterOperationKind::NativeSettings(settings) => {
+                self.external_canister_service
+                    .change_canister_ic_settings(external_canister.canister_id, settings.clone())
+                    .await
+                    .map_err(|e| RequestExecuteError::Failed {
+                        reason: format!("Failed to configure native settings: {}", e),
+                    })?;
+            }
+            ConfigureExternalCanisterOperationKind::Settings(settings) => {
+                self.external_canister_service
+                    .edit_external_canister(&external_canister.id, settings.clone())
+                    .map_err(|e| RequestExecuteError::Failed {
+                        reason: format!("Failed to configure settings: {}", e),
+                    })?;
+            }
+        }
+
+        Ok(RequestExecuteStage::Completed(
+            self.request.operation.clone(),
+        ))
+    }
+}

--- a/core/station/impl/src/factories/requests/configure_external_canister.rs
+++ b/core/station/impl/src/factories/requests/configure_external_canister.rs
@@ -72,6 +72,20 @@ impl Execute for ConfigureExternalCanisterRequestExecute<'_, '_> {
                 reason: format!("External canister not found: {}", e),
             })?;
 
+        if external_canister.is_archived() {
+            match &self.operation.kind {
+                ConfigureExternalCanisterOperationKind::Delete
+                | ConfigureExternalCanisterOperationKind::SoftDelete
+                | ConfigureExternalCanisterOperationKind::Settings(_) => {}
+                _ => {
+                    return Err(RequestExecuteError::Failed {
+                        reason: "Canister is archived, please reactivate and try again."
+                            .to_string(),
+                    });
+                }
+            }
+        }
+
         match &self.operation.kind {
             ConfigureExternalCanisterOperationKind::Delete => {
                 self.external_canister_service
@@ -116,5 +130,83 @@ impl Execute for ConfigureExternalCanisterRequestExecute<'_, '_> {
         Ok(RequestExecuteStage::Completed(
             self.request.operation.clone(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        factories::requests::requests_test_utils::mock_request_api_input,
+        models::{external_canister_test_utils::mock_external_canister, ExternalCanisterState},
+        repositories::{EXTERNAL_CANISTER_REPOSITORY, REQUEST_REPOSITORY},
+        services::EXTERNAL_CANISTER_SERVICE,
+    };
+    use configure_external_canister_test_utils::mock_operation_api_input;
+    use orbit_essentials::repository::Repository;
+
+    #[tokio::test]
+    async fn execute_settings_change_fails_when_archived() {
+        let operation_input = mock_operation_api_input();
+        let mut external_canister = mock_external_canister();
+        external_canister.state = ExternalCanisterState::Archived;
+        external_canister.canister_id = operation_input.canister_id;
+
+        EXTERNAL_CANISTER_REPOSITORY.insert(external_canister.to_key(), external_canister);
+
+        let request_id = [0u8; 16];
+        let requested_by_user = [1u8; 16];
+        let request_input = mock_request_api_input(
+            station_api::RequestOperationInput::ConfigureExternalCanister(operation_input.clone()),
+        );
+        let creator = Box::new(ConfigureExternalCanisterRequestCreate {});
+        let request = creator
+            .create(
+                request_id,
+                requested_by_user,
+                request_input,
+                operation_input,
+            )
+            .await
+            .unwrap();
+
+        REQUEST_REPOSITORY.insert(request.to_key(), request.to_owned());
+
+        match &request.operation {
+            RequestOperation::ConfigureExternalCanister(operation) => {
+                let stage = ConfigureExternalCanisterRequestExecute::new(
+                    &request,
+                    operation,
+                    Arc::clone(&EXTERNAL_CANISTER_SERVICE),
+                )
+                .execute()
+                .await
+                .unwrap_err();
+
+                assert_eq!(
+                    stage,
+                    RequestExecuteError::Failed {
+                        reason: "Canister is archived, please reactivate and try again."
+                            .to_string()
+                    }
+                );
+            }
+            _ => panic!(
+                "Expected ConfigureExternalCanister operation, got {:?}",
+                request.operation
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod configure_external_canister_test_utils {
+    use candid::Principal;
+
+    pub fn mock_operation_api_input() -> station_api::ConfigureExternalCanisterOperationInput {
+        station_api::ConfigureExternalCanisterOperationInput {
+            canister_id: Principal::from_slice(&[1; 29]),
+            kind: station_api::ConfigureExternalCanisterOperationKindDTO::TopUp(100),
+        }
     }
 }

--- a/core/station/impl/src/factories/requests/configure_external_canister.rs
+++ b/core/station/impl/src/factories/requests/configure_external_canister.rs
@@ -72,7 +72,7 @@ impl Execute for ConfigureExternalCanisterRequestExecute<'_, '_> {
                 reason: format!("External canister not found: {}", e),
             })?;
 
-        match &self.operation.operation {
+        match &self.operation.kind {
             ConfigureExternalCanisterOperationKind::Delete => {
                 self.external_canister_service
                     .hard_delete_external_canister(&external_canister.id)

--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -20,6 +20,7 @@ mod add_user;
 mod add_user_group;
 mod call_canister;
 mod change_canister;
+mod configure_external_canister;
 mod create_canister;
 mod edit_account;
 mod edit_address_book_entry;
@@ -44,6 +45,9 @@ use self::{
     change_canister::{
         ChangeCanisterRequestCreate, ChangeCanisterRequestExecute,
         ChangeExternalCanisterRequestCreate, ChangeExternalCanisterRequestExecute,
+    },
+    configure_external_canister::{
+        ConfigureExternalCanisterRequestCreate, ConfigureExternalCanisterRequestExecute,
     },
     create_canister::{CreateExternalCanisterRequestCreate, CreateExternalCanisterRequestExecute},
     edit_account::{EditAccountRequestCreate, EditAccountRequestExecute},
@@ -182,8 +186,11 @@ impl RequestFactory {
                     .create(id, requested_by_user, input.clone(), operation.clone())
                     .await
             }
-            RequestOperationInput::ConfigureExternalCanister(_operation) => {
-                unimplemented!("ConfigureExternalCanister operation is not implemented yet.")
+            RequestOperationInput::ConfigureExternalCanister(operation) => {
+                let creator = Box::new(ConfigureExternalCanisterRequestCreate {});
+                creator
+                    .create(id, requested_by_user, input.clone(), operation.clone())
+                    .await
             }
             RequestOperationInput::CreateExternalCanister(operation) => {
                 let creator = Box::new(CreateExternalCanisterRequestCreate {});
@@ -295,6 +302,13 @@ impl RequestFactory {
             }
             RequestOperation::CallExternalCanister(operation) => {
                 Box::new(CallExternalCanisterRequestExecute::new(
+                    request,
+                    operation,
+                    Arc::clone(&EXTERNAL_CANISTER_SERVICE),
+                ))
+            }
+            RequestOperation::ConfigureExternalCanister(operation) => {
+                Box::new(ConfigureExternalCanisterRequestExecute::new(
                     request,
                     operation,
                     Arc::clone(&EXTERNAL_CANISTER_SERVICE),

--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -348,3 +348,17 @@ impl RequestFactory {
         }
     }
 }
+
+#[cfg(test)]
+pub mod requests_test_utils {
+    pub fn mock_request_api_input(
+        operation: station_api::RequestOperationInput,
+    ) -> station_api::CreateRequestInput {
+        station_api::CreateRequestInput {
+            operation,
+            title: None,
+            summary: None,
+            execution_plan: None,
+        }
+    }
+}

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -1,8 +1,13 @@
 use crate::{
     core::ic_cdk::next_time,
-    models::{CreateExternalCanisterOperationInput, ExternalCanister, ExternalCanisterState},
+    models::{
+        ConfigureExternalCanisterOperationInput, ConfigureExternalCanisterOperationKind,
+        ConfigureExternalCanisterSettingsInput, CreateExternalCanisterOperationInput,
+        DefiniteCanisterSettingsInput, ExternalCanister, ExternalCanisterState,
+    },
 };
 use candid::Principal;
+use ic_cdk::api::management_canister::main::CanisterSettings;
 use uuid::Uuid;
 
 #[derive(Default, Clone, Debug)]
@@ -22,6 +27,79 @@ impl ExternalCanisterMapper {
             state: ExternalCanisterState::Active,
             created_at: next_time(),
             modified_at: None,
+        }
+    }
+}
+
+impl From<DefiniteCanisterSettingsInput> for CanisterSettings {
+    fn from(input: DefiniteCanisterSettingsInput) -> Self {
+        CanisterSettings {
+            controllers: input.controllers,
+            compute_allocation: input.compute_allocation,
+            freezing_threshold: input.freezing_threshold,
+            memory_allocation: input.memory_allocation,
+            reserved_cycles_limit: input.reserved_cycles_limit,
+        }
+    }
+}
+
+impl From<station_api::ConfigureExternalCanisterOperationInput>
+    for ConfigureExternalCanisterOperationInput
+{
+    fn from(input: station_api::ConfigureExternalCanisterOperationInput) -> Self {
+        ConfigureExternalCanisterOperationInput {
+            canister_id: input.canister_id,
+            operation: input.operation.into(),
+        }
+    }
+}
+
+impl From<station_api::ConfigureExternalCanisterOperationKindDTO>
+    for ConfigureExternalCanisterOperationKind
+{
+    fn from(input: station_api::ConfigureExternalCanisterOperationKindDTO) -> Self {
+        match input {
+            station_api::ConfigureExternalCanisterOperationKindDTO::Delete => {
+                ConfigureExternalCanisterOperationKind::Delete
+            }
+            station_api::ConfigureExternalCanisterOperationKindDTO::SoftDelete => {
+                ConfigureExternalCanisterOperationKind::SoftDelete
+            }
+            station_api::ConfigureExternalCanisterOperationKindDTO::TopUp(cycles) => {
+                ConfigureExternalCanisterOperationKind::TopUp(cycles)
+            }
+            station_api::ConfigureExternalCanisterOperationKindDTO::NativeSettings(settings) => {
+                ConfigureExternalCanisterOperationKind::NativeSettings(settings.into())
+            }
+            station_api::ConfigureExternalCanisterOperationKindDTO::Settings(settings) => {
+                ConfigureExternalCanisterOperationKind::Settings(settings.into())
+            }
+        }
+    }
+}
+
+impl From<station_api::DefiniteCanisterSettingsInput> for DefiniteCanisterSettingsInput {
+    fn from(input: station_api::DefiniteCanisterSettingsInput) -> Self {
+        DefiniteCanisterSettingsInput {
+            controllers: input.controllers,
+            compute_allocation: input.compute_allocation,
+            freezing_threshold: input.freezing_threshold,
+            memory_allocation: input.memory_allocation,
+            reserved_cycles_limit: input.reserved_cycles_limit,
+        }
+    }
+}
+
+impl From<station_api::ConfigureExternalCanisterSettingsInput>
+    for ConfigureExternalCanisterSettingsInput
+{
+    fn from(input: station_api::ConfigureExternalCanisterSettingsInput) -> Self {
+        ConfigureExternalCanisterSettingsInput {
+            name: input.name,
+            description: input.description,
+            labels: input.labels,
+            permissions: input.permissions.map(Into::into),
+            request_policies: input.request_policies.map(Into::into),
         }
     }
 }

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -1,0 +1,27 @@
+use crate::{
+    core::ic_cdk::next_time,
+    models::{CreateExternalCanisterOperationInput, ExternalCanister, ExternalCanisterState},
+};
+use candid::Principal;
+use uuid::Uuid;
+
+#[derive(Default, Clone, Debug)]
+pub struct ExternalCanisterMapper {}
+
+impl ExternalCanisterMapper {
+    pub fn from_create_input(
+        canister_id: Principal,
+        input: CreateExternalCanisterOperationInput,
+    ) -> ExternalCanister {
+        ExternalCanister {
+            id: *Uuid::new_v4().as_bytes(),
+            canister_id,
+            name: input.name.clone(),
+            description: input.description.clone(),
+            labels: input.labels.clone().unwrap_or_default(),
+            state: ExternalCanisterState::Active,
+            created_at: next_time(),
+            modified_at: None,
+        }
+    }
+}

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -49,7 +49,7 @@ impl From<station_api::ConfigureExternalCanisterOperationInput>
     fn from(input: station_api::ConfigureExternalCanisterOperationInput) -> Self {
         ConfigureExternalCanisterOperationInput {
             canister_id: input.canister_id,
-            operation: input.operation.into(),
+            kind: input.kind.into(),
         }
     }
 }
@@ -98,8 +98,27 @@ impl From<station_api::ConfigureExternalCanisterSettingsInput>
             name: input.name,
             description: input.description,
             labels: input.labels,
+            state: input.state.map(Into::into),
             permissions: input.permissions.map(Into::into),
             request_policies: input.request_policies.map(Into::into),
+        }
+    }
+}
+
+impl From<ExternalCanisterState> for station_api::ExternalCanisterStateDTO {
+    fn from(state: ExternalCanisterState) -> Self {
+        match state {
+            ExternalCanisterState::Active => station_api::ExternalCanisterStateDTO::Active,
+            ExternalCanisterState::Archived => station_api::ExternalCanisterStateDTO::Archived,
+        }
+    }
+}
+
+impl From<station_api::ExternalCanisterStateDTO> for ExternalCanisterState {
+    fn from(state: station_api::ExternalCanisterStateDTO) -> Self {
+        match state {
+            station_api::ExternalCanisterStateDTO::Active => ExternalCanisterState::Active,
+            station_api::ExternalCanisterStateDTO::Archived => ExternalCanisterState::Archived,
         }
     }
 }

--- a/core/station/impl/src/mappers/mod.rs
+++ b/core/station/impl/src/mappers/mod.rs
@@ -39,6 +39,9 @@ pub use helper::*;
 mod user;
 pub use user::*;
 
+mod external_canister;
+pub use external_canister::*;
+
 mod user_group;
 
 mod user_status;

--- a/core/station/impl/src/mappers/notification_type.rs
+++ b/core/station/impl/src/mappers/notification_type.rs
@@ -90,6 +90,7 @@ impl TryFrom<NotificationType> for NotificationTypeDTO {
                     | RequestOperation::SetDisasterRecovery(_)
                     | RequestOperation::ChangeCanister(_)
                     | RequestOperation::ChangeExternalCanister(_)
+                    | RequestOperation::ConfigureExternalCanister(_)
                     | RequestOperation::CreateExternalCanister(_)
                     | RequestOperation::CallExternalCanister(_) => None,
                 };
@@ -114,6 +115,7 @@ impl TryFrom<NotificationType> for NotificationTypeDTO {
                     | RequestOperation::SetDisasterRecovery(_)
                     | RequestOperation::ChangeCanister(_)
                     | RequestOperation::ChangeExternalCanister(_)
+                    | RequestOperation::ConfigureExternalCanister(_)
                     | RequestOperation::CreateExternalCanister(_)
                     | RequestOperation::CallExternalCanister(_) => None,
                 };

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -701,14 +701,7 @@ impl From<CreateExternalCanisterOperation> for CreateExternalCanisterOperationDT
     fn from(operation: CreateExternalCanisterOperation) -> CreateExternalCanisterOperationDTO {
         CreateExternalCanisterOperationDTO {
             canister_id: operation.canister_id,
-        }
-    }
-}
-
-impl From<CreateExternalCanisterOperationDTO> for CreateExternalCanisterOperation {
-    fn from(operation: CreateExternalCanisterOperationDTO) -> CreateExternalCanisterOperation {
-        CreateExternalCanisterOperation {
-            canister_id: operation.canister_id,
+            input: operation.input.into(),
         }
     }
 }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -488,7 +488,7 @@ impl From<ConfigureExternalCanisterOperation>
     ) -> station_api::ConfigureExternalCanisterOperationDTO {
         station_api::ConfigureExternalCanisterOperationDTO {
             canister_id: operation.canister_id,
-            operation: operation.operation.into(),
+            kind: operation.kind.into(),
         }
     }
 }
@@ -529,6 +529,7 @@ impl From<ConfigureExternalCanisterSettingsInput>
             name: input.name,
             description: input.description,
             labels: input.labels,
+            state: input.state.map(Into::into),
             permissions: input.permissions.map(Into::into),
             request_policies: input.request_policies.map(Into::into),
         }

--- a/core/station/impl/src/mappers/request_operation_type.rs
+++ b/core/station/impl/src/mappers/request_operation_type.rs
@@ -117,6 +117,9 @@ impl From<RequestOperation> for RequestOperationType {
             RequestOperation::ChangeExternalCanister(_) => {
                 RequestOperationType::ChangeExternalCanister
             }
+            RequestOperation::ConfigureExternalCanister(_) => {
+                RequestOperationType::ConfigureExternalCanister
+            }
             RequestOperation::CreateExternalCanister(_) => {
                 RequestOperationType::CreateExternalCanister
             }

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -80,6 +80,11 @@ impl ExternalCanister {
         Self::key(self.id)
     }
 
+    /// Checks if the external canister is archived.
+    pub fn is_archived(&self) -> bool {
+        self.state == ExternalCanisterState::Archived
+    }
+
     pub fn update_with(&mut self, changes: ConfigureExternalCanisterSettingsInput) {
         if let Some(name) = changes.name {
             self.name = name;

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -1,0 +1,180 @@
+use super::indexes::external_canister_index::{ExternalCanisterIndex, ExternalCanisterIndexKind};
+use super::resource::ValidationMethodResourceTarget;
+use crate::core::utils::format_unique_string;
+use crate::errors::ExternalCanisterError;
+use candid::Principal;
+use orbit_essentials::storable;
+use orbit_essentials::{
+    model::{ModelValidator, ModelValidatorResult},
+    types::{Timestamp, UUID},
+};
+use std::hash::Hash;
+
+/// The external canister id, which is a UUID.
+pub type ExternalCanisterId = UUID;
+
+/// Represents an external canister that the station can interact with.
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanister {
+    /// The external canister id, which is a UUID.
+    pub id: ExternalCanisterId,
+    /// The canister id, which is a Principal.
+    pub canister_id: Principal,
+    /// The canister name.
+    pub name: String,
+    /// The canister description.
+    pub description: Option<String>,
+    /// The canister labels.
+    ///
+    /// This is a list of strings that can be used to categorize the canister
+    /// and make it easier to search for.
+    pub labels: Vec<String>,
+    /// The state of the canister (e.g. active, archived, etc.)
+    pub state: ExternalCanisterState,
+    /// When the canister was added to the station.
+    pub created_at: Timestamp,
+    /// The last time the record was updated.
+    pub modified_at: Option<Timestamp>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterKey {
+    pub id: ExternalCanisterId,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ExternalCanisterState {
+    Active,
+    Archived,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterCallerMethodsPrivileges {
+    pub validation_method: ValidationMethodResourceTarget,
+    pub execution_method: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterCallerPrivileges {
+    pub id: UUID,
+    pub can_change: bool,
+    pub can_call: Vec<ExternalCanisterCallerMethodsPrivileges>,
+}
+
+impl ExternalCanister {
+    pub const MAX_NAME_LENGTH: usize = 100;
+    pub const MAX_LABEL_LENGTH: usize = 50;
+    pub const MAX_LABELS: usize = 10;
+    pub const MAX_DESCRIPTION_LENGTH: usize = 1000;
+
+    /// Creates a new external canister key from the given key components.
+    pub fn key(id: ExternalCanisterId) -> ExternalCanisterKey {
+        ExternalCanisterKey { id }
+    }
+
+    /// Extracts the lookup key of the external canister.
+    pub fn to_key(&self) -> ExternalCanisterKey {
+        Self::key(self.id)
+    }
+
+    /// Converts the external canister to an index by its name.
+    pub fn to_index_by_name(&self) -> ExternalCanisterIndex {
+        ExternalCanisterIndex {
+            index: ExternalCanisterIndexKind::Name(format_unique_string(self.name.as_str())),
+            external_canister_id: self.id,
+        }
+    }
+
+    /// Converts the external canister to indexes by its labels.
+    pub fn to_index_by_labels(&self) -> Vec<ExternalCanisterIndex> {
+        self.labels
+            .iter()
+            .map(|label| ExternalCanisterIndex {
+                index: ExternalCanisterIndexKind::Label(format_unique_string(label.as_str())),
+                external_canister_id: self.id,
+            })
+            .collect()
+    }
+
+    /// Converts the external canister to indexes to facilitate searching.
+    pub fn indexes(&self) -> Vec<ExternalCanisterIndex> {
+        let mut indexes = vec![self.to_index_by_name()];
+        indexes.extend(self.to_index_by_labels());
+
+        indexes
+    }
+}
+
+fn validate_name(name: &str) -> ModelValidatorResult<ExternalCanisterError> {
+    if name.is_empty() {
+        return Err(ExternalCanisterError::ValidationError {
+            info: "The name of the external canister cannot be empty.".to_string(),
+        });
+    }
+
+    if name.len() > ExternalCanister::MAX_NAME_LENGTH {
+        return Err(ExternalCanisterError::ValidationError {
+            info: format!(
+                "The name of the external canister cannot be longer than {} characters.",
+                ExternalCanister::MAX_NAME_LENGTH
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_description(
+    description: &Option<String>,
+) -> ModelValidatorResult<ExternalCanisterError> {
+    if let Some(description) = description {
+        if description.len() > ExternalCanister::MAX_DESCRIPTION_LENGTH {
+            return Err(ExternalCanisterError::ValidationError {
+                info: format!(
+                    "The description of the external canister cannot be longer than {} characters.",
+                    ExternalCanister::MAX_DESCRIPTION_LENGTH
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_labels(labels: &[String]) -> ModelValidatorResult<ExternalCanisterError> {
+    if labels.len() > ExternalCanister::MAX_LABELS {
+        return Err(ExternalCanisterError::ValidationError {
+            info: format!(
+                "The external canister cannot have more than {} labels.",
+                ExternalCanister::MAX_LABELS
+            ),
+        });
+    }
+
+    for label in labels {
+        if label.len() > ExternalCanister::MAX_LABEL_LENGTH {
+            return Err(ExternalCanisterError::ValidationError {
+                info: format!(
+                    "The label '{}' cannot be longer than {} characters.",
+                    label,
+                    ExternalCanister::MAX_LABEL_LENGTH
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+impl ModelValidator<ExternalCanisterError> for ExternalCanister {
+    fn validate(&self) -> ModelValidatorResult<ExternalCanisterError> {
+        validate_name(&self.name)?;
+        validate_description(&self.description)?;
+        validate_labels(&self.labels)?;
+
+        Ok(())
+    }
+}

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -1,4 +1,5 @@
 use crate::models::ExternalCanisterId;
+use candid::Principal;
 use orbit_essentials::storable;
 
 /// The main index for external canisters.
@@ -14,6 +15,7 @@ pub struct ExternalCanisterIndex {
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ExternalCanisterIndexKind {
+    CanisterId(Principal),
     Name(String),
     Label(String),
 }

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -1,0 +1,25 @@
+use crate::models::ExternalCanisterId;
+use orbit_essentials::storable;
+
+/// The main index for external canisters.
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterIndex {
+    /// An indexed value of the external canister.
+    pub index: ExternalCanisterIndexKind,
+    /// The external canister id, which is a UUID.
+    pub external_canister_id: ExternalCanisterId,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ExternalCanisterIndexKind {
+    Name(String),
+    Label(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct ExternalCanisterIndexCriteria {
+    pub from: ExternalCanisterIndexKind,
+    pub to: ExternalCanisterIndexKind,
+}

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -1,4 +1,7 @@
-use crate::models::ExternalCanisterId;
+use crate::{
+    core::utils::format_unique_string,
+    models::{ExternalCanister, ExternalCanisterId},
+};
 use candid::Principal;
 use orbit_essentials::storable;
 
@@ -20,8 +23,131 @@ pub enum ExternalCanisterIndexKind {
     Label(String),
 }
 
+impl ExternalCanister {
+    /// Converts the external canister to an index by its name.
+    pub fn to_index_by_name(&self) -> ExternalCanisterIndex {
+        ExternalCanisterIndex {
+            index: ExternalCanisterIndexKind::Name(format_unique_string(self.name.as_str())),
+            external_canister_id: self.id,
+        }
+    }
+
+    /// Converts the external canister to indexes by its labels.
+    pub fn to_index_by_labels(&self) -> Vec<ExternalCanisterIndex> {
+        self.labels
+            .iter()
+            .map(|label| ExternalCanisterIndex {
+                index: ExternalCanisterIndexKind::Label(format_unique_string(label.as_str())),
+                external_canister_id: self.id,
+            })
+            .collect()
+    }
+
+    /// Converts the external canister to an index by its canister id.
+    pub fn to_index_by_canister_id(&self) -> ExternalCanisterIndex {
+        ExternalCanisterIndex {
+            index: ExternalCanisterIndexKind::CanisterId(self.canister_id),
+            external_canister_id: self.id,
+        }
+    }
+
+    /// Converts the external canister to indexes to facilitate searching.
+    pub fn indexes(&self) -> Vec<ExternalCanisterIndex> {
+        let mut indexes = vec![self.to_index_by_name(), self.to_index_by_canister_id()];
+        indexes.extend(self.to_index_by_labels());
+
+        indexes
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ExternalCanisterIndexCriteria {
     pub from: ExternalCanisterIndexKind,
     pub to: ExternalCanisterIndexKind,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::external_canister_test_utils::mock_external_canister;
+    use ic_stable_structures::Storable;
+
+    #[test]
+    fn valid_model_serialization() {
+        let model = ExternalCanisterIndex {
+            index: ExternalCanisterIndexKind::CanisterId(Principal::anonymous()),
+            external_canister_id: [u8::MAX; 16],
+        };
+
+        let serialized_model = model.to_bytes();
+        let deserialized_model = ExternalCanisterIndex::from_bytes(serialized_model);
+
+        assert_eq!(model.index, deserialized_model.index);
+        assert_eq!(
+            model.external_canister_id,
+            deserialized_model.external_canister_id
+        );
+    }
+
+    #[test]
+    fn valid_external_canister_name_index_mapping() {
+        let mut canister = mock_external_canister();
+        canister.name = "Finance".to_string();
+
+        let index = canister.to_index_by_name();
+
+        assert_eq!(
+            index.index,
+            ExternalCanisterIndexKind::Name(format_unique_string("Finance"))
+        );
+        assert_eq!(index.external_canister_id, canister.id);
+    }
+
+    #[test]
+    fn valid_external_canister_canister_id_index_mapping() {
+        let mut canister = mock_external_canister();
+        canister.canister_id = Principal::anonymous();
+
+        let index = canister.to_index_by_canister_id();
+
+        assert_eq!(
+            index.index,
+            ExternalCanisterIndexKind::CanisterId(Principal::anonymous())
+        );
+        assert_eq!(index.external_canister_id, canister.id);
+    }
+
+    #[test]
+    fn valid_external_canister_label_index_mapping() {
+        let mut canister = mock_external_canister();
+        canister.labels = vec!["label-1".to_string(), "label-2".to_string()];
+
+        let indexes = canister.to_index_by_labels();
+        assert_eq!(indexes.len(), 2);
+
+        let index = &indexes[0];
+        assert_eq!(
+            index.index,
+            ExternalCanisterIndexKind::Label("label-1".to_string())
+        );
+        assert_eq!(index.external_canister_id, canister.id);
+
+        let index = &indexes[1];
+        assert_eq!(
+            index.index,
+            ExternalCanisterIndexKind::Label("label-2".to_string())
+        );
+        assert_eq!(index.external_canister_id, canister.id);
+    }
+
+    #[test]
+    fn valid_external_canister_indexes_includes_all() {
+        let mut canister = mock_external_canister();
+        canister.name = "Finance".to_string();
+        canister.canister_id = Principal::anonymous();
+        canister.labels = vec!["label-1".to_string()];
+
+        let indexes = canister.indexes();
+        assert_eq!(indexes.len(), 3);
+    }
 }

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -12,7 +12,7 @@ pub struct ExternalCanisterIndex {
     /// An indexed value of the external canister.
     pub index: ExternalCanisterIndexKind,
     /// The external canister id, which is a UUID.
-    pub external_canister_id: ExternalCanisterId,
+    pub external_canister_resource_id: ExternalCanisterId,
 }
 
 #[storable]
@@ -28,7 +28,7 @@ impl ExternalCanister {
     pub fn to_index_by_name(&self) -> ExternalCanisterIndex {
         ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::Name(format_unique_string(self.name.as_str())),
-            external_canister_id: self.id,
+            external_canister_resource_id: self.id,
         }
     }
 
@@ -38,7 +38,7 @@ impl ExternalCanister {
             .iter()
             .map(|label| ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Label(format_unique_string(label.as_str())),
-                external_canister_id: self.id,
+                external_canister_resource_id: self.id,
             })
             .collect()
     }
@@ -47,7 +47,7 @@ impl ExternalCanister {
     pub fn to_index_by_canister_id(&self) -> ExternalCanisterIndex {
         ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::CanisterId(self.canister_id),
-            external_canister_id: self.id,
+            external_canister_resource_id: self.id,
         }
     }
 
@@ -76,7 +76,7 @@ mod tests {
     fn valid_model_serialization() {
         let model = ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::CanisterId(Principal::anonymous()),
-            external_canister_id: [u8::MAX; 16],
+            external_canister_resource_id: [u8::MAX; 16],
         };
 
         let serialized_model = model.to_bytes();
@@ -84,8 +84,8 @@ mod tests {
 
         assert_eq!(model.index, deserialized_model.index);
         assert_eq!(
-            model.external_canister_id,
-            deserialized_model.external_canister_id
+            model.external_canister_resource_id,
+            deserialized_model.external_canister_resource_id
         );
     }
 
@@ -100,7 +100,7 @@ mod tests {
             index.index,
             ExternalCanisterIndexKind::Name(format_unique_string("Finance"))
         );
-        assert_eq!(index.external_canister_id, canister.id);
+        assert_eq!(index.external_canister_resource_id, canister.id);
     }
 
     #[test]
@@ -114,7 +114,7 @@ mod tests {
             index.index,
             ExternalCanisterIndexKind::CanisterId(Principal::anonymous())
         );
-        assert_eq!(index.external_canister_id, canister.id);
+        assert_eq!(index.external_canister_resource_id, canister.id);
     }
 
     #[test]
@@ -130,14 +130,14 @@ mod tests {
             index.index,
             ExternalCanisterIndexKind::Label("label-1".to_string())
         );
-        assert_eq!(index.external_canister_id, canister.id);
+        assert_eq!(index.external_canister_resource_id, canister.id);
 
         let index = &indexes[1];
         assert_eq!(
             index.index,
             ExternalCanisterIndexKind::Label("label-2".to_string())
         );
-        assert_eq!(index.external_canister_id, canister.id);
+        assert_eq!(index.external_canister_resource_id, canister.id);
     }
 
     #[test]

--- a/core/station/impl/src/models/indexes/mod.rs
+++ b/core/station/impl/src/models/indexes/mod.rs
@@ -1,5 +1,6 @@
 pub mod address_book_index;
 pub mod address_book_standard_index;
+pub mod external_canister_index;
 pub mod name_to_account_id_index;
 pub mod name_to_user_id_index;
 pub mod notification_user_index;

--- a/core/station/impl/src/models/indexes/request_operation_type_index.rs
+++ b/core/station/impl/src/models/indexes/request_operation_type_index.rs
@@ -84,6 +84,18 @@ impl Request {
                     request_id: self.id,
                 },
             ],
+            RequestOperation::ConfigureExternalCanister(operation) => vec![
+                RequestOperationTypeIndex {
+                    operation_type: RequestOperationFilterType::ConfigureExternalCanister(None),
+                    request_id: self.id,
+                },
+                RequestOperationTypeIndex {
+                    operation_type: RequestOperationFilterType::ConfigureExternalCanister(Some(
+                        operation.canister_id,
+                    )),
+                    request_id: self.id,
+                },
+            ],
             RequestOperation::CreateExternalCanister(_) => vec![RequestOperationTypeIndex {
                 operation_type: RequestOperationFilterType::CreateExternalCanister,
                 request_id: self.id,

--- a/core/station/impl/src/models/mod.rs
+++ b/core/station/impl/src/models/mod.rs
@@ -20,6 +20,9 @@ pub use metadata::*;
 pub mod user;
 pub use user::*;
 
+pub mod external_canister;
+pub use external_canister::*;
+
 pub mod user_group;
 pub use user_group::*;
 

--- a/core/station/impl/src/models/request.rs
+++ b/core/station/impl/src/models/request.rs
@@ -207,6 +207,7 @@ fn validate_request_operation_foreign_keys(
         }
         RequestOperation::ChangeCanister(_) => (),
         RequestOperation::ChangeExternalCanister(_) => (),
+        RequestOperation::ConfigureExternalCanister(_) => (),
         RequestOperation::CreateExternalCanister(_) => (),
         RequestOperation::CallExternalCanister(op) => {
             let validation_method_target: ValidationMethodResourceTarget =

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -32,6 +32,7 @@ pub enum RequestOperation {
     RemoveUserGroup(RemoveUserGroupOperation),
     ChangeCanister(ChangeCanisterOperation),
     ChangeExternalCanister(ChangeExternalCanisterOperation),
+    ConfigureExternalCanister(ConfigureExternalCanisterOperation),
     CreateExternalCanister(CreateExternalCanisterOperation),
     CallExternalCanister(CallExternalCanisterOperation),
     AddRequestPolicy(AddRequestPolicyOperation),
@@ -58,6 +59,9 @@ impl Display for RequestOperation {
             RequestOperation::RemoveUserGroup(_) => write!(f, "remove_user_group"),
             RequestOperation::ChangeCanister(_) => write!(f, "change_canister"),
             RequestOperation::ChangeExternalCanister(_) => write!(f, "change_external_canister"),
+            RequestOperation::ConfigureExternalCanister(_) => {
+                write!(f, "configure_external_canister")
+            }
             RequestOperation::CreateExternalCanister(_) => write!(f, "create_external_canister"),
             RequestOperation::CallExternalCanister(_) => write!(f, "call_external_canister"),
             RequestOperation::AddRequestPolicy(_) => write!(f, "add_request_policy"),
@@ -389,6 +393,45 @@ pub struct CreateExternalCanisterOperationInput {
 pub struct CreateExternalCanisterOperation {
     pub canister_id: Option<Principal>,
     pub input: CreateExternalCanisterOperationInput,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ConfigureExternalCanisterOperationInput {
+    pub canister_id: Principal,
+    pub operation: ConfigureExternalCanisterOperationKind,
+}
+
+pub type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ConfigureExternalCanisterOperationKind {
+    Settings(ConfigureExternalCanisterSettingsInput),
+    TopUp(u64),
+    SoftDelete,
+    Delete,
+    NativeSettings(DefiniteCanisterSettingsInput),
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefiniteCanisterSettingsInput {
+    pub controllers: Option<Vec<Principal>>,
+    pub compute_allocation: Option<candid::Nat>,
+    pub memory_allocation: Option<candid::Nat>,
+    pub freezing_threshold: Option<candid::Nat>,
+    pub reserved_cycles_limit: Option<candid::Nat>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ConfigureExternalCanisterSettingsInput {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub permissions: Option<ExternalCanisterPermissionsInput>,
+    pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
 }
 
 #[storable]

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -4,7 +4,8 @@ use super::{
     request_specifier::RequestSpecifier,
     resource::{Resource, ValidationMethodResourceTarget},
     AccountId, AddressBookEntryId, Blockchain, BlockchainStandard, ChangeMetadata,
-    DisasterRecoveryCommittee, MetadataItem, UserGroupId, UserId, UserStatus,
+    DisasterRecoveryCommittee, ExternalCanisterState, MetadataItem, UserGroupId, UserId,
+    UserStatus,
 };
 use crate::core::validation::EnsureExternalCanister;
 use crate::errors::ValidationError;
@@ -399,7 +400,7 @@ pub struct CreateExternalCanisterOperation {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ConfigureExternalCanisterOperationInput {
     pub canister_id: Principal,
-    pub operation: ConfigureExternalCanisterOperationKind,
+    pub kind: ConfigureExternalCanisterOperationKind,
 }
 
 pub type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
@@ -430,6 +431,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub name: Option<String>,
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
+    pub state: Option<ExternalCanisterState>,
     pub permissions: Option<ExternalCanisterPermissionsInput>,
     pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
 }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -388,6 +388,7 @@ pub struct CreateExternalCanisterOperationInput {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CreateExternalCanisterOperation {
     pub canister_id: Option<Principal>,
+    pub input: CreateExternalCanisterOperationInput,
 }
 
 #[storable]

--- a/core/station/impl/src/repositories/external_canister.rs
+++ b/core/station/impl/src/repositories/external_canister.rs
@@ -1,0 +1,88 @@
+use super::indexes::external_canister_index::ExternalCanisterIndexRepository;
+use crate::{
+    core::{utils::format_unique_string, with_memory_manager, Memory, EXTERNAL_CANISTER_MEMORY_ID},
+    models::{
+        indexes::external_canister_index::{
+            ExternalCanisterIndexCriteria, ExternalCanisterIndexKind,
+        },
+        ExternalCanister, ExternalCanisterId, ExternalCanisterKey,
+    },
+};
+use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
+use lazy_static::lazy_static;
+use orbit_essentials::repository::IndexRepository;
+use orbit_essentials::repository::{RefreshIndexMode, Repository};
+use std::{cell::RefCell, sync::Arc};
+
+thread_local! {
+  /// The memory reference to the external canister repository.
+  static DB: RefCell<StableBTreeMap<ExternalCanisterKey, ExternalCanister, VirtualMemory<Memory>>> = with_memory_manager(|memory_manager| {
+    RefCell::new(
+      StableBTreeMap::init(memory_manager.get(EXTERNAL_CANISTER_MEMORY_ID))
+    )
+  })
+}
+
+lazy_static! {
+    pub static ref EXTERNAL_CANISTER_REPOSITORY: Arc<ExternalCanisterRepository> =
+        Arc::new(ExternalCanisterRepository::default());
+}
+
+/// A repository that enables managing external canisters in stable memory.
+#[derive(Debug, Default)]
+pub struct ExternalCanisterRepository {
+    indexes: ExternalCanisterIndexRepository,
+}
+
+impl Repository<ExternalCanisterKey, ExternalCanister> for ExternalCanisterRepository {
+    fn list(&self) -> Vec<ExternalCanister> {
+        DB.with(|m| m.borrow().iter().map(|(_, v)| v).collect())
+    }
+
+    fn get(&self, key: &ExternalCanisterKey) -> Option<ExternalCanister> {
+        DB.with(|m| m.borrow().get(key))
+    }
+
+    fn insert(
+        &self,
+        key: ExternalCanisterKey,
+        value: ExternalCanister,
+    ) -> Option<ExternalCanister> {
+        DB.with(|m| {
+            let prev = m.borrow_mut().insert(key, value.clone());
+
+            self.indexes
+                .refresh_index_on_modification(RefreshIndexMode::List {
+                    previous: prev
+                        .clone()
+                        .map_or(Vec::new(), |prev: ExternalCanister| prev.indexes()),
+                    current: value.indexes(),
+                });
+
+            prev
+        })
+    }
+
+    fn remove(&self, key: &ExternalCanisterKey) -> Option<ExternalCanister> {
+        DB.with(|m| m.borrow_mut().remove(key))
+    }
+
+    fn len(&self) -> usize {
+        DB.with(|m| m.borrow().len()) as usize
+    }
+}
+
+impl ExternalCanisterRepository {
+    /// Returns an external canister by its name if it exists.
+    pub fn find_by_name(&self, name: &str) -> Option<ExternalCanisterId> {
+        let name = format_unique_string(name);
+        let found = self
+            .indexes
+            .find_by_criteria(ExternalCanisterIndexCriteria {
+                from: ExternalCanisterIndexKind::Name(name.to_string()),
+                to: ExternalCanisterIndexKind::Name(name.to_string()),
+            });
+
+        found.into_iter().next()
+    }
+}

--- a/core/station/impl/src/repositories/external_canister.rs
+++ b/core/station/impl/src/repositories/external_canister.rs
@@ -100,12 +100,16 @@ impl ExternalCanisterRepository {
     }
 
     /// Verifies that the name is unique among external canisters.
+    ///
+    /// If `skip_id` is provided, it will be ignored if the match would be the same.
     pub fn is_unique_name(&self, name: &str, skip_id: Option<ExternalCanisterId>) -> bool {
         self.find_by_name(name)
             .map_or(true, |existing_id| skip_id == Some(existing_id))
     }
 
     /// Verifies that the canister id is unique among external canisters.
+    ///
+    /// If `skip_id` is provided, it will be ignored if the match would be the same.
     pub fn is_unique_canister_id(
         &self,
         canister_id: &Principal,
@@ -113,5 +117,85 @@ impl ExternalCanisterRepository {
     ) -> bool {
         self.find_by_canister_id(canister_id)
             .map_or(true, |existing_id| skip_id == Some(existing_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::external_canister_test_utils::mock_external_canister;
+
+    #[test]
+    fn test_crud() {
+        let repository = ExternalCanisterRepository::default();
+        let entry = mock_external_canister();
+
+        assert!(repository.get(&entry.to_key()).is_none());
+
+        repository.insert(entry.to_key(), entry.clone());
+
+        assert!(repository.get(&entry.to_key()).is_some());
+        assert!(repository.remove(&entry.to_key()).is_some());
+        assert!(repository.get(&entry.to_key()).is_none());
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let repository = ExternalCanisterRepository::default();
+        for i in 0..10 {
+            let mut entry = mock_external_canister();
+            entry.name = format!("test-{}", i);
+
+            repository.insert(entry.to_key(), entry);
+        }
+
+        let result = repository.find_by_name("test-5");
+
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_find_by_canister_id() {
+        let repository = ExternalCanisterRepository::default();
+        for i in 0..10 {
+            let mut entry = mock_external_canister();
+            entry.canister_id = Principal::from_slice(&[i; 29]);
+
+            repository.insert(entry.to_key(), entry);
+        }
+
+        assert!(repository
+            .find_by_canister_id(&Principal::from_slice(&[8; 29]))
+            .is_some());
+
+        assert!(repository
+            .find_by_canister_id(&Principal::from_slice(&[10; 29]))
+            .is_none());
+    }
+
+    #[test]
+    fn test_is_unique_name() {
+        let repository = ExternalCanisterRepository::default();
+        let entry = mock_external_canister();
+
+        assert!(repository.is_unique_name(&entry.name, None));
+
+        repository.insert(entry.to_key(), entry.clone());
+
+        assert!(!repository.is_unique_name(&entry.name, None));
+        assert!(repository.is_unique_name(&entry.name, Some(entry.id)));
+    }
+
+    #[test]
+    fn test_is_unique_canister_id() {
+        let repository = ExternalCanisterRepository::default();
+        let entry = mock_external_canister();
+
+        assert!(repository.is_unique_canister_id(&entry.canister_id, None));
+
+        repository.insert(entry.to_key(), entry.clone());
+
+        assert!(!repository.is_unique_canister_id(&entry.canister_id, None));
+        assert!(repository.is_unique_canister_id(&entry.canister_id, Some(entry.id)));
     }
 }

--- a/core/station/impl/src/repositories/external_canister.rs
+++ b/core/station/impl/src/repositories/external_canister.rs
@@ -8,6 +8,7 @@ use crate::{
         ExternalCanister, ExternalCanisterId, ExternalCanisterKey,
     },
 };
+use candid::Principal;
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
 use lazy_static::lazy_static;
 use orbit_essentials::repository::IndexRepository;
@@ -84,5 +85,33 @@ impl ExternalCanisterRepository {
             });
 
         found.into_iter().next()
+    }
+
+    /// Returns an external canister by its canister id if it exists.
+    pub fn find_by_canister_id(&self, canister_id: &Principal) -> Option<ExternalCanisterId> {
+        let found = self
+            .indexes
+            .find_by_criteria(ExternalCanisterIndexCriteria {
+                from: ExternalCanisterIndexKind::CanisterId(*canister_id),
+                to: ExternalCanisterIndexKind::CanisterId(*canister_id),
+            });
+
+        found.into_iter().next()
+    }
+
+    /// Verifies that the name is unique among external canisters.
+    pub fn is_unique_name(&self, name: &str, skip_id: Option<ExternalCanisterId>) -> bool {
+        self.find_by_name(name)
+            .map_or(true, |existing_id| skip_id == Some(existing_id))
+    }
+
+    /// Verifies that the canister id is unique among external canisters.
+    pub fn is_unique_canister_id(
+        &self,
+        canister_id: &Principal,
+        skip_id: Option<ExternalCanisterId>,
+    ) -> bool {
+        self.find_by_canister_id(canister_id)
+            .map_or(true, |existing_id| skip_id == Some(existing_id))
     }
 }

--- a/core/station/impl/src/repositories/indexes/external_canister_index.rs
+++ b/core/station/impl/src/repositories/indexes/external_canister_index.rs
@@ -75,6 +75,7 @@ mod tests {
         },
         repositories::indexes::external_canister_index::ExternalCanisterIndexRepository,
     };
+    use candid::Principal;
     use orbit_essentials::repository::IndexRepository;
 
     #[test]
@@ -112,5 +113,46 @@ mod tests {
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
         assert!(result.contains(&[5; 16]));
+    }
+
+    #[test]
+    fn test_find_by_canister_id() {
+        let repository = ExternalCanisterIndexRepository::default();
+        for i in 0..10 {
+            repository.insert(ExternalCanisterIndex {
+                index: ExternalCanisterIndexKind::CanisterId(Principal::from_slice(&[i; 29])),
+                external_canister_id: [i; 16],
+            });
+        }
+
+        let result = repository.find_by_criteria(ExternalCanisterIndexCriteria {
+            from: ExternalCanisterIndexKind::CanisterId(Principal::from_slice(&[5; 29])),
+            to: ExternalCanisterIndexKind::CanisterId(Principal::from_slice(&[5; 29])),
+        });
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&[5; 16]));
+    }
+
+    #[test]
+    fn test_find_by_labels() {
+        let repository = ExternalCanisterIndexRepository::default();
+        for i in 0..10 {
+            repository.insert(ExternalCanisterIndex {
+                index: ExternalCanisterIndexKind::Label(format!("label-{}", i)),
+                external_canister_id: [i; 16],
+            });
+        }
+
+        let result = repository.find_by_criteria(ExternalCanisterIndexCriteria {
+            from: ExternalCanisterIndexKind::Label("label-5".to_string()),
+            to: ExternalCanisterIndexKind::Label("label-6".to_string()),
+        });
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&[5; 16]));
+        assert!(result.contains(&[6; 16]));
     }
 }

--- a/core/station/impl/src/repositories/indexes/external_canister_index.rs
+++ b/core/station/impl/src/repositories/indexes/external_canister_index.rs
@@ -1,0 +1,116 @@
+use crate::{
+    core::{with_memory_manager, Memory, EXTERNAL_CANISTER_INDEX_MEMORY_ID},
+    models::{
+        indexes::external_canister_index::{ExternalCanisterIndex, ExternalCanisterIndexCriteria},
+        ExternalCanisterId,
+    },
+};
+use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
+use orbit_essentials::repository::IndexRepository;
+use std::{cell::RefCell, collections::HashSet};
+
+thread_local! {
+  static DB: RefCell<StableBTreeMap<ExternalCanisterIndex, (), VirtualMemory<Memory>>> = with_memory_manager(|memory_manager| {
+    RefCell::new(
+      StableBTreeMap::init(memory_manager.get(EXTERNAL_CANISTER_INDEX_MEMORY_ID))
+    )
+  })
+}
+
+/// A repository that holds the external canisters indexes, which is used to find external canisters efficiently.
+#[derive(Default, Debug)]
+pub struct ExternalCanisterIndexRepository {}
+
+impl IndexRepository<ExternalCanisterIndex, ExternalCanisterId>
+    for ExternalCanisterIndexRepository
+{
+    type FindByCriteria = ExternalCanisterIndexCriteria;
+
+    fn exists(&self, index: &ExternalCanisterIndex) -> bool {
+        DB.with(|m| m.borrow().get(index).is_some())
+    }
+
+    fn insert(&self, index: ExternalCanisterIndex) {
+        DB.with(|m| m.borrow_mut().insert(index, ()));
+    }
+
+    fn remove(&self, index: &ExternalCanisterIndex) -> bool {
+        DB.with(|m| m.borrow_mut().remove(index).is_some())
+    }
+
+    fn find_by_criteria(&self, criteria: Self::FindByCriteria) -> HashSet<ExternalCanisterId> {
+        DB.with(|db| {
+            let start_key = ExternalCanisterIndex {
+                index: criteria.from,
+                external_canister_id: [u8::MIN; 16],
+            };
+            let end_key = ExternalCanisterIndex {
+                index: criteria.to,
+                external_canister_id: [u8::MAX; 16],
+            };
+
+            db.borrow()
+                .range(start_key..=end_key)
+                .map(|(index, _)| index.external_canister_id)
+                .collect::<HashSet<ExternalCanisterId>>()
+        })
+    }
+}
+
+impl ExternalCanisterIndexRepository {
+    pub fn len(&self) -> u64 {
+        DB.with(|m| m.borrow().len())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        DB.with(|m| m.borrow().is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        models::indexes::external_canister_index::{
+            ExternalCanisterIndex, ExternalCanisterIndexCriteria, ExternalCanisterIndexKind,
+        },
+        repositories::indexes::external_canister_index::ExternalCanisterIndexRepository,
+    };
+    use orbit_essentials::repository::IndexRepository;
+
+    #[test]
+    fn test_index_repository() {
+        let repository = ExternalCanisterIndexRepository::default();
+        let index = ExternalCanisterIndex {
+            index: ExternalCanisterIndexKind::Name("test".to_string()),
+            external_canister_id: [1; 16],
+        };
+
+        assert!(!repository.exists(&index));
+
+        repository.insert(index.clone());
+
+        assert!(repository.exists(&index));
+        assert!(repository.remove(&index));
+        assert!(!repository.exists(&index));
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let repository = ExternalCanisterIndexRepository::default();
+        for i in 0..10 {
+            repository.insert(ExternalCanisterIndex {
+                index: ExternalCanisterIndexKind::Name(format!("test-{}", i)),
+                external_canister_id: [i; 16],
+            });
+        }
+
+        let result = repository.find_by_criteria(ExternalCanisterIndexCriteria {
+            from: ExternalCanisterIndexKind::Name("test-5".to_string()),
+            to: ExternalCanisterIndexKind::Name("test-5".to_string()),
+        });
+
+        assert!(!result.is_empty());
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&[5; 16]));
+    }
+}

--- a/core/station/impl/src/repositories/indexes/external_canister_index.rs
+++ b/core/station/impl/src/repositories/indexes/external_canister_index.rs
@@ -42,16 +42,16 @@ impl IndexRepository<ExternalCanisterIndex, ExternalCanisterId>
         DB.with(|db| {
             let start_key = ExternalCanisterIndex {
                 index: criteria.from,
-                external_canister_id: [u8::MIN; 16],
+                external_canister_resource_id: [u8::MIN; 16],
             };
             let end_key = ExternalCanisterIndex {
                 index: criteria.to,
-                external_canister_id: [u8::MAX; 16],
+                external_canister_resource_id: [u8::MAX; 16],
             };
 
             db.borrow()
                 .range(start_key..=end_key)
-                .map(|(index, _)| index.external_canister_id)
+                .map(|(index, _)| index.external_canister_resource_id)
                 .collect::<HashSet<ExternalCanisterId>>()
         })
     }
@@ -83,7 +83,7 @@ mod tests {
         let repository = ExternalCanisterIndexRepository::default();
         let index = ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::Name("test".to_string()),
-            external_canister_id: [1; 16],
+            external_canister_resource_id: [1; 16],
         };
 
         assert!(!repository.exists(&index));
@@ -101,7 +101,7 @@ mod tests {
         for i in 0..10 {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Name(format!("test-{}", i)),
-                external_canister_id: [i; 16],
+                external_canister_resource_id: [i; 16],
             });
         }
 
@@ -121,7 +121,7 @@ mod tests {
         for i in 0..10 {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::CanisterId(Principal::from_slice(&[i; 29])),
-                external_canister_id: [i; 16],
+                external_canister_resource_id: [i; 16],
             });
         }
 
@@ -141,7 +141,7 @@ mod tests {
         for i in 0..10 {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Label(format!("label-{}", i)),
-                external_canister_id: [i; 16],
+                external_canister_resource_id: [i; 16],
             });
         }
 

--- a/core/station/impl/src/repositories/indexes/mod.rs
+++ b/core/station/impl/src/repositories/indexes/mod.rs
@@ -1,5 +1,6 @@
 pub mod address_book_index;
 pub mod address_book_standard_index;
+pub mod external_canister_index;
 pub mod name_to_account_id_index;
 pub mod name_to_user_id_index;
 pub mod notification_user_index;

--- a/core/station/impl/src/repositories/mod.rs
+++ b/core/station/impl/src/repositories/mod.rs
@@ -12,6 +12,9 @@ pub use user_group::*;
 pub mod account;
 pub use account::*;
 
+pub mod external_canister;
+pub use external_canister::*;
+
 pub mod transfer;
 pub use transfer::*;
 

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -2,20 +2,23 @@ use crate::core::validation::EnsureExternalCanister;
 use crate::errors::ExternalCanisterError;
 use crate::mappers::ExternalCanisterMapper;
 use crate::models::{
-    CreateExternalCanisterOperationInput, CreateExternalCanisterOperationKind, ExternalCanister,
+    ConfigureExternalCanisterSettingsInput, CreateExternalCanisterOperationInput,
+    CreateExternalCanisterOperationKind, DefiniteCanisterSettingsInput, ExternalCanister,
     ExternalCanisterId,
 };
 use crate::repositories::{ExternalCanisterRepository, EXTERNAL_CANISTER_REPOSITORY};
 use candid::{Encode, Principal};
 use ic_cdk::api::call::call_raw;
 use ic_cdk::api::management_canister::main::{
-    self as mgmt, CanisterIdRecord, CanisterStatusResponse, CreateCanisterArgument,
+    self as mgmt, delete_canister, deposit_cycles, stop_canister, update_settings,
+    CanisterIdRecord, CanisterStatusResponse, CreateCanisterArgument, UpdateSettingsArgument,
 };
 use lazy_static::lazy_static;
 use orbit_essentials::api::ServiceResult;
 use orbit_essentials::model::ModelValidator;
 use orbit_essentials::repository::Repository;
 use std::sync::Arc;
+use uuid::Uuid;
 
 lazy_static! {
     pub static ref EXTERNAL_CANISTER_SERVICE: Arc<ExternalCanisterService> = Arc::new(
@@ -35,6 +38,36 @@ impl ExternalCanisterService {
         Self {
             external_canister_repository,
         }
+    }
+
+    // Returns the external canister if found, otherwise an error.
+    pub fn get_external_canister(
+        &self,
+        id: &ExternalCanisterId,
+    ) -> ServiceResult<ExternalCanister> {
+        let resource = self
+            .external_canister_repository
+            .get(&ExternalCanister::key(*id))
+            .ok_or(ExternalCanisterError::NotFound {
+                id: Uuid::from_bytes(*id).hyphenated().to_string(),
+            })?;
+
+        Ok(resource)
+    }
+
+    // Returns the external canister by its canister id if found, otherwise an error.
+    pub fn get_external_canister_by_canister_id(
+        &self,
+        canister_id: &Principal,
+    ) -> ServiceResult<ExternalCanister> {
+        let recource_id = self
+            .external_canister_repository
+            .find_by_canister_id(canister_id)
+            .ok_or(ExternalCanisterError::InvalidExternalCanister {
+                principal: *canister_id,
+            })?;
+
+        self.get_external_canister(&recource_id)
     }
 
     pub async fn create_canister(
@@ -103,7 +136,7 @@ impl ExternalCanisterService {
         &self,
         input: CreateExternalCanisterOperationInput,
     ) -> ServiceResult<ExternalCanister> {
-        self.assert_name_is_unique(input.name.clone().as_str(), None)?;
+        self.check_unique_name(input.name.clone().as_str(), None)?;
 
         let canister_id = match &input.kind {
             CreateExternalCanisterOperationKind::CreateNew(opts) => self
@@ -115,6 +148,8 @@ impl ExternalCanisterService {
             CreateExternalCanisterOperationKind::AddExisting(opts) => {
                 EnsureExternalCanister::is_external_canister(opts.canister_id)?;
 
+                self.check_unique_canister_id(&opts.canister_id, None)?;
+
                 opts.canister_id
             }
         };
@@ -123,26 +158,170 @@ impl ExternalCanisterService {
 
         external_canister.validate()?;
 
+        // todo: add permissions and request policies handling
+
         self.external_canister_repository
             .insert(external_canister.to_key(), external_canister.clone());
 
         Ok(external_canister)
     }
 
+    /// Edits an external canister's settings.
+    pub fn edit_external_canister(
+        &self,
+        id: &ExternalCanisterId,
+        input: ConfigureExternalCanisterSettingsInput,
+    ) -> ServiceResult<ExternalCanister> {
+        let mut external_canister = self.get_external_canister(id)?;
+
+        external_canister.update_with(input);
+        external_canister.validate()?;
+
+        // todo: add permissions and request policies handling
+
+        self.external_canister_repository
+            .insert(external_canister.to_key(), external_canister.clone());
+
+        Ok(external_canister)
+    }
+
+    /// Adds cycles to the external canister, the cycles are taken from the station's balance.
+    pub async fn top_up_canister(&self, canister_id: Principal, cycles: u128) -> ServiceResult<()> {
+        if let Err((err_code, err_msg)) =
+            deposit_cycles(CanisterIdRecord { canister_id }, cycles).await
+        {
+            Err(ExternalCanisterError::Failed {
+                reason: format!(
+                    "Failed to top up canister {} with {} cycles, code: {:?} and reason: {:?}",
+                    canister_id.to_text(),
+                    cycles,
+                    err_code,
+                    err_msg
+                ),
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Only deletes the external canister from the system.
+    pub fn soft_delete_external_canister(
+        &self,
+        id: &ExternalCanisterId,
+    ) -> ServiceResult<ExternalCanister> {
+        let external_canister = self.get_external_canister(id)?;
+        self.external_canister_repository
+            .remove(&external_canister.to_key());
+
+        // todo: remove permissions and request policies
+
+        Ok(external_canister)
+    }
+
+    /// Deletes an external canister from the system, as well as from the subnet.
+    pub async fn hard_delete_external_canister(
+        &self,
+        id: &ExternalCanisterId,
+    ) -> ServiceResult<ExternalCanister> {
+        let external_canister = self.get_external_canister(id)?;
+
+        // Deleting a canister requires the canister to be stopped first.
+        //
+        // See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister
+        if let Err((err_code, err_msg)) = stop_canister(CanisterIdRecord {
+            canister_id: external_canister.canister_id,
+        })
+        .await
+        {
+            Err(ExternalCanisterError::Failed {
+                reason: format!(
+                    "Failed to stop canister {}, code: {:?} and reason: {:?}",
+                    external_canister.canister_id.to_text(),
+                    err_code,
+                    err_msg
+                ),
+            })?;
+        }
+
+        if let Err((err_code, err_msg)) = delete_canister(CanisterIdRecord {
+            canister_id: external_canister.canister_id,
+        })
+        .await
+        {
+            Err(ExternalCanisterError::Failed {
+                reason: format!(
+                    "Failed to delete canister {} from the subnet, code: {:?} and reason: {:?}",
+                    external_canister.canister_id.to_text(),
+                    err_code,
+                    err_msg
+                ),
+            })?;
+        }
+
+        // The soft delete is done after the hard delete to ensure that the external canister
+        // is removed from the subnet before it is removed from the system.
+        //
+        // The intercanister call is more likely to fail than the local operation.
+        self.soft_delete_external_canister(id)?;
+
+        Ok(external_canister)
+    }
+
+    /// Changes the IC settings of the external canister.
+    pub async fn change_canister_ic_settings(
+        &self,
+        canister_id: Principal,
+        settings: DefiniteCanisterSettingsInput,
+    ) -> ServiceResult<()> {
+        if let Err((err_code, err_msg)) = update_settings(UpdateSettingsArgument {
+            canister_id,
+            settings: settings.into(),
+        })
+        .await
+        {
+            Err(ExternalCanisterError::Failed {
+                reason: format!(
+                    "Failed to update canister {} settings, code: {:?} and reason: {:?}",
+                    canister_id.to_text(),
+                    err_code,
+                    err_msg
+                ),
+            })?;
+        }
+
+        Ok(())
+    }
+
     /// Verifies that the name is unique among external canisters.
-    fn assert_name_is_unique(
+    fn check_unique_name(
         &self,
         name: &str,
         skip_id: Option<ExternalCanisterId>,
     ) -> ServiceResult<()> {
-        if let Some(existing_id) = self.external_canister_repository.find_by_name(name) {
-            if skip_id == Some(existing_id) {
-                // The name is the same as the one being updated, so it's valid.
-                return Ok(());
-            }
-
-            return Err(ExternalCanisterError::ValidationError {
+        if !self
+            .external_canister_repository
+            .is_unique_name(name, skip_id)
+        {
+            Err(ExternalCanisterError::ValidationError {
                 info: format!("The name '{}' is already in use.", name),
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Verifies that the canister id is unique among external canisters.
+    fn check_unique_canister_id(
+        &self,
+        canister_id: &Principal,
+        skip_id: Option<ExternalCanisterId>,
+    ) -> ServiceResult<()> {
+        if !self
+            .external_canister_repository
+            .is_unique_canister_id(canister_id, skip_id)
+        {
+            Err(ExternalCanisterError::ValidationError {
+                info: format!("The canister id '{}' is already in use.", canister_id),
             })?;
         }
 

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -1,5 +1,11 @@
 use crate::core::validation::EnsureExternalCanister;
 use crate::errors::ExternalCanisterError;
+use crate::mappers::ExternalCanisterMapper;
+use crate::models::{
+    CreateExternalCanisterOperationInput, CreateExternalCanisterOperationKind, ExternalCanister,
+    ExternalCanisterId,
+};
+use crate::repositories::{ExternalCanisterRepository, EXTERNAL_CANISTER_REPOSITORY};
 use candid::{Encode, Principal};
 use ic_cdk::api::call::call_raw;
 use ic_cdk::api::management_canister::main::{
@@ -7,29 +13,46 @@ use ic_cdk::api::management_canister::main::{
 };
 use lazy_static::lazy_static;
 use orbit_essentials::api::ServiceResult;
+use orbit_essentials::model::ModelValidator;
+use orbit_essentials::repository::Repository;
 use std::sync::Arc;
 
 lazy_static! {
-    pub static ref EXTERNAL_CANISTER_SERVICE: Arc<ExternalCanisterService> =
-        Arc::new(ExternalCanisterService::default());
+    pub static ref EXTERNAL_CANISTER_SERVICE: Arc<ExternalCanisterService> = Arc::new(
+        ExternalCanisterService::new(Arc::clone(&EXTERNAL_CANISTER_REPOSITORY))
+    );
 }
 
 const CREATE_CANISTER_CYCLES: u128 = 100_000_000_000; // the default fee of 100 B cycles
 
 #[derive(Default, Debug)]
-pub struct ExternalCanisterService {}
+pub struct ExternalCanisterService {
+    external_canister_repository: Arc<ExternalCanisterRepository>,
+}
 
 impl ExternalCanisterService {
-    pub async fn create_canister(&self) -> ServiceResult<Principal, ExternalCanisterError> {
+    pub fn new(external_canister_repository: Arc<ExternalCanisterRepository>) -> Self {
+        Self {
+            external_canister_repository,
+        }
+    }
+
+    pub async fn create_canister(
+        &self,
+        cycles: Option<u128>,
+    ) -> ServiceResult<Principal, ExternalCanisterError> {
         let create_canister_arg = CreateCanisterArgument { settings: None };
 
-        let canister_id = mgmt::create_canister(create_canister_arg, CREATE_CANISTER_CYCLES)
-            .await
-            .map_err(|(_, err)| ExternalCanisterError::Failed {
-                reason: err.to_string(),
-            })?
-            .0
-            .canister_id;
+        let canister_id = mgmt::create_canister(
+            create_canister_arg,
+            cycles.unwrap_or(CREATE_CANISTER_CYCLES),
+        )
+        .await
+        .map_err(|(_, err)| ExternalCanisterError::Failed {
+            reason: err.to_string(),
+        })?
+        .0
+        .canister_id;
 
         Ok(canister_id)
     }
@@ -71,5 +94,58 @@ impl ExternalCanisterService {
         .map_err(|(_, err)| ExternalCanisterError::Failed {
             reason: err.to_string(),
         })
+    }
+
+    /// Adds a new external canister to the system.
+    ///
+    /// Can be used to create another canister to a subnet or add an existing canister.
+    pub async fn add_external_canister(
+        &self,
+        input: CreateExternalCanisterOperationInput,
+    ) -> ServiceResult<ExternalCanister> {
+        self.assert_name_is_unique(input.name.clone().as_str(), None)?;
+
+        let canister_id = match &input.kind {
+            CreateExternalCanisterOperationKind::CreateNew(opts) => self
+                .create_canister(opts.initial_cycles.map(|cycles| cycles as u128))
+                .await
+                .map_err(|err| ExternalCanisterError::Failed {
+                    reason: format!("failed to create external canister: {}", err),
+                })?,
+            CreateExternalCanisterOperationKind::AddExisting(opts) => {
+                EnsureExternalCanister::is_external_canister(opts.canister_id)?;
+
+                opts.canister_id
+            }
+        };
+
+        let external_canister = ExternalCanisterMapper::from_create_input(canister_id, input);
+
+        external_canister.validate()?;
+
+        self.external_canister_repository
+            .insert(external_canister.to_key(), external_canister.clone());
+
+        Ok(external_canister)
+    }
+
+    /// Verifies that the name is unique among external canisters.
+    fn assert_name_is_unique(
+        &self,
+        name: &str,
+        skip_id: Option<ExternalCanisterId>,
+    ) -> ServiceResult<()> {
+        if let Some(existing_id) = self.external_canister_repository.find_by_name(name) {
+            if skip_id == Some(existing_id) {
+                // The name is the same as the one being updated, so it's valid.
+                return Ok(());
+            }
+
+            return Err(ExternalCanisterError::ValidationError {
+                info: format!("The name '{}' is already in use.", name),
+            })?;
+        }
+
+        Ok(())
     }
 }

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -447,4 +447,38 @@ mod tests {
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_soft_delete_of_canister() {
+        setup();
+        let canister = EXTERNAL_CANISTER_SERVICE
+            .add_external_canister(CreateExternalCanisterOperationInput {
+                name: "test".to_string(),
+                description: None,
+                labels: None,
+                permissions: ExternalCanisterPermissionsInput {
+                    read: Allow::authenticated(),
+                    change: Allow::authenticated(),
+                    calls: Vec::new(),
+                },
+                request_policies: ExternalCanisterRequestPoliciesInput {
+                    change: None,
+                    calls: Vec::new(),
+                },
+                kind: CreateExternalCanisterOperationKind::AddExisting(
+                    CreateExternalCanisterOperationKindAddExisting {
+                        canister_id: Principal::from_slice(&[10; 29]),
+                    },
+                ),
+            })
+            .await
+            .unwrap();
+
+        let result = EXTERNAL_CANISTER_SERVICE.soft_delete_external_canister(&canister.id);
+
+        assert!(result.is_ok());
+        assert!(EXTERNAL_CANISTER_SERVICE
+            .get_external_canister(&canister.id)
+            .is_err());
+    }
 }


### PR DESCRIPTION
This initial PR adds the implementation of the external canister management.

**The following TODOs will be added in future PRs:**

- Integrate with request policies
- Integrate with permissions
- Use the service methods in the `ExternalCanisterController`
- Add integration tests for the top up and update ic settings operations
- Implement the search leveraging the indexes