### PR TITLE
feat(station): integrate request policies and external canisters

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2184,6 +2184,10 @@ type ExternalCanisterCallPermission = record {
 
 // The request policy rule for the canister call operation.
 type ExternalCanisterCallRequestPolicyRule = record {
+  // The optional id of the request policy rule.
+  //
+  // If not provided a new policy rule will be created.
+  policy_id : opt UUID;
   // The request policy rule for the canister call operation.
   rule : RequestPolicyRule;
   // The validation method that is used to match the policy against
@@ -2192,6 +2196,16 @@ type ExternalCanisterCallRequestPolicyRule = record {
   // The method name that the rule is for,
   // if `*` is used the rule applies to all methods.
   execution_method : text;
+};
+
+// The request policy rule for the canister change operation.
+type ExternalCanisterChangeRequestPolicyRule = record {
+  // The optional id of the request policy rule.
+  //
+  // If not provided a new policy rule will be created.
+  policy_id : opt UUID;
+  // The request policy rule for the canister change operation.
+  rule : RequestPolicyRule;
 };
 
 // The permissions set for the external canister.
@@ -2212,8 +2226,8 @@ type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
 
 // The request policy rules for the external canister.
 type ExternalCanisterRequestPolicies = record {
-  // The request policy rule for the canister change operation.
-  change : opt RequestPolicyRule;
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRule;
   // The request policy rules for the calling methods on the canister.
   calls : vec ExternalCanisterCallRequestPolicyRule;
 };

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -391,6 +391,7 @@ export interface ExternalCanisterCallRequestPolicyRule {
   'execution_method' : string,
   'rule' : RequestPolicyRule,
   'validation_method' : ValidationMethodResourceTarget,
+  'policy_id' : [] | [UUID],
 }
 export interface ExternalCanisterCallerMethodsPrivileges {
   'execution_method' : string,
@@ -401,6 +402,10 @@ export interface ExternalCanisterCallerPrivileges {
   'can_change' : boolean,
   'can_call' : Array<ExternalCanisterCallerMethodsPrivileges>,
 }
+export interface ExternalCanisterChangeRequestPolicyRule {
+  'rule' : RequestPolicyRule,
+  'policy_id' : [] | [UUID],
+}
 export interface ExternalCanisterPermissions {
   'calls' : Array<ExternalCanisterCallPermission>,
   'read' : Allow,
@@ -409,7 +414,7 @@ export interface ExternalCanisterPermissions {
 export type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
 export interface ExternalCanisterRequestPolicies {
   'calls' : Array<ExternalCanisterCallRequestPolicyRule>,
-  'change' : [] | [RequestPolicyRule],
+  'change' : Array<ExternalCanisterChangeRequestPolicyRule>,
 }
 export type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
 export type ExternalCanisterResourceAction = {

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -229,10 +229,15 @@ export const idlFactory = ({ IDL }) => {
     'execution_method' : IDL.Text,
     'rule' : RequestPolicyRule,
     'validation_method' : ValidationMethodResourceTarget,
+    'policy_id' : IDL.Opt(UUID),
+  });
+  const ExternalCanisterChangeRequestPolicyRule = IDL.Record({
+    'rule' : RequestPolicyRule,
+    'policy_id' : IDL.Opt(UUID),
   });
   const ExternalCanisterRequestPolicies = IDL.Record({
     'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRule),
-    'change' : IDL.Opt(RequestPolicyRule),
+    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRule),
   });
   const ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
   const ExternalCanisterState = IDL.Variant({

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2184,6 +2184,10 @@ type ExternalCanisterCallPermission = record {
 
 // The request policy rule for the canister call operation.
 type ExternalCanisterCallRequestPolicyRule = record {
+  // The optional id of the request policy rule.
+  //
+  // If not provided a new policy rule will be created.
+  policy_id : opt UUID;
   // The request policy rule for the canister call operation.
   rule : RequestPolicyRule;
   // The validation method that is used to match the policy against
@@ -2192,6 +2196,16 @@ type ExternalCanisterCallRequestPolicyRule = record {
   // The method name that the rule is for,
   // if `*` is used the rule applies to all methods.
   execution_method : text;
+};
+
+// The request policy rule for the canister change operation.
+type ExternalCanisterChangeRequestPolicyRule = record {
+  // The optional id of the request policy rule.
+  //
+  // If not provided a new policy rule will be created.
+  policy_id : opt UUID;
+  // The request policy rule for the canister change operation.
+  rule : RequestPolicyRule;
 };
 
 // The permissions set for the external canister.
@@ -2212,8 +2226,8 @@ type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
 
 // The request policy rules for the external canister.
 type ExternalCanisterRequestPolicies = record {
-  // The request policy rule for the canister change operation.
-  change : opt RequestPolicyRule;
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRule;
   // The request policy rules for the calling methods on the canister.
   calls : vec ExternalCanisterCallRequestPolicyRule;
 };

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -134,9 +134,16 @@ pub struct ExternalCanisterCallPermissionDTO {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterCallRequestPolicyRule {
+    pub policy_id: Option<UuidDTO>,
     pub rule: RequestPolicyRuleDTO,
     pub validation_method: ValidationMethodResourceTargetDTO,
     pub execution_method: String,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterChangeRequestPolicyRule {
+    pub policy_id: Option<UuidDTO>,
+    pub rule: RequestPolicyRuleDTO,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -148,7 +155,7 @@ pub struct ExternalCanisterPermissionsDTO {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterRequestPoliciesDTO {
-    pub change: Option<RequestPolicyRuleDTO>,
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRule>,
     pub calls: Vec<ExternalCanisterCallRequestPolicyRule>,
 }
 

--- a/core/station/impl/results.yml
+++ b/core/station/impl/results.yml
@@ -1,7 +1,13 @@
 benches:
+  find_external_canister_policies_are_below_query_limit:
+    total:
+      instructions: 27299957
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
   repository_batch_insert_100_requests:
     total:
-      instructions: 490228420
+      instructions: 490157820
       heap_increase: 0
       stable_memory_increase: 241
     scopes: {}
@@ -13,19 +19,19 @@ benches:
     scopes: {}
   repository_list_all_requests:
     total:
-      instructions: 98801149
-      heap_increase: 12
+      instructions: 97189374
+      heap_increase: 10
       stable_memory_increase: 0
     scopes: {}
   service_filter_all_requests_with_creation_time_filters:
     total:
-      instructions: 1151410169
+      instructions: 1151272167
       heap_increase: 0
       stable_memory_increase: 16
     scopes: {}
   service_filter_all_requests_with_default_filters:
     total:
-      instructions: 6015873885
+      instructions: 6015172658
       heap_increase: 3
       stable_memory_increase: 16
     scopes: {}

--- a/core/station/impl/src/controllers/request_policy.rs
+++ b/core/station/impl/src/controllers/request_policy.rs
@@ -56,8 +56,7 @@ impl RequestPolicyController {
             .get_request_policy(HelperMapper::to_uuid(input.id)?.as_bytes())?;
         let privileges = self
             .request_policy_service
-            .get_caller_privileges_for_request_policy(&request_policy.id, &ctx)
-            .await?;
+            .get_caller_privileges_for_request_policy(&request_policy.id, &ctx)?;
 
         Ok(GetRequestPolicyResponse {
             policy: request_policy.to_dto(),
@@ -73,15 +72,13 @@ impl RequestPolicyController {
         let ctx = call_context();
         let result = self
             .request_policy_service
-            .list_request_policies(input, &ctx)
-            .await?;
+            .list_request_policies(input, &ctx)?;
 
         let mut privileges = Vec::new();
         for policy in &result.items {
             let privilege = self
                 .request_policy_service
-                .get_caller_privileges_for_request_policy(&policy.id, &ctx)
-                .await?;
+                .get_caller_privileges_for_request_policy(&policy.id, &ctx)?;
 
             privileges.push(RequestPolicyCallerPrivilegesDTO::from(privilege));
         }

--- a/core/station/impl/src/factories/requests/add_request_policy.rs
+++ b/core/station/impl/src/factories/requests/add_request_policy.rs
@@ -68,7 +68,6 @@ impl Execute for AddRequestPolicyRequestExecute<'_, '_> {
         let policy = self
             .policy_service
             .add_request_policy(self.operation.input.to_owned())
-            .await
             .map_err(|e| RequestExecuteError::Failed {
                 reason: format!("Failed to create request policy: {}", e),
             })?;

--- a/core/station/impl/src/factories/requests/edit_request_policy.rs
+++ b/core/station/impl/src/factories/requests/edit_request_policy.rs
@@ -79,7 +79,6 @@ impl Execute for EditRequestPolicyRequestExecute<'_, '_> {
     async fn execute(&self) -> Result<RequestExecuteStage, RequestExecuteError> {
         self.policy_service
             .edit_request_policy(self.operation.input.to_owned())
-            .await
             .map_err(|e| RequestExecuteError::Failed {
                 reason: format!("Failed to update request policy: {}", e),
             })?;

--- a/core/station/impl/src/factories/requests/remove_request_policy.rs
+++ b/core/station/impl/src/factories/requests/remove_request_policy.rs
@@ -79,7 +79,6 @@ impl Execute for RemoveRequestPolicyRequestExecute<'_, '_> {
     async fn execute(&self) -> Result<RequestExecuteStage, RequestExecuteError> {
         self.policy_service
             .remove_request_policy(&self.operation.input.policy_id)
-            .await
             .map_err(|e| RequestExecuteError::Failed {
                 reason: format!("Failed to remove request policy: {}", e),
             })?;

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -24,9 +24,9 @@ use crate::{
         EditAddressBookEntryOperation, EditPermissionOperation, EditPermissionOperationInput,
         EditRequestPolicyOperation, EditRequestPolicyOperationInput, EditUserGroupOperation,
         EditUserOperation, EditUserOperationInput, ExternalCanisterCallPermission,
-        ExternalCanisterCallRequestPolicyRuleInput, ExternalCanisterPermissionsInput,
-        ExternalCanisterRequestPoliciesInput, ManageSystemInfoOperation,
-        ManageSystemInfoOperationInput, RemoveAddressBookEntryOperation,
+        ExternalCanisterCallRequestPolicyRuleInput, ExternalCanisterChangeRequestPolicyRuleInput,
+        ExternalCanisterPermissionsInput, ExternalCanisterRequestPoliciesInput,
+        ManageSystemInfoOperation, ManageSystemInfoOperationInput, RemoveAddressBookEntryOperation,
         RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, RemoveUserGroupOperation,
         RequestOperation, SetDisasterRecoveryOperation, SetDisasterRecoveryOperationInput,
         TransferOperation, User,
@@ -603,6 +603,11 @@ impl From<station_api::ExternalCanisterCallRequestPolicyRuleInput>
         input: station_api::ExternalCanisterCallRequestPolicyRuleInput,
     ) -> ExternalCanisterCallRequestPolicyRuleInput {
         ExternalCanisterCallRequestPolicyRuleInput {
+            policy_id: input.policy_id.map(|policy_id| {
+                *HelperMapper::to_uuid(policy_id)
+                    .expect("Invalid policy id format")
+                    .as_bytes()
+            }),
             rule: input.rule.into(),
             validation_method: input.validation_method.into(),
             execution_method: input.execution_method,
@@ -617,9 +622,44 @@ impl From<ExternalCanisterCallRequestPolicyRuleInput>
         input: ExternalCanisterCallRequestPolicyRuleInput,
     ) -> station_api::ExternalCanisterCallRequestPolicyRuleInput {
         station_api::ExternalCanisterCallRequestPolicyRuleInput {
+            policy_id: input
+                .policy_id
+                .map(|policy_id| Uuid::from_bytes(policy_id).hyphenated().to_string()),
             rule: input.rule.into(),
             validation_method: input.validation_method.into(),
             execution_method: input.execution_method,
+        }
+    }
+}
+
+impl From<station_api::ExternalCanisterChangeRequestPolicyRule>
+    for ExternalCanisterChangeRequestPolicyRuleInput
+{
+    fn from(
+        input: station_api::ExternalCanisterChangeRequestPolicyRule,
+    ) -> ExternalCanisterChangeRequestPolicyRuleInput {
+        ExternalCanisterChangeRequestPolicyRuleInput {
+            policy_id: input.policy_id.map(|policy_id| {
+                *HelperMapper::to_uuid(policy_id)
+                    .expect("Invalid policy id format")
+                    .as_bytes()
+            }),
+            rule: input.rule.into(),
+        }
+    }
+}
+
+impl From<ExternalCanisterChangeRequestPolicyRuleInput>
+    for station_api::ExternalCanisterChangeRequestPolicyRule
+{
+    fn from(
+        input: ExternalCanisterChangeRequestPolicyRuleInput,
+    ) -> station_api::ExternalCanisterChangeRequestPolicyRule {
+        station_api::ExternalCanisterChangeRequestPolicyRule {
+            policy_id: input
+                .policy_id
+                .map(|policy_id| Uuid::from_bytes(policy_id).hyphenated().to_string()),
+            rule: input.rule.into(),
         }
     }
 }
@@ -631,7 +671,7 @@ impl From<station_api::ExternalCanisterRequestPoliciesInput>
         input: station_api::ExternalCanisterRequestPoliciesInput,
     ) -> ExternalCanisterRequestPoliciesInput {
         ExternalCanisterRequestPoliciesInput {
-            change: input.change.map(Into::into),
+            change: input.change.into_iter().map(Into::into).collect(),
             calls: input.calls.into_iter().map(Into::into).collect(),
         }
     }
@@ -644,7 +684,7 @@ impl From<ExternalCanisterRequestPoliciesInput>
         input: ExternalCanisterRequestPoliciesInput,
     ) -> station_api::ExternalCanisterRequestPoliciesInput {
         station_api::ExternalCanisterRequestPoliciesInput {
-            change: input.change.map(Into::into),
+            change: input.change.into_iter().map(Into::into).collect(),
             calls: input.calls.into_iter().map(Into::into).collect(),
         }
     }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -347,6 +347,7 @@ pub struct ExternalCanisterPermissionsInput {
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExternalCanisterCallRequestPolicyRuleInput {
+    pub policy_id: Option<UUID>,
     pub rule: RequestPolicyRule,
     pub validation_method: ValidationMethodResourceTarget,
     pub execution_method: String,
@@ -354,8 +355,15 @@ pub struct ExternalCanisterCallRequestPolicyRuleInput {
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterChangeRequestPolicyRuleInput {
+    pub policy_id: Option<UUID>,
+    pub rule: RequestPolicyRule,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExternalCanisterRequestPoliciesInput {
-    pub change: Option<RequestPolicyRule>,
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
     pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
 }
 

--- a/core/station/impl/src/repositories/indexes/request_policy_resource_index.rs
+++ b/core/station/impl/src/repositories/indexes/request_policy_resource_index.rs
@@ -1,9 +1,18 @@
 use crate::{
     core::{with_memory_manager, Memory, POLICY_RESOURCE_INDEX_MEMORY_ID},
-    models::indexes::request_policy_resource_index::{
-        RequestPolicyResourceIndex, RequestPolicyResourceIndexCriteria,
+    models::{
+        indexes::request_policy_resource_index::{
+            RequestPolicyResourceIndex, RequestPolicyResourceIndexCriteria,
+        },
+        resource::{
+            CallExternalCanisterResourceTarget, ChangeExternalCanisterResourceTarget,
+            ExecutionMethodResourceTarget, ExternalCanisterResourceAction, Resource,
+            ValidationMethodResourceTarget,
+        },
+        CanisterMethod,
     },
 };
+use candid::Principal;
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
 use orbit_essentials::{repository::IndexRepository, types::UUID};
 use std::{cell::RefCell, collections::HashSet};
@@ -69,6 +78,82 @@ impl IndexRepository<RequestPolicyResourceIndex, UUID> for RequestPolicyResource
     }
 }
 
+impl RequestPolicyResourceIndexRepository {
+    /// Finds all external canister policies related to the specified canister id.
+    ///
+    /// Includes:
+    ///
+    /// - `Change` related policies.
+    /// - `Call` related policies.
+    pub fn find_external_canister_policies(&self, canister_id: &Principal) -> Vec<UUID> {
+        DB.with(|db| {
+            let mut policies = Vec::new();
+            // Find all change related policies for the specified canister id.
+            policies.extend(
+                db.borrow()
+                    .range(
+                        (RequestPolicyResourceIndex {
+                            resource: Resource::ExternalCanister(
+                                ExternalCanisterResourceAction::Change(
+                                    ChangeExternalCanisterResourceTarget::Canister(*canister_id),
+                                ),
+                            ),
+                            policy_id: [u8::MIN; 16],
+                        })..(RequestPolicyResourceIndex {
+                            resource: Resource::ExternalCanister(
+                                ExternalCanisterResourceAction::Change(
+                                    ChangeExternalCanisterResourceTarget::Canister(*canister_id),
+                                ),
+                            ),
+                            policy_id: [u8::MAX; 16],
+                        }),
+                    )
+                    .map(|(index, _)| index.policy_id)
+                    .collect::<Vec<UUID>>(),
+            );
+
+            // Find all call related policies for the specified canister id.
+            policies.extend(
+                db.borrow()
+                .range(
+                    (RequestPolicyResourceIndex {
+                        resource: Resource::ExternalCanister(ExternalCanisterResourceAction::Call(
+                            CallExternalCanisterResourceTarget {
+                                execution_method: ExecutionMethodResourceTarget::ExecutionMethod(
+                                    CanisterMethod {
+                                        canister_id: *canister_id,
+                                        method_name: String::new(),
+                                    },
+                                ),
+                                validation_method: ValidationMethodResourceTarget::No,
+                            },
+                        )),
+                        policy_id: [u8::MIN; 16],
+                    })..,
+                )
+                .take_while(|(index, _)| {
+                    matches!(
+                        &index.resource,
+                        Resource::ExternalCanister(ExternalCanisterResourceAction::Call(
+                            CallExternalCanisterResourceTarget {
+                                execution_method: ExecutionMethodResourceTarget::ExecutionMethod(
+                                    CanisterMethod { canister_id: id, .. }
+                                ),
+                                ..
+                            }
+                        ))
+                        if id == canister_id
+                    )
+                })
+                .map(|(index, _)| index.policy_id)
+                .collect::<Vec<UUID>>()
+            );
+
+            policies
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::models::resource::{Resource, UserResourceAction};
@@ -110,5 +195,53 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert!(result.contains(&index.policy_id));
+    }
+
+    #[test]
+    fn test_find_external_canister_policies() {
+        let repository = RequestPolicyResourceIndexRepository::default();
+        for i in 0..10 {
+            let index = RequestPolicyResourceIndex {
+                resource: Resource::ExternalCanister(ExternalCanisterResourceAction::Change(
+                    ChangeExternalCanisterResourceTarget::Canister(Principal::from_slice(
+                        &[i % 2; 29],
+                    )),
+                )),
+                policy_id: [i; 16],
+            };
+
+            repository.insert(index);
+        }
+
+        let policies = repository.find_external_canister_policies(&Principal::from_slice(&[1; 29]));
+
+        assert_eq!(policies.len(), 5);
+    }
+
+    #[test]
+    fn test_find_external_canister_policies_with_call() {
+        let repository = RequestPolicyResourceIndexRepository::default();
+        for i in 0..10 {
+            let index = RequestPolicyResourceIndex {
+                resource: Resource::ExternalCanister(ExternalCanisterResourceAction::Call(
+                    CallExternalCanisterResourceTarget {
+                        execution_method: ExecutionMethodResourceTarget::ExecutionMethod(
+                            CanisterMethod {
+                                canister_id: Principal::from_slice(&[i % 2; 29]),
+                                method_name: format!("method_{}", i),
+                            },
+                        ),
+                        validation_method: ValidationMethodResourceTarget::No,
+                    },
+                )),
+                policy_id: [i; 16],
+            };
+
+            repository.insert(index);
+        }
+
+        let policies = repository.find_external_canister_policies(&Principal::from_slice(&[1; 29]));
+
+        assert_eq!(policies.len(), 5);
     }
 }

--- a/core/station/impl/src/repositories/request_policy.rs
+++ b/core/station/impl/src/repositories/request_policy.rs
@@ -8,6 +8,7 @@ use crate::{
         resource::Resource, RequestPolicy,
     },
 };
+use candid::Principal;
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
 use lazy_static::lazy_static;
 use orbit_essentials::repository::{IndexRepository, RefreshIndexMode, Repository};
@@ -104,6 +105,17 @@ impl RequestPolicyRepository {
             .find_by_criteria(RequestPolicyResourceIndexCriteria { resource });
 
         ids.iter().filter_map(|id| self.get(id)).collect()
+    }
+
+    /// Finds all external canister policies related to the specified canister id.
+    ///
+    /// Includes:
+    ///
+    /// - `Change` related policies.
+    /// - `Call` related policies.
+    pub fn find_external_canister_policies(&self, canister_id: &Principal) -> Vec<UUID> {
+        self.resource_index
+            .find_external_canister_policies(canister_id)
     }
 }
 

--- a/core/station/impl/src/repositories/request_policy.rs
+++ b/core/station/impl/src/repositories/request_policy.rs
@@ -249,6 +249,7 @@ mod tests {
 
 #[cfg(feature = "canbench")]
 mod benchs {
+    use super::*;
     use crate::models::{
         request_specifier::RequestSpecifier,
         resource::{
@@ -257,7 +258,6 @@ mod benchs {
         },
         CanisterMethod, RequestPolicyRule,
     };
-    use super::*;
     use canbench_rs::{bench, BenchResult};
     use uuid::Uuid;
 

--- a/core/station/impl/src/services/account.rs
+++ b/core/station/impl/src/services/account.rs
@@ -180,28 +180,28 @@ impl AccountService {
 
         // adds the associated transfer policy based on the transfer criteria
         if let Some(policy_rule) = &input.transfer_request_policy {
-            let transfer_request_policy = self
-                .request_policy_service
-                .add_request_policy(AddRequestPolicyOperationInput {
-                    specifier: RequestSpecifier::Transfer(ResourceIds::Ids(vec![*uuid.as_bytes()])),
-                    rule: policy_rule.clone(),
-                })
-                .await?;
+            let transfer_request_policy =
+                self.request_policy_service
+                    .add_request_policy(AddRequestPolicyOperationInput {
+                        specifier: RequestSpecifier::Transfer(ResourceIds::Ids(vec![
+                            *uuid.as_bytes()
+                        ])),
+                        rule: policy_rule.clone(),
+                    })?;
 
             new_account.transfer_request_policy_id = Some(transfer_request_policy.id);
         }
 
         // adds the associated edit policy based on the edit criteria
         if let Some(policy_rule) = &input.configs_request_policy {
-            let configs_request_policy = self
-                .request_policy_service
-                .add_request_policy(AddRequestPolicyOperationInput {
-                    specifier: RequestSpecifier::EditAccount(ResourceIds::Ids(vec![
-                        *uuid.as_bytes()
-                    ])),
-                    rule: policy_rule.to_owned(),
-                })
-                .await?;
+            let configs_request_policy =
+                self.request_policy_service
+                    .add_request_policy(AddRequestPolicyOperationInput {
+                        specifier: RequestSpecifier::EditAccount(ResourceIds::Ids(vec![
+                            *uuid.as_bytes()
+                        ])),
+                        rule: policy_rule.to_owned(),
+                    })?;
 
             new_account.configs_request_policy_id = Some(configs_request_policy.id);
         }
@@ -280,23 +280,19 @@ impl AccountService {
         };
 
         if let Some(transfer_request_policy_input) = input.transfer_request_policy {
-            self.request_policy_service
-                .handle_policy_change(
-                    RequestSpecifier::Transfer(ResourceIds::Ids(vec![account.id])),
-                    transfer_request_policy_input,
-                    &mut account.transfer_request_policy_id,
-                )
-                .await?;
+            self.request_policy_service.handle_policy_change(
+                RequestSpecifier::Transfer(ResourceIds::Ids(vec![account.id])),
+                transfer_request_policy_input,
+                &mut account.transfer_request_policy_id,
+            )?;
         }
 
         if let Some(configs_request_policy_input) = input.configs_request_policy {
-            self.request_policy_service
-                .handle_policy_change(
-                    RequestSpecifier::EditAccount(ResourceIds::Ids(vec![account.id])),
-                    configs_request_policy_input,
-                    &mut account.configs_request_policy_id,
-                )
-                .await?;
+            self.request_policy_service.handle_policy_change(
+                RequestSpecifier::EditAccount(ResourceIds::Ids(vec![account.id])),
+                configs_request_policy_input,
+                &mut account.configs_request_policy_id,
+            )?;
         }
 
         account.validate()?;

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -1,21 +1,27 @@
 use super::permission::{PermissionService, PERMISSION_SERVICE};
+use super::request_policy::{RequestPolicyService, REQUEST_POLICY_SERVICE};
 use crate::core::ic_cdk::api::print;
 use crate::core::validation::EnsureExternalCanister;
 use crate::errors::ExternalCanisterError;
 use crate::mappers::ExternalCanisterMapper;
+use crate::models::request_specifier::RequestSpecifier;
 use crate::models::resource::{
     CallExternalCanisterResourceTarget, ChangeExternalCanisterResourceTarget,
     ExecutionMethodResourceTarget, ExternalCanisterResourceAction,
-    ReadExternalCanisterResourceTarget, Resource,
+    ReadExternalCanisterResourceTarget, Resource, ValidationMethodResourceTarget,
 };
 use crate::models::{
-    CanisterMethod, ConfigureExternalCanisterSettingsInput, CreateExternalCanisterOperationInput,
-    CreateExternalCanisterOperationKind, DefiniteCanisterSettingsInput,
-    EditPermissionOperationInput, ExternalCanister, ExternalCanisterId,
-    ExternalCanisterPermissionsInput,
+    AddRequestPolicyOperationInput, CanisterMethod, ConfigureExternalCanisterSettingsInput,
+    CreateExternalCanisterOperationInput, CreateExternalCanisterOperationKind,
+    DefiniteCanisterSettingsInput, EditPermissionOperationInput, EditRequestPolicyOperationInput,
+    ExternalCanister, ExternalCanisterId, ExternalCanisterPermissionsInput,
+    ExternalCanisterRequestPoliciesInput,
 };
 use crate::repositories::permission::{PermissionRepository, PERMISSION_REPOSITORY};
-use crate::repositories::{ExternalCanisterRepository, EXTERNAL_CANISTER_REPOSITORY};
+use crate::repositories::{
+    ExternalCanisterRepository, RequestPolicyRepository, EXTERNAL_CANISTER_REPOSITORY,
+    REQUEST_POLICY_REPOSITORY,
+};
 use candid::{Encode, Principal};
 use ic_cdk::api::call::call_raw;
 use ic_cdk::api::management_canister::main::{
@@ -26,6 +32,8 @@ use lazy_static::lazy_static;
 use orbit_essentials::api::ServiceResult;
 use orbit_essentials::model::ModelValidator;
 use orbit_essentials::repository::Repository;
+use orbit_essentials::types::UUID;
+use std::collections::HashSet;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -35,6 +43,8 @@ lazy_static! {
             Arc::clone(&EXTERNAL_CANISTER_REPOSITORY),
             Arc::clone(&PERMISSION_SERVICE),
             Arc::clone(&PERMISSION_REPOSITORY),
+            Arc::clone(&REQUEST_POLICY_SERVICE),
+            Arc::clone(&REQUEST_POLICY_REPOSITORY),
         ));
 }
 
@@ -45,6 +55,8 @@ pub struct ExternalCanisterService {
     external_canister_repository: Arc<ExternalCanisterRepository>,
     permission_service: Arc<PermissionService>,
     permission_repository: Arc<PermissionRepository>,
+    request_policy_service: Arc<RequestPolicyService>,
+    request_policy_repository: Arc<RequestPolicyRepository>,
 }
 
 impl ExternalCanisterService {
@@ -52,11 +64,15 @@ impl ExternalCanisterService {
         external_canister_repository: Arc<ExternalCanisterRepository>,
         permission_service: Arc<PermissionService>,
         permission_repository: Arc<PermissionRepository>,
+        request_policy_service: Arc<RequestPolicyService>,
+        request_policy_repository: Arc<RequestPolicyRepository>,
     ) -> Self {
         Self {
             external_canister_repository,
             permission_service,
             permission_repository,
+            request_policy_service,
+            request_policy_repository,
         }
     }
 
@@ -195,8 +211,10 @@ impl ExternalCanisterService {
             .insert(external_canister.to_key(), external_canister.clone());
 
         self.configure_external_canister_permissions(&external_canister, input.permissions)?;
-
-        // todo: add request policies handling
+        self.configure_external_canister_request_policies(
+            &external_canister,
+            input.request_policies,
+        )?;
 
         Ok(external_canister)
     }
@@ -268,6 +286,133 @@ impl ExternalCanisterService {
         Ok(())
     }
 
+    fn configure_external_canister_request_policies(
+        &self,
+        external_canister: &ExternalCanister,
+        input: ExternalCanisterRequestPoliciesInput,
+    ) -> ServiceResult<()> {
+        let current_policies: HashSet<UUID> = self
+            .request_policy_repository
+            .find_external_canister_policies(&external_canister.canister_id)
+            .into_iter()
+            .collect();
+
+        // if the updated list of policies does not contain the current policy, remove it from the system
+        let policies_to_remove = current_policies
+            .iter()
+            .filter(|policy_id| {
+                !input
+                    .calls
+                    .iter()
+                    .any(|policy| policy.policy_id == Some(**policy_id))
+                    || !input
+                        .change
+                        .iter()
+                        .any(|policy| policy.policy_id == Some(**policy_id))
+            })
+            .collect::<Vec<&UUID>>();
+
+        for policy_id in policies_to_remove {
+            self.request_policy_service
+                .remove_request_policy(policy_id)?;
+        }
+
+        // add or update the `Change` policies
+        for policy in input.change {
+            match policy.policy_id {
+                Some(policy_id) => {
+                    if !current_policies.contains(&policy_id) {
+                        print(format!(
+                            "Policy with id {} not found for external canister {}",
+                            Uuid::from_bytes(policy_id).hyphenated(),
+                            external_canister.canister_id.to_text()
+                        ));
+
+                        continue;
+                    }
+
+                    self.request_policy_service.edit_request_policy(
+                        EditRequestPolicyOperationInput {
+                            policy_id,
+                            rule: Some(policy.rule),
+                            specifier: None,
+                        },
+                    )?;
+                }
+                None => {
+                    self.request_policy_service.add_request_policy(
+                        AddRequestPolicyOperationInput {
+                            rule: policy.rule,
+                            specifier: RequestSpecifier::ChangeExternalCanister(
+                                ChangeExternalCanisterResourceTarget::Canister(
+                                    external_canister.canister_id,
+                                ),
+                            ),
+                        },
+                    )?;
+                }
+            }
+        }
+
+        // add or update the `Call` policies
+        for policy in input.calls {
+            match policy.policy_id {
+                Some(policy_id) => {
+                    if !current_policies.contains(&policy_id) {
+                        print(format!(
+                            "Policy with id {} not found for external canister {}",
+                            Uuid::from_bytes(policy_id).hyphenated(),
+                            external_canister.canister_id.to_text()
+                        ));
+
+                        continue;
+                    }
+
+                    self.request_policy_service.edit_request_policy(
+                        EditRequestPolicyOperationInput {
+                            policy_id,
+                            rule: Some(policy.rule),
+                            specifier: None,
+                        },
+                    )?;
+                }
+                None => {
+                    if let ValidationMethodResourceTarget::ValidationMethod(validation) =
+                        &policy.validation_method
+                    {
+                        if validation.canister_id == external_canister.canister_id
+                            && validation.method_name == policy.execution_method
+                        {
+                            Err(ExternalCanisterError::ValidationError {
+                                info: format!("The validation method `{}` cannot be the same as the execution method.", policy.execution_method),
+                            })?;
+                        }
+                    }
+
+                    self.request_policy_service.add_request_policy(
+                        AddRequestPolicyOperationInput {
+                            rule: policy.rule,
+                            specifier: RequestSpecifier::CallExternalCanister(
+                                CallExternalCanisterResourceTarget {
+                                    execution_method:
+                                        ExecutionMethodResourceTarget::ExecutionMethod(
+                                            CanisterMethod {
+                                                canister_id: external_canister.canister_id,
+                                                method_name: policy.execution_method,
+                                            },
+                                        ),
+                                    validation_method: policy.validation_method,
+                                },
+                            ),
+                        },
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Edits an external canister's settings.
     pub fn edit_external_canister(
         &self,
@@ -279,13 +424,18 @@ impl ExternalCanisterService {
         external_canister.update_with(input.clone());
         external_canister.validate()?;
 
-        // todo: request policies handling
-
         self.external_canister_repository
             .insert(external_canister.to_key(), external_canister.clone());
 
         if let Some(updated_permissions) = input.permissions {
             self.configure_external_canister_permissions(&external_canister, updated_permissions)?;
+        }
+
+        if let Some(updated_request_policies) = input.request_policies {
+            self.configure_external_canister_request_policies(
+                &external_canister,
+                updated_request_policies,
+            )?;
         }
 
         Ok(external_canister)
@@ -319,7 +469,29 @@ impl ExternalCanisterService {
         self.external_canister_repository
             .remove(&external_canister.to_key());
 
-        // todo: remove permissions and request policies
+        // Remove all permissions related to the external canister.
+        self.permission_repository
+            .find_external_canister_call_permissions(&external_canister.canister_id)
+            .iter()
+            .for_each(|permission| {
+                self.permission_service
+                    .remove_permission(&permission.resource);
+            });
+
+        // Remove all request policies related to the external canister.
+        self.request_policy_repository
+            .find_external_canister_policies(&external_canister.canister_id)
+            .iter()
+            .for_each(|policy_id| {
+                if let Err(err) = self.request_policy_service.remove_request_policy(policy_id) {
+                    // This can be ignored to not block the deletion of the external canister.
+                    print(format!(
+                        "Failed to remove request policy with id {}, reason: {}",
+                        Uuid::from_bytes(*policy_id).hyphenated(),
+                        err
+                    ));
+                }
+            });
 
         Ok(external_canister)
     }
@@ -441,13 +613,17 @@ impl ExternalCanisterService {
 
 #[cfg(test)]
 mod tests {
+    use orbit_essentials::api::ApiError;
+
     use super::*;
     use crate::{
         core::test_utils,
         models::{
             permission::Allow, resource::ValidationMethodResourceTarget,
             CreateExternalCanisterOperationKindAddExisting, ExternalCanisterCallPermission,
-            ExternalCanisterPermissionsInput, ExternalCanisterRequestPoliciesInput,
+            ExternalCanisterCallRequestPolicyRuleInput,
+            ExternalCanisterChangeRequestPolicyRuleInput, ExternalCanisterPermissionsInput,
+            ExternalCanisterRequestPoliciesInput, RequestPolicyRule,
         },
     };
 
@@ -485,8 +661,16 @@ mod tests {
                     ],
                 },
                 request_policies: ExternalCanisterRequestPoliciesInput {
-                    change: None,
-                    calls: Vec::new(),
+                    change: vec![ExternalCanisterChangeRequestPolicyRuleInput {
+                        policy_id: None,
+                        rule: RequestPolicyRule::AutoApproved,
+                    }],
+                    calls: vec![ExternalCanisterCallRequestPolicyRuleInput {
+                        policy_id: None,
+                        execution_method: "test".to_string(),
+                        validation_method: ValidationMethodResourceTarget::No,
+                        rule: RequestPolicyRule::AutoApproved,
+                    }],
                 },
                 kind: CreateExternalCanisterOperationKind::AddExisting(
                     CreateExternalCanisterOperationKindAddExisting {
@@ -533,6 +717,117 @@ mod tests {
         for permission in call_permission {
             assert!(permission.allowed_authenticated());
         }
+
+        let request_policies = REQUEST_POLICY_REPOSITORY
+            .find_external_canister_policies(&external_canister.canister_id);
+
+        assert_eq!(request_policies.len(), 2);
+
+        for policy in request_policies {
+            let policy = REQUEST_POLICY_REPOSITORY.get(&policy).unwrap();
+
+            assert_eq!(policy.rule, RequestPolicyRule::AutoApproved);
+        }
+    }
+
+    #[tokio::test]
+    async fn add_external_canister_with_non_compatible_policy_is_ignored() {
+        setup();
+        let incompatible_policy = REQUEST_POLICY_SERVICE
+            .add_request_policy(AddRequestPolicyOperationInput {
+                rule: RequestPolicyRule::AutoApproved,
+                specifier: RequestSpecifier::ChangeExternalCanister(
+                    ChangeExternalCanisterResourceTarget::Canister(Principal::from_slice(&[1; 29])),
+                ),
+            })
+            .unwrap();
+
+        let external_canister = EXTERNAL_CANISTER_SERVICE
+            .add_external_canister(CreateExternalCanisterOperationInput {
+                name: "test".to_string(),
+                description: None,
+                labels: None,
+                permissions: ExternalCanisterPermissionsInput {
+                    read: Allow::authenticated(),
+                    change: Allow::authenticated(),
+                    calls: Vec::new(),
+                },
+                request_policies: ExternalCanisterRequestPoliciesInput {
+                    change: vec![ExternalCanisterChangeRequestPolicyRuleInput {
+                        policy_id: Some(incompatible_policy.id),
+                        rule: RequestPolicyRule::AutoApproved,
+                    }],
+                    calls: Vec::new(),
+                },
+                kind: CreateExternalCanisterOperationKind::AddExisting(
+                    CreateExternalCanisterOperationKindAddExisting {
+                        canister_id: Principal::from_slice(&[10; 29]),
+                    },
+                ),
+            })
+            .await
+            .unwrap();
+
+        let request_policies = REQUEST_POLICY_REPOSITORY
+            .find_external_canister_policies(&external_canister.canister_id);
+
+        assert!(request_policies.is_empty());
+
+        let policy = REQUEST_POLICY_REPOSITORY
+            .get(&incompatible_policy.id)
+            .unwrap();
+
+        assert_eq!(
+            policy.specifier,
+            RequestSpecifier::ChangeExternalCanister(
+                ChangeExternalCanisterResourceTarget::Canister(Principal::from_slice(&[1; 29])),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn same_validation_and_execution_method_should_fail() {
+        setup();
+        let result = EXTERNAL_CANISTER_SERVICE
+            .add_external_canister(CreateExternalCanisterOperationInput {
+                name: "test".to_string(),
+                description: None,
+                labels: None,
+                permissions: ExternalCanisterPermissionsInput {
+                    read: Allow::authenticated(),
+                    change: Allow::authenticated(),
+                    calls: Vec::new(),
+                },
+                request_policies: ExternalCanisterRequestPoliciesInput {
+                    change: Vec::new(),
+                    calls: vec![ExternalCanisterCallRequestPolicyRuleInput {
+                        policy_id: None,
+                        execution_method: "test".to_string(),
+                        validation_method: ValidationMethodResourceTarget::ValidationMethod(
+                            CanisterMethod {
+                                canister_id: Principal::from_slice(&[10; 29]),
+                                method_name: "test".to_string(),
+                            },
+                        ),
+                        rule: RequestPolicyRule::AutoApproved,
+                    }],
+                },
+                kind: CreateExternalCanisterOperationKind::AddExisting(
+                    CreateExternalCanisterOperationKindAddExisting {
+                        canister_id: Principal::from_slice(&[10; 29]),
+                    },
+                ),
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            ApiError::from(ExternalCanisterError::ValidationError {
+                info: "The validation method `test` cannot be the same as the execution method."
+                    .to_string()
+            })
+        );
     }
 
     #[tokio::test]
@@ -550,7 +845,7 @@ mod tests {
                         calls: Vec::new(),
                     },
                     request_policies: ExternalCanisterRequestPoliciesInput {
-                        change: None,
+                        change: Vec::new(),
                         calls: Vec::new(),
                     },
                     kind: CreateExternalCanisterOperationKind::AddExisting(
@@ -584,7 +879,7 @@ mod tests {
                         calls: Vec::new(),
                     },
                     request_policies: ExternalCanisterRequestPoliciesInput {
-                        change: None,
+                        change: Vec::new(),
                         calls: Vec::new(),
                     },
                     kind: CreateExternalCanisterOperationKind::AddExisting(
@@ -617,7 +912,7 @@ mod tests {
                     calls: Vec::new(),
                 },
                 request_policies: ExternalCanisterRequestPoliciesInput {
-                    change: None,
+                    change: Vec::new(),
                     calls: Vec::new(),
                 },
                 kind: CreateExternalCanisterOperationKind::AddExisting(
@@ -655,7 +950,7 @@ mod tests {
                     }],
                 },
                 request_policies: ExternalCanisterRequestPoliciesInput {
-                    change: None,
+                    change: Vec::new(),
                     calls: Vec::new(),
                 },
                 kind: CreateExternalCanisterOperationKind::AddExisting(
@@ -681,7 +976,7 @@ mod tests {
                         calls: Vec::new(),
                     }),
                     request_policies: Some(ExternalCanisterRequestPoliciesInput {
-                        change: None,
+                        change: Vec::new(),
                         calls: Vec::new(),
                     }),
                 },

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -469,6 +469,21 @@ impl ExternalCanisterService {
         self.external_canister_repository
             .remove(&external_canister.to_key());
 
+        // Removes the read & change permissions.
+        self.permission_service
+            .remove_permission(&Resource::ExternalCanister(
+                ExternalCanisterResourceAction::Read(ReadExternalCanisterResourceTarget::Canister(
+                    external_canister.canister_id,
+                )),
+            ));
+
+        self.permission_service
+            .remove_permission(&Resource::ExternalCanister(
+                ExternalCanisterResourceAction::Change(
+                    ChangeExternalCanisterResourceTarget::Canister(external_canister.canister_id),
+                ),
+            ));
+
         // Remove all permissions related to the external canister.
         self.permission_repository
             .find_external_canister_call_permissions(&external_canister.canister_id)

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -412,7 +412,6 @@ mod install_canister_handlers {
                     specifier: policy.0.to_owned(),
                     rule: policy.1.to_owned(),
                 })
-                .await
                 .map_err(|e| format!("Failed to add default request policy: {:?}", e))?;
         }
 

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -396,7 +396,7 @@ fn create_external_canister_and_check_status() {
                 },
             },
             request_policies: ExternalCanisterRequestPoliciesInput {
-                change: None,
+                change: Vec::new(),
                 calls: vec![],
             },
         });


### PR DESCRIPTION
This PR integrates the request policies with the external canisters.

**Note:** i've also removed the async need in the request policy service methods.