### PR TITLE
feat(station): add external canister endpoints

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2307,14 +2307,24 @@ type GetExternalCanisterResult = variant {
   Err : Error;
 };
 
+// The input type for sorting the results of listing external canisters.
+type ListExternalCanistersSortInput = variant {
+  // Sort by the name of the external canister.
+  Name : SortByDirection;
+};
+
 // Input type for listing external canisters with the given filters.
 type ListExternalCanistersInput = record {
   // The principal id of the external canister to search for.
   canister_ids : opt vec principal;
   // The labels to use for filtering the external canisters.
   labels : opt vec text;
+  // The current state of the external canisters to use for filtering (e.g. `Active`, `Archived`).
+  states : opt vec ExternalCanisterState;
   // The pagination parameters.
   paginate : opt PaginationInput;
+  // The sort parameters.
+  sort_by : opt ListExternalCanistersSortInput;
 };
 
 // Result type for listing external canisters.

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2287,8 +2287,10 @@ type ExternalCanisterCallerMethodsPrivileges = record {
 
 // The caller privileges for the external canister.
 type ExternalCanisterCallerPrivileges = record {
-  // The external canister retource id.
+  // The external canister entry id.
   id : UUID;
+  // The canister id.
+  canister_id : principal;
   // Wether or not the caller can edit the external canister.
   can_change : bool;
   // The list of methods that the caller can call on the external canister.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -400,6 +400,7 @@ export interface ExternalCanisterCallerMethodsPrivileges {
 export interface ExternalCanisterCallerPrivileges {
   'id' : UUID,
   'can_change' : boolean,
+  'canister_id' : Principal,
   'can_call' : Array<ExternalCanisterCallerMethodsPrivileges>,
 }
 export interface ExternalCanisterChangeRequestPolicyRule {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -572,6 +572,8 @@ export type ListAddressBookEntriesResult = {
   } |
   { 'Err' : Error };
 export interface ListExternalCanistersInput {
+  'sort_by' : [] | [ListExternalCanistersSortInput],
+  'states' : [] | [Array<ExternalCanisterState>],
   'canister_ids' : [] | [Array<Principal>],
   'labels' : [] | [Array<string>],
   'paginate' : [] | [PaginationInput],
@@ -585,6 +587,7 @@ export type ListExternalCanistersResult = {
     }
   } |
   { 'Err' : Error };
+export type ListExternalCanistersSortInput = { 'Name' : SortByDirection };
 export interface ListNotificationsInput {
   'status' : [] | [NotificationStatus],
   'to_dt' : [] | [TimestampRFC3339],

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -987,7 +987,13 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Err' : Error,
   });
+  const SortByDirection = IDL.Variant({ 'Asc' : IDL.Null, 'Desc' : IDL.Null });
+  const ListExternalCanistersSortInput = IDL.Variant({
+    'Name' : SortByDirection,
+  });
   const ListExternalCanistersInput = IDL.Record({
+    'sort_by' : IDL.Opt(ListExternalCanistersSortInput),
+    'states' : IDL.Opt(IDL.Vec(ExternalCanisterState)),
     'canister_ids' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),
     'paginate' : IDL.Opt(PaginationInput),
@@ -1101,7 +1107,6 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Err' : Error,
   });
-  const SortByDirection = IDL.Variant({ 'Asc' : IDL.Null, 'Desc' : IDL.Null });
   const ListRequestsSortBy = IDL.Variant({
     'ExpirationDt' : SortByDirection,
     'LastModificationDt' : SortByDirection,

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -755,6 +755,7 @@ export const idlFactory = ({ IDL }) => {
   const ExternalCanisterCallerPrivileges = IDL.Record({
     'id' : UUID,
     'can_change' : IDL.Bool,
+    'canister_id' : IDL.Principal,
     'can_call' : IDL.Vec(ExternalCanisterCallerMethodsPrivileges),
   });
   const ExternalCanister = IDL.Record({

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2307,14 +2307,24 @@ type GetExternalCanisterResult = variant {
   Err : Error;
 };
 
+// The input type for sorting the results of listing external canisters.
+type ListExternalCanistersSortInput = variant {
+  // Sort by the name of the external canister.
+  Name : SortByDirection;
+};
+
 // Input type for listing external canisters with the given filters.
 type ListExternalCanistersInput = record {
   // The principal id of the external canister to search for.
   canister_ids : opt vec principal;
   // The labels to use for filtering the external canisters.
   labels : opt vec text;
+  // The current state of the external canisters to use for filtering (e.g. `Active`, `Archived`).
+  states : opt vec ExternalCanisterState;
   // The pagination parameters.
   paginate : opt PaginationInput;
+  // The sort parameters.
+  sort_by : opt ListExternalCanistersSortInput;
 };
 
 // Result type for listing external canisters.

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2287,8 +2287,10 @@ type ExternalCanisterCallerMethodsPrivileges = record {
 
 // The caller privileges for the external canister.
 type ExternalCanisterCallerPrivileges = record {
-  // The external canister retource id.
+  // The external canister entry id.
   id : UUID;
+  // The canister id.
+  canister_id : principal;
   // Wether or not the caller can edit the external canister.
   can_change : bool;
   // The list of methods that the caller can call on the external canister.

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -1,6 +1,6 @@
 use crate::{
     AllowDTO, CanisterInstallMode, PaginationInput, RequestPolicyRuleDTO, Sha256HashDTO,
-    TimestampRfc3339, UuidDTO, ValidationMethodResourceTargetDTO,
+    SortDirection, TimestampRfc3339, UuidDTO, ValidationMethodResourceTargetDTO,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 
@@ -205,10 +205,17 @@ pub struct GetExternalCanisterResponse {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub enum ListExternalCanistersSortInput {
+    Name(SortDirection),
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ListExternalCanistersInput {
     pub canister_ids: Option<Vec<Principal>>,
     pub labels: Option<Vec<String>>,
+    pub states: Option<Vec<ExternalCanisterStateDTO>>,
     pub paginate: Option<PaginationInput>,
+    pub sort_by: Option<ListExternalCanistersSortInput>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -221,13 +221,13 @@ pub struct ListExternalCanistersResponse {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetExternalCanisterFiltersInputWithName {
-    prefix: Option<String>,
+    pub prefix: Option<String>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct GetExternalCanisterFiltersInput {
-    with_name: Option<GetExternalCanisterFiltersInputWithName>,
-    with_labels: Option<bool>,
+    pub with_name: Option<GetExternalCanisterFiltersInputWithName>,
+    pub with_labels: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -193,6 +193,7 @@ pub struct ExternalCanisterCallerMethodPrivilegesDTO {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterCallerPrivilegesDTO {
     pub id: UuidDTO,
+    pub canister_id: Principal,
     pub can_change: bool,
     pub can_call: Vec<ExternalCanisterCallerMethodPrivilegesDTO>,
 }

--- a/core/station/impl/src/controllers/external_canister.rs
+++ b/core/station/impl/src/controllers/external_canister.rs
@@ -142,9 +142,10 @@ impl ExternalCanisterController {
         &self,
         input: GetExternalCanisterFiltersInput,
     ) -> ApiResult<GetExternalCanisterFiltersResponse> {
+        let ctx = call_context();
         let filters = self
             .canister_service
-            .available_external_canisters_filters(input);
+            .available_external_canisters_filters(input, &ctx);
 
         Ok(GetExternalCanisterFiltersResponse {
             names: filters.names,

--- a/core/station/impl/src/controllers/system.rs
+++ b/core/station/impl/src/controllers/system.rs
@@ -30,9 +30,19 @@ async fn initialize(input: Option<SystemInstall>) {
 #[cfg(all(feature = "canbench", not(test)))]
 #[ic_cdk_macros::init]
 pub async fn mock_init() {
+    use crate::core::write_system_info;
+    use crate::models::SystemInfo;
+    use candid::Principal;
+
     // Initialize the random number generator with a fixed seed to ensure deterministic
     // results across runs of the benchmarks.
     orbit_essentials::utils::initialize_rng_from_seed([0u8; 32]);
+
+    // Initialize the system info.
+    let mut system = SystemInfo::default();
+    system.set_upgrader_canister_id(Principal::from_slice(&[25; 29]));
+
+    write_system_info(system);
 }
 
 #[post_upgrade]

--- a/core/station/impl/src/core/mod.rs
+++ b/core/station/impl/src/core/mod.rs
@@ -50,7 +50,7 @@ pub mod test_utils {
     pub const UPGRADER_CANISTER_ID: [u8; 29] = [25; 29];
 
     pub fn init_canister_system() -> SystemInfo {
-        let mut system = SystemInfo::default();
+        let mut system: SystemInfo = SystemInfo::default();
         system
             .set_upgrader_canister_id(Principal::from_slice(self::UPGRADER_CANISTER_ID.as_slice()));
 

--- a/core/station/impl/src/core/utils.rs
+++ b/core/station/impl/src/core/utils.rs
@@ -1,3 +1,5 @@
+use candid::Principal;
+
 use super::authorization::Authorization;
 use super::CallContext;
 use crate::errors::PaginationError;
@@ -112,6 +114,10 @@ pub(crate) fn retain_accessible_resources<T, F>(
 pub(crate) fn format_unique_string(text: &str) -> String {
     deunicode::deunicode(text).to_lowercase().replace(' ', "")
 }
+
+/// The minimum principal value that can be used.
+pub const MIN_PRINCIPAL: Principal = Principal::from_slice(&[0; 29]);
+pub const MAX_PRINCIPAL: Principal = Principal::from_slice(&[255; 29]);
 
 #[cfg(test)]
 mod tests {

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -7,10 +7,11 @@ use crate::{
         ExternalCanisterCallerPrivileges, ExternalCanisterPermissions,
         ExternalCanisterRequestPolicies, ExternalCanisterState,
     },
+    repositories::ExternalCanisterWhereClauseSort,
 };
 use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterSettings;
-use orbit_essentials::utils::timestamp_to_rfc3339;
+use orbit_essentials::{repository::SortDirection, utils::timestamp_to_rfc3339};
 use station_api::ExternalCanisterDTO;
 use uuid::Uuid;
 
@@ -63,6 +64,19 @@ impl From<ExternalCanisterCallerPrivileges> for station_api::ExternalCanisterCal
             canister_id: privileges.canister_id,
             can_change: privileges.can_change,
             can_call: privileges.can_call.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<station_api::ListExternalCanistersSortInput> for ExternalCanisterWhereClauseSort {
+    fn from(input: station_api::ListExternalCanistersSortInput) -> Self {
+        match input {
+            station_api::ListExternalCanistersSortInput::Name(direction) => {
+                ExternalCanisterWhereClauseSort::Name(match direction {
+                    station_api::SortDirection::Asc => SortDirection::Ascending,
+                    station_api::SortDirection::Desc => SortDirection::Descending,
+                })
+            }
         }
     }
 }

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -192,7 +192,7 @@ impl ModelValidator<ExternalCanisterError> for ExternalCanister {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "canbench"))]
 pub mod external_canister_test_utils {
     use super::*;
     use crate::core::ic_cdk::next_time;

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -10,6 +10,7 @@ use orbit_essentials::{
     model::{ModelValidator, ModelValidatorResult},
     types::{Timestamp, UUID},
 };
+use station_api::GetExternalCanisterFiltersResponse;
 use std::collections::BTreeSet;
 use std::hash::Hash;
 
@@ -70,6 +71,8 @@ pub struct ExternalCanisterCallerPrivileges {
     pub can_change: bool,
     pub can_call: Vec<ExternalCanisterCallerMethodsPrivileges>,
 }
+
+pub type ExternalCanisterAvailableFilters = GetExternalCanisterFiltersResponse;
 
 impl ExternalCanister {
     pub const MAX_NAME_LENGTH: usize = 100;

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -1,5 +1,8 @@
 use super::resource::ValidationMethodResourceTarget;
-use super::ConfigureExternalCanisterSettingsInput;
+use super::{
+    ConfigureExternalCanisterSettingsInput, ExternalCanisterPermissionsInput,
+    ExternalCanisterRequestPoliciesInput,
+};
 use crate::errors::ExternalCanisterError;
 use candid::Principal;
 use orbit_essentials::storable;
@@ -38,6 +41,9 @@ pub struct ExternalCanister {
     pub modified_at: Option<Timestamp>,
 }
 
+pub type ExternalCanisterPermissions = ExternalCanisterPermissionsInput;
+pub type ExternalCanisterRequestPolicies = ExternalCanisterRequestPoliciesInput;
+
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExternalCanisterKey {
@@ -60,6 +66,7 @@ pub struct ExternalCanisterCallerMethodsPrivileges {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExternalCanisterCallerPrivileges {
     pub id: UUID,
+    pub canister_id: Principal,
     pub can_change: bool,
     pub can_call: Vec<ExternalCanisterCallerMethodsPrivileges>,
 }

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -13,6 +13,8 @@ pub struct ExternalCanisterIndex {
     pub index: ExternalCanisterIndexKind,
     /// The external canister id, which is a UUID.
     pub external_canister_entry_id: ExternalCanisterId,
+    /// The external canister id, which is a Principal.
+    pub canister_id: Principal,
 }
 
 #[storable]
@@ -29,6 +31,7 @@ impl ExternalCanister {
         ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::Name(format_unique_string(self.name.as_str())),
             external_canister_entry_id: self.id,
+            canister_id: self.canister_id,
         }
     }
 
@@ -39,6 +42,7 @@ impl ExternalCanister {
             .map(|label| ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Label(format_unique_string(label.as_str())),
                 external_canister_entry_id: self.id,
+                canister_id: self.canister_id,
             })
             .collect()
     }
@@ -48,6 +52,7 @@ impl ExternalCanister {
         ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::CanisterId(self.canister_id),
             external_canister_entry_id: self.id,
+            canister_id: self.canister_id,
         }
     }
 
@@ -77,6 +82,7 @@ mod tests {
         let model = ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::CanisterId(Principal::anonymous()),
             external_canister_entry_id: [u8::MAX; 16],
+            canister_id: Principal::anonymous(),
         };
 
         let serialized_model = model.to_bytes();

--- a/core/station/impl/src/models/indexes/external_canister_index.rs
+++ b/core/station/impl/src/models/indexes/external_canister_index.rs
@@ -13,15 +13,18 @@ pub struct ExternalCanisterIndex {
     pub index: ExternalCanisterIndexKind,
     /// The external canister id, which is a UUID.
     pub external_canister_entry_id: ExternalCanisterId,
-    /// The external canister id, which is a Principal.
+    /// The canister id of the external canister, also, it helps avoid an extra lookup for permission checks.
     pub canister_id: Principal,
 }
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ExternalCanisterIndexKind {
+    // Used to check if a canister id already exists.
     CanisterId(Principal),
+    // Used to check if a name already exists and to list all names to facilitate searching.
     Name(String),
+    // Used to list all labels to facilitate searching/
     Label(String),
 }
 
@@ -59,6 +62,7 @@ impl ExternalCanister {
     /// Converts the external canister to indexes to facilitate searching.
     pub fn indexes(&self) -> Vec<ExternalCanisterIndex> {
         let mut indexes = vec![self.to_index_by_name(), self.to_index_by_canister_id()];
+
         indexes.extend(self.to_index_by_labels());
 
         indexes

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -434,7 +434,7 @@ pub struct DefiniteCanisterSettingsInput {
 }
 
 #[storable]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct ConfigureExternalCanisterSettingsInput {
     pub name: Option<String>,
     pub description: Option<String>,

--- a/core/station/impl/src/models/user_group.rs
+++ b/core/station/impl/src/models/user_group.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "canbench"))]
 pub mod user_group_test_utils {
     use super::*;
     use orbit_essentials::repository::Repository;

--- a/core/station/impl/src/repositories/external_canister.rs
+++ b/core/station/impl/src/repositories/external_canister.rs
@@ -5,15 +5,15 @@ use crate::{
         indexes::external_canister_index::{
             ExternalCanisterIndexCriteria, ExternalCanisterIndexKind,
         },
-        ExternalCanister, ExternalCanisterId, ExternalCanisterKey,
+        ExternalCanister, ExternalCanisterId, ExternalCanisterKey, ExternalCanisterState,
     },
 };
 use candid::Principal;
 use ic_stable_structures::{memory_manager::VirtualMemory, StableBTreeMap};
 use lazy_static::lazy_static;
-use orbit_essentials::repository::IndexRepository;
+use orbit_essentials::repository::{IndexRepository, SortDirection};
 use orbit_essentials::repository::{RefreshIndexMode, Repository};
-use std::{cell::RefCell, sync::Arc};
+use std::{cell::RefCell, collections::HashSet, sync::Arc};
 
 thread_local! {
   /// The memory reference to the external canister repository.
@@ -77,14 +77,8 @@ impl ExternalCanisterRepository {
     /// Returns an external canister by its name if it exists.
     pub fn find_by_name(&self, name: &str) -> Option<ExternalCanisterId> {
         let name = format_unique_string(name);
-        let found = self
-            .indexes
-            .find_by_criteria(ExternalCanisterIndexCriteria {
-                from: ExternalCanisterIndexKind::Name(name.to_string()),
-                to: ExternalCanisterIndexKind::Name(name.to_string()),
-            });
 
-        found.into_iter().next()
+        self.indexes.find_by_name(&name)
     }
 
     /// Returns an external canister by its canister id if it exists.
@@ -128,24 +122,80 @@ impl ExternalCanisterRepository {
     pub fn find_names_by_prefix(
         &self,
         prefix: &str,
-        limit: Option<usize>,
     ) -> Vec<(String, ExternalCanisterId, Principal)> {
-        self.indexes.find_names_by_prefix(prefix, limit)
+        self.indexes.find_names_by_prefix(prefix)
     }
 
     /// Finds external canisters based on the provided where clause.
     pub fn find_canister_ids_where(
         &self,
-        _where_clause: ExternalCanisterWhereClause,
+        where_clause: ExternalCanisterWhereClause,
     ) -> Vec<Principal> {
-        unimplemented!()
+        let filter_by_labels: HashSet<String> = where_clause.labels.into_iter().collect();
+        let filter_by_canister_ids: HashSet<Principal> =
+            where_clause.canister_ids.into_iter().collect();
+        let filter_by_states: HashSet<ExternalCanisterState> =
+            where_clause.states.into_iter().collect();
+
+        let mut found_ids = self
+            .list()
+            .into_iter()
+            .filter_map(|entry| {
+                if !filter_by_labels.is_empty()
+                    && !entry
+                        .labels
+                        .iter()
+                        .any(|label| filter_by_labels.contains(label))
+                {
+                    return None;
+                }
+
+                if !filter_by_canister_ids.is_empty()
+                    && !filter_by_canister_ids.contains(&entry.canister_id)
+                {
+                    return None;
+                }
+
+                if !filter_by_states.is_empty() && !filter_by_states.contains(&entry.state) {
+                    return None;
+                }
+
+                Some((entry.name, entry.canister_id))
+            })
+            .collect::<Vec<(String, Principal)>>();
+
+        let sort_by = match where_clause.sort_by {
+            Some(sort_by) => sort_by,
+            None => ExternalCanisterWhereClauseSort::Name(SortDirection::Ascending),
+        };
+
+        match sort_by {
+            ExternalCanisterWhereClauseSort::Name(direction) => {
+                found_ids.sort_by(|(name_a, _), (name_b, _)| match direction {
+                    SortDirection::Ascending => name_a.cmp(name_b),
+                    SortDirection::Descending => name_b.cmp(name_a),
+                });
+            }
+        }
+
+        found_ids
+            .into_iter()
+            .map(|(_, canister_id)| canister_id)
+            .collect()
     }
 }
 
 #[derive(Debug, Clone)]
+pub enum ExternalCanisterWhereClauseSort {
+    Name(SortDirection),
+}
+
+#[derive(Debug, Clone)]
 pub struct ExternalCanisterWhereClause {
-    pub canister_ids: Option<Vec<Principal>>,
-    pub labels: Option<Vec<String>>,
+    pub canister_ids: Vec<Principal>,
+    pub labels: Vec<String>,
+    pub states: Vec<ExternalCanisterState>,
+    pub sort_by: Option<ExternalCanisterWhereClauseSort>,
 }
 
 #[cfg(test)]

--- a/core/station/impl/src/repositories/external_canister.rs
+++ b/core/station/impl/src/repositories/external_canister.rs
@@ -118,6 +118,34 @@ impl ExternalCanisterRepository {
         self.find_by_canister_id(canister_id)
             .map_or(true, |existing_id| skip_id == Some(existing_id))
     }
+
+    /// Finds all the labels of the external canisters, which are unique.
+    pub fn find_all_labels(&self) -> Vec<String> {
+        self.indexes.find_all_labels()
+    }
+
+    /// Finds the names of the external canisters that start with the given prefix.
+    pub fn find_names_by_prefix(
+        &self,
+        prefix: &str,
+        limit: Option<usize>,
+    ) -> Vec<(String, ExternalCanisterId, Principal)> {
+        self.indexes.find_names_by_prefix(prefix, limit)
+    }
+
+    /// Finds external canisters based on the provided where clause.
+    pub fn find_canister_ids_where(
+        &self,
+        _where_clause: ExternalCanisterWhereClause,
+    ) -> Vec<Principal> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalCanisterWhereClause {
+    pub canister_ids: Option<Vec<Principal>>,
+    pub labels: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/core/station/impl/src/repositories/indexes/external_canister_index.rs
+++ b/core/station/impl/src/repositories/indexes/external_canister_index.rs
@@ -1,5 +1,8 @@
 use crate::{
-    core::{with_memory_manager, Memory, EXTERNAL_CANISTER_INDEX_MEMORY_ID},
+    core::{
+        utils::{MAX_PRINCIPAL, MIN_PRINCIPAL},
+        with_memory_manager, Memory, EXTERNAL_CANISTER_INDEX_MEMORY_ID,
+    },
     models::{
         indexes::external_canister_index::{
             ExternalCanisterIndex, ExternalCanisterIndexCriteria, ExternalCanisterIndexKind,
@@ -46,12 +49,12 @@ impl IndexRepository<ExternalCanisterIndex, ExternalCanisterId>
             let start_key = ExternalCanisterIndex {
                 index: criteria.from,
                 external_canister_entry_id: [u8::MIN; 16],
-                canister_id: Principal::from_slice(&[u8::MIN; 29]),
+                canister_id: MIN_PRINCIPAL,
             };
             let end_key = ExternalCanisterIndex {
                 index: criteria.to,
                 external_canister_entry_id: [u8::MAX; 16],
-                canister_id: Principal::from_slice(&[u8::MAX; 29]),
+                canister_id: MAX_PRINCIPAL,
             };
 
             db.borrow()
@@ -79,31 +82,48 @@ impl ExternalCanisterIndexRepository {
     pub fn find_names_by_prefix(
         &self,
         prefix: &str,
-        limit: Option<usize>,
     ) -> Vec<(String, ExternalCanisterId, Principal)> {
-        let limit = limit.unwrap_or(Self::MAX_NAME_PREFIX_LIST_LIMIT);
-        let mut count = 0;
-
         DB.with(|db| {
             db.borrow()
                 .range((ExternalCanisterIndex {
                     index: ExternalCanisterIndexKind::Name(prefix.to_string()),
                     external_canister_entry_id: [u8::MIN; 16],
-                    canister_id: Principal::from_slice(&[u8::MIN; 29]),
+                    canister_id: MIN_PRINCIPAL,
                 })..)
-                .take_while(|(index, _)| {
-                    if count >= limit {
-                        return false;
-                    }
-
-                    count += 1;
-                    matches!(&index.index, ExternalCanisterIndexKind::Name(name) if name.starts_with(prefix))
-                })
+                .take_while(|(index, _)| matches!(&index.index, ExternalCanisterIndexKind::Name(name) if name.starts_with(prefix)))
                 .filter_map(|(index, _)| match &index.index {
                     ExternalCanisterIndexKind::Name(name) => Some((name.clone(), index.external_canister_entry_id, index.canister_id)),
                     _ => None,
                 })
                 .collect()
+        })
+    }
+
+    /// Finds the external canister that matches the given name.
+    pub fn find_by_name(&self, search_name: &str) -> Option<ExternalCanisterId> {
+        DB.with(|db| {
+            db.borrow()
+                .range(
+                    (ExternalCanisterIndex {
+                        index: ExternalCanisterIndexKind::Name(search_name.to_string()),
+                        external_canister_entry_id: [u8::MIN; 16],
+                        canister_id: MIN_PRINCIPAL,
+                    })..=(ExternalCanisterIndex {
+                        index: ExternalCanisterIndexKind::Name(search_name.to_string()),
+                        external_canister_entry_id: [u8::MAX; 16],
+                        canister_id: MAX_PRINCIPAL,
+                    }),
+                )
+                .filter_map(|(index, _)| match &index.index {
+                    ExternalCanisterIndexKind::Name(name) => match name == search_name {
+                        true => Some(index.external_canister_entry_id),
+                        false => None,
+                    },
+                    _ => None,
+                })
+                .collect::<Vec<ExternalCanisterId>>()
+                .first()
+                .cloned()
         })
     }
 
@@ -115,7 +135,7 @@ impl ExternalCanisterIndexRepository {
                     (ExternalCanisterIndex {
                         index: ExternalCanisterIndexKind::Label(String::new()),
                         external_canister_entry_id: [u8::MIN; 16],
-                        canister_id: Principal::from_slice(&[u8::MIN; 29]),
+                        canister_id: MIN_PRINCIPAL,
                     })..,
                 )
                 .take_while(|(index, _)| {
@@ -149,7 +169,7 @@ mod tests {
         let index = ExternalCanisterIndex {
             index: ExternalCanisterIndexKind::Name("test".to_string()),
             external_canister_entry_id: [1; 16],
-            canister_id: Principal::anonymous(),
+            canister_id: Principal::from_slice(&[1; 29]),
         };
 
         assert!(!repository.exists(&index));
@@ -168,18 +188,16 @@ mod tests {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Name(format!("test-{}", i)),
                 external_canister_entry_id: [i; 16],
-                canister_id: Principal::anonymous(),
+                canister_id: Principal::from_slice(&[i; 29]),
             });
         }
 
-        let result = repository.find_by_criteria(ExternalCanisterIndexCriteria {
-            from: ExternalCanisterIndexKind::Name("test-5".to_string()),
-            to: ExternalCanisterIndexKind::Name("test-5".to_string()),
-        });
+        for i in 0..10 {
+            let result = repository.find_by_name(&format!("test-{}", i));
 
-        assert!(!result.is_empty());
-        assert_eq!(result.len(), 1);
-        assert!(result.contains(&[5; 16]));
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), [i; 16]);
+        }
     }
 
     #[test]
@@ -189,7 +207,7 @@ mod tests {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::CanisterId(Principal::from_slice(&[i; 29])),
                 external_canister_entry_id: [i; 16],
-                canister_id: Principal::anonymous(),
+                canister_id: Principal::from_slice(&[i; 29]),
             });
         }
 
@@ -204,28 +222,6 @@ mod tests {
     }
 
     #[test]
-    fn test_find_by_labels() {
-        let repository = ExternalCanisterIndexRepository::default();
-        for i in 0..10 {
-            repository.insert(ExternalCanisterIndex {
-                index: ExternalCanisterIndexKind::Label(format!("label-{}", i)),
-                external_canister_entry_id: [i; 16],
-                canister_id: Principal::anonymous(),
-            });
-        }
-
-        let result = repository.find_by_criteria(ExternalCanisterIndexCriteria {
-            from: ExternalCanisterIndexKind::Label("label-5".to_string()),
-            to: ExternalCanisterIndexKind::Label("label-6".to_string()),
-        });
-
-        assert!(!result.is_empty());
-        assert_eq!(result.len(), 2);
-        assert!(result.contains(&[5; 16]));
-        assert!(result.contains(&[6; 16]));
-    }
-
-    #[test]
     fn test_find_by_name_prefix() {
         let repository = ExternalCanisterIndexRepository::default();
         let mut expected_results = Vec::new();
@@ -235,7 +231,7 @@ mod tests {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Name(index_name.clone()),
                 external_canister_entry_id: [i; 16],
-                canister_id: Principal::anonymous(),
+                canister_id: Principal::from_slice(&[i; 29]),
             });
 
             if index_name.starts_with(search_prefix) {
@@ -244,7 +240,7 @@ mod tests {
         }
 
         let result = repository
-            .find_names_by_prefix("test2", None)
+            .find_names_by_prefix("test2")
             .into_iter()
             .map(|(name, _, _)| name)
             .collect::<Vec<String>>();
@@ -263,7 +259,7 @@ mod tests {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Label(format!("label-{}", i)),
                 external_canister_entry_id: [i; 16],
-                canister_id: Principal::anonymous(),
+                canister_id: Principal::from_slice(&[i; 29]),
             });
         }
 
@@ -271,7 +267,7 @@ mod tests {
             repository.insert(ExternalCanisterIndex {
                 index: ExternalCanisterIndexKind::Label(format!("label-{}", i)),
                 external_canister_entry_id: [i + 20; 16],
-                canister_id: Principal::anonymous(),
+                canister_id: Principal::from_slice(&[i + 20; 29]),
             });
         }
 

--- a/core/station/impl/src/services/user.rs
+++ b/core/station/impl/src/services/user.rs
@@ -578,3 +578,32 @@ mod tests {
         assert!(privileges.contains(&UserPrivilege::AddUser));
     }
 }
+
+#[cfg(any(test, feature = "canbench"))]
+pub mod user_service_test_utils {
+    use super::*;
+    use crate::models::user_group_test_utils::add_group;
+
+    pub fn add_users(users_count: u8, groups_count: u8) -> Vec<User> {
+        let mut groups = Vec::new();
+        let mut users = Vec::new();
+        for _ in 0..groups_count {
+            let group_name = Uuid::new_v4().to_string();
+            groups.push(add_group(&group_name));
+        }
+
+        for _ in 0..users_count {
+            let user_id = Uuid::new_v4();
+            let input = AddUserOperationInput {
+                identities: vec![Principal::from_slice(user_id.as_bytes())],
+                groups: groups.iter().map(|g| g.id).collect(),
+                status: UserStatus::Active,
+                name: user_id.to_string(),
+            };
+
+            users.push(USER_SERVICE.add_user(input).unwrap());
+        }
+
+        users
+    }
+}


### PR DESCRIPTION
Adds the implementation of the endpoints to search and get external canisters information.