### PR TITLE
chore(station): remove fn assert_notification_access

### DIFF
--- a/core/station/impl/src/controllers/notification.rs
+++ b/core/station/impl/src/controllers/notification.rs
@@ -79,9 +79,7 @@ impl NotificationController {
     #[with_middleware(guard = authorize(&call_context(), &MarkNotificationsReadInputRef(&input).to_resources()))]
     #[with_middleware(tail = use_canister_call_metric("mark_notifications_read", &result))]
     async fn mark_notifications_read(&self, input: MarkNotificationsReadInput) -> ApiResult<()> {
-        self.notification_service
-            .mark_read(input, &call_context())
-            .await?;
+        self.notification_service.mark_read(input).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR removes notification access checks in the notification service since the access checks are now performed early in the authorization middleware (cf. https://github.com/dfinity/orbit/pull/323).