### PR TITLE
chore(control-panel): introduce candid decoding quota for http_request

### DIFF
--- a/core/control-panel/impl/src/controllers/http.rs
+++ b/core/control-panel/impl/src/controllers/http.rs
@@ -11,7 +11,7 @@ use orbit_essentials::metrics::with_metrics_registry;
 use std::sync::Arc;
 
 // Canister entrypoints for the controller.
-#[query(name = "http_request")]
+#[query(name = "http_request", decoding_quota = 10000)]
 async fn http_request(request: HttpRequest) -> HttpResponse {
     CONTROLLER.router(request).await
 }

--- a/tests/integration/src/http.rs
+++ b/tests/integration/src/http.rs
@@ -50,4 +50,5 @@ fn test_http_request_deconding_quota() {
     } = setup_new_env();
 
     test_candid_decoding_quota(&env, canister_ids.station);
+    test_candid_decoding_quota(&env, canister_ids.control_panel);
 }


### PR DESCRIPTION
This PR adds candid decoding quota to `http_request` endpoint of the control panel canister. This way, excessively large HTTP requests are rejected early.
