### PR TITLE
feat(station): use different types for input and get of external canister policies

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2184,9 +2184,23 @@ type ExternalCanisterCallPermission = record {
 
 // The request policy rule for the canister call operation.
 type ExternalCanisterCallRequestPolicyRule = record {
-  // The optional id of the request policy rule.
+  // The id of the request policy rule.
+  policy_id : UUID;
+  // The request policy rule for the canister call operation.
+  rule : RequestPolicyRule;
+  // The validation method that is used to match the policy against
+  // the permission of the resource.
+  validation_method : ValidationMethodResourceTarget;
+  // The method name that the rule is for,
+  // if `*` is used the rule applies to all methods.
+  execution_method : text;
+};
+
+// The request policy rule for the canister call operation.
+type ExternalCanisterCallRequestPolicyRuleInput = record {
+  // The id of the request policy rule.
   //
-  // If not provided a new policy rule will be created.
+  // If not provided a new entry will be created.
   policy_id : opt UUID;
   // The request policy rule for the canister call operation.
   rule : RequestPolicyRule;
@@ -2200,9 +2214,17 @@ type ExternalCanisterCallRequestPolicyRule = record {
 
 // The request policy rule for the canister change operation.
 type ExternalCanisterChangeRequestPolicyRule = record {
-  // The optional id of the request policy rule.
+  // The id of the request policy rule.
+  policy_id : UUID;
+  // The request policy rule for the canister change operation.
+  rule : RequestPolicyRule;
+};
+
+// The request policy rule for the canister change operation.
+type ExternalCanisterChangeRequestPolicyRuleInput = record {
+  // The id of the request policy rule.
   //
-  // If not provided a new policy rule will be created.
+  // If not provided a new entry will be created.
   policy_id : opt UUID;
   // The request policy rule for the canister change operation.
   rule : RequestPolicyRule;
@@ -2233,7 +2255,12 @@ type ExternalCanisterRequestPolicies = record {
 };
 
 // The input type for setting the request policies for the external canister.
-type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
+type ExternalCanisterRequestPoliciesInput = record {
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  // The request policy rules for the calling methods on the canister.
+  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
 
 // An external canister that the station can interact with.
 type ExternalCanister = record {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -391,6 +391,12 @@ export interface ExternalCanisterCallRequestPolicyRule {
   'execution_method' : string,
   'rule' : RequestPolicyRule,
   'validation_method' : ValidationMethodResourceTarget,
+  'policy_id' : UUID,
+}
+export interface ExternalCanisterCallRequestPolicyRuleInput {
+  'execution_method' : string,
+  'rule' : RequestPolicyRule,
+  'validation_method' : ValidationMethodResourceTarget,
   'policy_id' : [] | [UUID],
 }
 export interface ExternalCanisterCallerMethodsPrivileges {
@@ -405,6 +411,10 @@ export interface ExternalCanisterCallerPrivileges {
 }
 export interface ExternalCanisterChangeRequestPolicyRule {
   'rule' : RequestPolicyRule,
+  'policy_id' : UUID,
+}
+export interface ExternalCanisterChangeRequestPolicyRuleInput {
+  'rule' : RequestPolicyRule,
   'policy_id' : [] | [UUID],
 }
 export interface ExternalCanisterPermissions {
@@ -417,7 +427,10 @@ export interface ExternalCanisterRequestPolicies {
   'calls' : Array<ExternalCanisterCallRequestPolicyRule>,
   'change' : Array<ExternalCanisterChangeRequestPolicyRule>,
 }
-export type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
+export interface ExternalCanisterRequestPoliciesInput {
+  'calls' : Array<ExternalCanisterCallRequestPolicyRuleInput>,
+  'change' : Array<ExternalCanisterChangeRequestPolicyRuleInput>,
+}
 export type ExternalCanisterResourceAction = {
     'Call' : CallExternalCanisterResourceTarget
   } |

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -225,21 +225,20 @@ export const idlFactory = ({ IDL }) => {
       'AllowListedByMetadata' : AddressBookMetadata,
     })
   );
-  const ExternalCanisterCallRequestPolicyRule = IDL.Record({
+  const ExternalCanisterCallRequestPolicyRuleInput = IDL.Record({
     'execution_method' : IDL.Text,
     'rule' : RequestPolicyRule,
     'validation_method' : ValidationMethodResourceTarget,
     'policy_id' : IDL.Opt(UUID),
   });
-  const ExternalCanisterChangeRequestPolicyRule = IDL.Record({
+  const ExternalCanisterChangeRequestPolicyRuleInput = IDL.Record({
     'rule' : RequestPolicyRule,
     'policy_id' : IDL.Opt(UUID),
   });
-  const ExternalCanisterRequestPolicies = IDL.Record({
-    'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRule),
-    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRule),
+  const ExternalCanisterRequestPoliciesInput = IDL.Record({
+    'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput),
+    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRuleInput),
   });
-  const ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
   const ExternalCanisterState = IDL.Variant({
     'Active' : IDL.Null,
     'Archived' : IDL.Null,
@@ -757,6 +756,20 @@ export const idlFactory = ({ IDL }) => {
     'can_change' : IDL.Bool,
     'canister_id' : IDL.Principal,
     'can_call' : IDL.Vec(ExternalCanisterCallerMethodsPrivileges),
+  });
+  const ExternalCanisterCallRequestPolicyRule = IDL.Record({
+    'execution_method' : IDL.Text,
+    'rule' : RequestPolicyRule,
+    'validation_method' : ValidationMethodResourceTarget,
+    'policy_id' : UUID,
+  });
+  const ExternalCanisterChangeRequestPolicyRule = IDL.Record({
+    'rule' : RequestPolicyRule,
+    'policy_id' : UUID,
+  });
+  const ExternalCanisterRequestPolicies = IDL.Record({
+    'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRule),
+    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRule),
   });
   const ExternalCanister = IDL.Record({
     'id' : UUID,

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2184,9 +2184,23 @@ type ExternalCanisterCallPermission = record {
 
 // The request policy rule for the canister call operation.
 type ExternalCanisterCallRequestPolicyRule = record {
-  // The optional id of the request policy rule.
+  // The id of the request policy rule.
+  policy_id : UUID;
+  // The request policy rule for the canister call operation.
+  rule : RequestPolicyRule;
+  // The validation method that is used to match the policy against
+  // the permission of the resource.
+  validation_method : ValidationMethodResourceTarget;
+  // The method name that the rule is for,
+  // if `*` is used the rule applies to all methods.
+  execution_method : text;
+};
+
+// The request policy rule for the canister call operation.
+type ExternalCanisterCallRequestPolicyRuleInput = record {
+  // The id of the request policy rule.
   //
-  // If not provided a new policy rule will be created.
+  // If not provided a new entry will be created.
   policy_id : opt UUID;
   // The request policy rule for the canister call operation.
   rule : RequestPolicyRule;
@@ -2200,9 +2214,17 @@ type ExternalCanisterCallRequestPolicyRule = record {
 
 // The request policy rule for the canister change operation.
 type ExternalCanisterChangeRequestPolicyRule = record {
-  // The optional id of the request policy rule.
+  // The id of the request policy rule.
+  policy_id : UUID;
+  // The request policy rule for the canister change operation.
+  rule : RequestPolicyRule;
+};
+
+// The request policy rule for the canister change operation.
+type ExternalCanisterChangeRequestPolicyRuleInput = record {
+  // The id of the request policy rule.
   //
-  // If not provided a new policy rule will be created.
+  // If not provided a new entry will be created.
   policy_id : opt UUID;
   // The request policy rule for the canister change operation.
   rule : RequestPolicyRule;
@@ -2233,7 +2255,12 @@ type ExternalCanisterRequestPolicies = record {
 };
 
 // The input type for setting the request policies for the external canister.
-type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPolicies;
+type ExternalCanisterRequestPoliciesInput = record {
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  // The request policy rules for the calling methods on the canister.
+  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
 
 // An external canister that the station can interact with.
 type ExternalCanister = record {

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -5,8 +5,6 @@ use crate::{
 use candid::{CandidType, Deserialize, Nat, Principal};
 
 pub type ExternalCanisterPermissionsInput = ExternalCanisterPermissionsDTO;
-pub type ExternalCanisterCallRequestPolicyRuleInput = ExternalCanisterCallRequestPolicyRule;
-pub type ExternalCanisterRequestPoliciesInput = ExternalCanisterRequestPoliciesDTO;
 
 // Taken from https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -133,7 +131,15 @@ pub struct ExternalCanisterCallPermissionDTO {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
-pub struct ExternalCanisterCallRequestPolicyRule {
+pub struct ExternalCanisterCallRequestPolicyRuleDTO {
+    pub policy_id: UuidDTO,
+    pub rule: RequestPolicyRuleDTO,
+    pub validation_method: ValidationMethodResourceTargetDTO,
+    pub execution_method: String,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterCallRequestPolicyRuleInput {
     pub policy_id: Option<UuidDTO>,
     pub rule: RequestPolicyRuleDTO,
     pub validation_method: ValidationMethodResourceTargetDTO,
@@ -141,7 +147,13 @@ pub struct ExternalCanisterCallRequestPolicyRule {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
-pub struct ExternalCanisterChangeRequestPolicyRule {
+pub struct ExternalCanisterChangeRequestPolicyRuleDTO {
+    pub policy_id: UuidDTO,
+    pub rule: RequestPolicyRuleDTO,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterChangeRequestPolicyRuleInput {
     pub policy_id: Option<UuidDTO>,
     pub rule: RequestPolicyRuleDTO,
 }
@@ -155,8 +167,14 @@ pub struct ExternalCanisterPermissionsDTO {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterRequestPoliciesDTO {
-    pub change: Vec<ExternalCanisterChangeRequestPolicyRule>,
-    pub calls: Vec<ExternalCanisterCallRequestPolicyRule>,
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleDTO>,
+    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleDTO>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterRequestPoliciesInput {
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
+    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -3,8 +3,9 @@ use crate::{
     models::{
         ConfigureExternalCanisterOperationInput, ConfigureExternalCanisterOperationKind,
         ConfigureExternalCanisterSettingsInput, CreateExternalCanisterOperationInput,
-        DefiniteCanisterSettingsInput, ExternalCanister, ExternalCanisterCallerMethodsPrivileges,
-        ExternalCanisterCallerPrivileges, ExternalCanisterPermissions,
+        DefiniteCanisterSettingsInput, ExternalCanister, ExternalCanisterCallRequestPolicyRule,
+        ExternalCanisterCallerMethodsPrivileges, ExternalCanisterCallerPrivileges,
+        ExternalCanisterChangeRequestPolicyRule, ExternalCanisterPermissions,
         ExternalCanisterRequestPolicies, ExternalCanisterState,
     },
     repositories::ExternalCanisterWhereClauseSort,
@@ -53,6 +54,51 @@ impl ExternalCanister {
             request_policies: policies.into(),
             created_at: timestamp_to_rfc3339(&self.created_at),
             modified_at: self.modified_at.map(|ts| timestamp_to_rfc3339(&ts)),
+        }
+    }
+}
+
+impl From<ExternalCanisterPermissions> for station_api::ExternalCanisterPermissionsDTO {
+    fn from(permissions: ExternalCanisterPermissions) -> Self {
+        station_api::ExternalCanisterPermissionsDTO {
+            read: permissions.read.into(),
+            change: permissions.change.into(),
+            calls: permissions.calls.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ExternalCanisterRequestPolicies> for station_api::ExternalCanisterRequestPoliciesDTO {
+    fn from(policies: ExternalCanisterRequestPolicies) -> Self {
+        station_api::ExternalCanisterRequestPoliciesDTO {
+            change: policies.change.into_iter().map(Into::into).collect(),
+            calls: policies.calls.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ExternalCanisterChangeRequestPolicyRule>
+    for station_api::ExternalCanisterChangeRequestPolicyRuleDTO
+{
+    fn from(rule: ExternalCanisterChangeRequestPolicyRule) -> Self {
+        station_api::ExternalCanisterChangeRequestPolicyRuleDTO {
+            policy_id: Uuid::from_bytes(rule.policy_id).hyphenated().to_string(),
+            rule: rule.rule.into(),
+        }
+    }
+}
+
+impl From<ExternalCanisterCallRequestPolicyRule>
+    for station_api::ExternalCanisterCallRequestPolicyRuleDTO
+{
+    fn from(privileges: ExternalCanisterCallRequestPolicyRule) -> Self {
+        station_api::ExternalCanisterCallRequestPolicyRuleDTO {
+            policy_id: Uuid::from_bytes(privileges.policy_id)
+                .hyphenated()
+                .to_string(),
+            rule: privileges.rule.into(),
+            validation_method: privileges.validation_method.into(),
+            execution_method: privileges.execution_method,
         }
     }
 }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -632,11 +632,11 @@ impl From<ExternalCanisterCallRequestPolicyRuleInput>
     }
 }
 
-impl From<station_api::ExternalCanisterChangeRequestPolicyRule>
+impl From<station_api::ExternalCanisterChangeRequestPolicyRuleInput>
     for ExternalCanisterChangeRequestPolicyRuleInput
 {
     fn from(
-        input: station_api::ExternalCanisterChangeRequestPolicyRule,
+        input: station_api::ExternalCanisterChangeRequestPolicyRuleInput,
     ) -> ExternalCanisterChangeRequestPolicyRuleInput {
         ExternalCanisterChangeRequestPolicyRuleInput {
             policy_id: input.policy_id.map(|policy_id| {
@@ -650,12 +650,12 @@ impl From<station_api::ExternalCanisterChangeRequestPolicyRule>
 }
 
 impl From<ExternalCanisterChangeRequestPolicyRuleInput>
-    for station_api::ExternalCanisterChangeRequestPolicyRule
+    for station_api::ExternalCanisterChangeRequestPolicyRuleInput
 {
     fn from(
         input: ExternalCanisterChangeRequestPolicyRuleInput,
-    ) -> station_api::ExternalCanisterChangeRequestPolicyRule {
-        station_api::ExternalCanisterChangeRequestPolicyRule {
+    ) -> station_api::ExternalCanisterChangeRequestPolicyRuleInput {
+        station_api::ExternalCanisterChangeRequestPolicyRuleInput {
             policy_id: input
                 .policy_id
                 .map(|policy_id| Uuid::from_bytes(policy_id).hyphenated().to_string()),

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -1,8 +1,6 @@
+use super::permission::Allow;
 use super::resource::ValidationMethodResourceTarget;
-use super::{
-    ConfigureExternalCanisterSettingsInput, ExternalCanisterPermissionsInput,
-    ExternalCanisterRequestPoliciesInput,
-};
+use super::{ConfigureExternalCanisterSettingsInput, RequestPolicyRule};
 use crate::errors::ExternalCanisterError;
 use candid::Principal;
 use orbit_essentials::storable;
@@ -42,8 +40,39 @@ pub struct ExternalCanister {
     pub modified_at: Option<Timestamp>,
 }
 
-pub type ExternalCanisterPermissions = ExternalCanisterPermissionsInput;
-pub type ExternalCanisterRequestPolicies = ExternalCanisterRequestPoliciesInput;
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterCallPermission {
+    pub allow: Allow,
+    pub validation_method: ValidationMethodResourceTarget,
+    pub execution_method: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterPermissions {
+    pub read: Allow,
+    pub change: Allow,
+    pub calls: Vec<ExternalCanisterCallPermission>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterChangeRequestPolicyRule {
+    pub policy_id: UUID,
+    pub rule: RequestPolicyRule,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterCallRequestPolicyRule {
+    pub policy_id: UUID,
+    pub rule: RequestPolicyRule,
+    pub validation_method: ValidationMethodResourceTarget,
+    pub execution_method: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterRequestPolicies {
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRule>,
+    pub calls: Vec<ExternalCanisterCallRequestPolicyRule>,
+}
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -4,8 +4,8 @@ use super::{
     request_specifier::RequestSpecifier,
     resource::{Resource, ValidationMethodResourceTarget},
     AccountId, AddressBookEntryId, Blockchain, BlockchainStandard, ChangeMetadata,
-    DisasterRecoveryCommittee, ExternalCanisterState, MetadataItem, UserGroupId, UserId,
-    UserStatus,
+    DisasterRecoveryCommittee, ExternalCanisterCallPermission, ExternalCanisterState, MetadataItem,
+    UserGroupId, UserId, UserStatus,
 };
 use crate::core::validation::EnsureExternalCanister;
 use crate::errors::ValidationError;
@@ -326,14 +326,6 @@ pub struct ChangeExternalCanisterOperation {
     pub module_checksum: Vec<u8>,
     pub arg_checksum: Option<Vec<u8>>,
     pub input: ChangeExternalCanisterOperationInput,
-}
-
-#[storable]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ExternalCanisterCallPermission {
-    pub allow: Allow,
-    pub validation_method: ValidationMethodResourceTarget,
-    pub execution_method: String,
 }
 
 #[storable]

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -18,10 +18,10 @@ use crate::models::{
     CreateExternalCanisterOperationInput, CreateExternalCanisterOperationKind,
     DefiniteCanisterSettingsInput, EditPermissionOperationInput, EditRequestPolicyOperationInput,
     ExternalCanister, ExternalCanisterAvailableFilters, ExternalCanisterCallPermission,
-    ExternalCanisterCallRequestPolicyRuleInput, ExternalCanisterCallerMethodsPrivileges,
-    ExternalCanisterCallerPrivileges, ExternalCanisterChangeRequestPolicyRuleInput,
-    ExternalCanisterId, ExternalCanisterPermissions, ExternalCanisterPermissionsInput,
-    ExternalCanisterRequestPolicies, ExternalCanisterRequestPoliciesInput, RequestPolicy,
+    ExternalCanisterCallRequestPolicyRule, ExternalCanisterCallerMethodsPrivileges,
+    ExternalCanisterCallerPrivileges, ExternalCanisterChangeRequestPolicyRule, ExternalCanisterId,
+    ExternalCanisterPermissions, ExternalCanisterPermissionsInput, ExternalCanisterRequestPolicies,
+    ExternalCanisterRequestPoliciesInput, RequestPolicy,
 };
 use crate::repositories::permission::{PermissionRepository, PERMISSION_REPOSITORY};
 use crate::repositories::{
@@ -149,8 +149,8 @@ impl ExternalCanisterService {
                             }),
                         validation_method,
                     } if *target_canister_id == *canister_id => {
-                        Some(ExternalCanisterCallRequestPolicyRuleInput {
-                            policy_id: Some(policy.id),
+                        Some(ExternalCanisterCallRequestPolicyRule {
+                            policy_id: policy.id,
                             execution_method: method_name.clone(),
                             validation_method: validation_method.clone(),
                             rule: policy.rule.clone(),
@@ -160,7 +160,7 @@ impl ExternalCanisterService {
                 },
                 _ => None,
             })
-            .collect::<Vec<ExternalCanisterCallRequestPolicyRuleInput>>();
+            .collect::<Vec<ExternalCanisterCallRequestPolicyRule>>();
 
         let change = policies
             .iter()
@@ -169,8 +169,8 @@ impl ExternalCanisterService {
                     ChangeExternalCanisterResourceTarget::Canister(target_canister_id)
                         if *target_canister_id == *canister_id =>
                     {
-                        Some(ExternalCanisterChangeRequestPolicyRuleInput {
-                            policy_id: Some(policy.id),
+                        Some(ExternalCanisterChangeRequestPolicyRule {
+                            policy_id: policy.id,
                             rule: policy.rule.clone(),
                         })
                     }
@@ -178,7 +178,7 @@ impl ExternalCanisterService {
                 },
                 _ => None,
             })
-            .collect::<Vec<ExternalCanisterChangeRequestPolicyRuleInput>>();
+            .collect::<Vec<ExternalCanisterChangeRequestPolicyRule>>();
 
         ExternalCanisterRequestPolicies { calls, change }
     }


### PR DESCRIPTION
The external canister policies were sharing the same type, this was not accurate in the case of a get operation, because this allowed a rule to be returned with an optional `policy_id` which could never happen.

This update separates those types.