### PR TITLE
chore: certify that http_request endpoint skips certification in control panel and station

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body",
- "ic-certification",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-transport-types",
  "ic-verify-bls-signature",
  "k256 0.13.3",
@@ -2068,7 +2068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b0e48b4166c891e79d624f3a184b4a7c145d307576872d9a46dedb8c73ea8f"
 dependencies = [
  "candid",
- "ic-certification",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "nom",
  "thiserror",
@@ -2165,7 +2165,7 @@ dependencies = [
  "cached 0.47.0",
  "candid",
  "ic-cbor",
- "ic-certification",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -2188,6 +2188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ic-certified-assets"
 version = "0.2.5"
 source = "git+https://github.com/dfinity/sdk.git?rev=75c080ebae22a70578c06ddf1eda0b18ef091845#75c080ebae22a70578c06ddf1eda0b18ef091845"
@@ -2196,8 +2207,8 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.13.5",
- "ic-certification",
- "ic-representation-independent-hash",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-response-verification",
  "itertools 0.10.5",
  "num-traits",
@@ -2216,8 +2227,22 @@ checksum = "ff0b97e949845039149dc5e7ea6a7c12ee4333bb402e37bc507904643c7b3e41"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification",
- "ic-representation-independent-hash",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "ic-http-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "candid",
+ "http 0.2.12",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
+ "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
  "serde",
  "thiserror",
  "urlencoding",
@@ -2262,6 +2287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-representation-independent-hash"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+dependencies = [
+ "leb128",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ic-response-verification"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,9 +2308,9 @@ dependencies = [
  "http 0.2.12",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification",
- "ic-http-certification",
- "ic-representation-independent-hash",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-http-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-representation-independent-hash 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "log",
  "nom",
@@ -2301,7 +2335,7 @@ source = "git+https://github.com/dfinity/agent-rs.git?rev=be929fd7967249c879f48f
 dependencies = [
  "candid",
  "hex",
- "ic-certification",
+ "ic-certification 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "serde",
  "serde_bytes",
@@ -3014,12 +3048,16 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 name = "orbit-essentials"
 version = "0.0.2-alpha.4"
 dependencies = [
+ "base64 0.22.1",
  "candid",
  "convert_case",
  "getrandom",
  "hex",
  "ic-cdk 0.13.5",
  "ic-cdk-timers",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
+ "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
+ "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
  "ic-stable-structures",
  "orbit-essentials-macros",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ codegen-units = 1
 anyhow = "1.0.75"
 deunicode = "1.4.4"
 async-trait = "0.1"
+base64 = "0.22.1"
 byteorder = "1.5"
 canbench-rs = "0.1.1"
 candid = "0.10.3"
@@ -46,7 +47,10 @@ hex = "0.4"
 # The ic-agent matches the one sed by bthe 
 ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 ic-asset = { git = "https://github.com/dfinity/sdk.git", rev = "75c080ebae22a70578c06ddf1eda0b18ef091845" }
+ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 ic-certified-assets = { git = "https://github.com/dfinity/sdk.git", rev = "75c080ebae22a70578c06ddf1eda0b18ef091845" }
+ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+ic-representation-independent-hash = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 ic-cdk = "0.13.2"
 ic-cdk-macros = "0.9"
 ic-cdk-timers = "0.7.0"

--- a/core/control-panel/impl/src/controllers/canister.rs
+++ b/core/control-panel/impl/src/controllers/canister.rs
@@ -8,6 +8,7 @@ use ic_cdk_macros::{init, post_upgrade};
 use ic_cdk_timers::{set_timer, set_timer_interval};
 use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::update;
+use orbit_essentials::http::set_certified_data_for_skip_certification;
 use std::time::Duration;
 
 pub const MINUTE: u64 = 60;
@@ -53,6 +54,7 @@ fn init_timers_fn() {
 
 #[init]
 async fn initialize() {
+    set_certified_data_for_skip_certification();
     init_timers_fn();
 
     CANISTER_SERVICE
@@ -63,6 +65,7 @@ async fn initialize() {
 
 #[post_upgrade]
 async fn post_upgrade() {
+    set_certified_data_for_skip_certification();
     recompute_all_metrics();
     init_timers_fn();
 

--- a/core/control-panel/impl/src/controllers/http.rs
+++ b/core/control-panel/impl/src/controllers/http.rs
@@ -7,13 +7,16 @@ use crate::{
 use ic_cdk_macros::query;
 use lazy_static::lazy_static;
 use orbit_essentials::api::{HeaderField, HttpRequest, HttpResponse};
+use orbit_essentials::http::add_skip_certification_headers;
 use orbit_essentials::metrics::with_metrics_registry;
 use std::sync::Arc;
 
 // Canister entrypoints for the controller.
 #[query(name = "http_request")]
 async fn http_request(request: HttpRequest) -> HttpResponse {
-    CONTROLLER.router(request).await
+    let mut resp = CONTROLLER.router(request).await;
+    add_skip_certification_headers(&mut resp);
+    resp
 }
 
 // Controller initialization and implementation.

--- a/core/station/impl/src/controllers/http.rs
+++ b/core/station/impl/src/controllers/http.rs
@@ -2,12 +2,15 @@ use crate::{core::ic_cdk::api::canister_balance, SERVICE_NAME};
 use ic_cdk_macros::query;
 use lazy_static::lazy_static;
 use orbit_essentials::api::{HeaderField, HttpRequest, HttpResponse};
+use orbit_essentials::http::add_skip_certification_headers;
 use orbit_essentials::metrics::with_metrics_registry;
 
 // Canister entrypoints for the controller.
 #[query(name = "http_request", decoding_quota = 10000)]
 async fn http_request(request: HttpRequest) -> HttpResponse {
-    CONTROLLER.router(request).await
+    let mut resp = CONTROLLER.router(request).await;
+    add_skip_certification_headers(&mut resp);
+    resp
 }
 
 // Controller initialization and implementation.

--- a/core/station/impl/src/controllers/system.rs
+++ b/core/station/impl/src/controllers/system.rs
@@ -11,6 +11,7 @@ use crate::{
 use ic_cdk_macros::{post_upgrade, query};
 use lazy_static::lazy_static;
 use orbit_essentials::api::ApiResult;
+use orbit_essentials::http::set_certified_data_for_skip_certification;
 use orbit_essentials::with_middleware;
 use station_api::{HealthStatus, SystemInfoResponse, SystemInstall, SystemUpgrade};
 use std::sync::Arc;
@@ -19,6 +20,7 @@ use std::sync::Arc;
 #[cfg(any(not(feature = "canbench"), test))]
 #[ic_cdk_macros::init]
 async fn initialize(input: Option<SystemInstall>) {
+    set_certified_data_for_skip_certification();
     match input {
         Some(SystemInstall::Init(input)) => CONTROLLER.initialize(input).await,
         Some(SystemInstall::Upgrade(_)) | None => trap("Invalid args to initialize canister"),
@@ -55,6 +57,7 @@ async fn post_upgrade(input: Option<SystemInstall>) {
     // datatype from the one that was initially stored.
     migration::MigrationHandler::run();
 
+    set_certified_data_for_skip_certification();
     match input {
         None => CONTROLLER.post_upgrade(None).await,
         Some(SystemInstall::Upgrade(input)) => CONTROLLER.post_upgrade(Some(input)).await,

--- a/libs/orbit-essentials/Cargo.toml
+++ b/libs/orbit-essentials/Cargo.toml
@@ -14,15 +14,20 @@ crate-type = ['lib']
 bench = false
 
 [dependencies]
+base64 = { workspace = true }
 candid = { workspace = true }
 convert_case = { workspace = true }
 getrandom = { workspace = true, features = ['custom'] }
 ic-cdk = { workspace = true }
+ic-certification = { workspace = true }
+ic-http-certification = { workspace = true }
+ic-representation-independent-hash = { workspace = true }
 ic-stable-structures = { workspace = true }
 orbit-essentials-macros = { path = '../orbit-essentials-macros', version = '0.0.2-alpha.3' }
 prometheus = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
+serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 serde_bytes = { workspace = true }
 time = { workspace = true, features = ['formatting', 'parsing'] }

--- a/libs/orbit-essentials/src/http.rs
+++ b/libs/orbit-essentials/src/http.rs
@@ -1,0 +1,62 @@
+use crate::api::{HeaderField, HttpResponse};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use ic_cdk::api::{data_certificate, set_certified_data};
+use ic_certification::{labeled, leaf, HashTree};
+use ic_http_certification::DefaultCelBuilder;
+use ic_representation_independent_hash::hash;
+use serde::Serialize;
+
+// Certify that frontend asset certification is skipped for this canister.
+
+const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
+const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
+
+fn skip_certification_cel_expr() -> String {
+    DefaultCelBuilder::skip_certification().to_string()
+}
+
+fn skip_certification_asset_tree() -> HashTree {
+    let cel_expr_hash = hash(skip_certification_cel_expr().as_bytes());
+    labeled(
+        "http_expr",
+        labeled("<*>", labeled(cel_expr_hash, leaf(vec![]))),
+    )
+}
+
+pub fn add_skip_certification_headers(response: &mut HttpResponse) {
+    let certified_data = data_certificate().expect("No data certificate available");
+    let witness = cbor_encode(&skip_certification_asset_tree());
+    let expr_path = ["http_expr", "<*>"];
+    let expr_path = cbor_encode(&expr_path);
+
+    response.headers.push(HeaderField(
+        IC_CERTIFICATE_EXPRESSION_HEADER.to_string(),
+        skip_certification_cel_expr(),
+    ));
+    response.headers.push(HeaderField(
+        IC_CERTIFICATE_HEADER.to_string(),
+        format!(
+            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+            BASE64.encode(certified_data),
+            BASE64.encode(witness),
+            BASE64.encode(expr_path)
+        ),
+    ));
+}
+
+// Encoding
+fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
+    let mut serializer = serde_cbor::Serializer::new(Vec::new());
+    serializer
+        .self_describe()
+        .expect("Failed to self describe CBOR");
+    value
+        .serialize(&mut serializer)
+        .expect("Failed to serialize value");
+    serializer.into_inner()
+}
+
+pub fn set_certified_data_for_skip_certification() {
+    set_certified_data(&skip_certification_asset_tree().digest());
+}

--- a/libs/orbit-essentials/src/lib.rs
+++ b/libs/orbit-essentials/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod api;
 pub mod cdk;
 pub mod deserialize;
+pub mod http;
 pub mod metrics;
 pub mod model;
 pub mod repository;

--- a/tests/integration/src/http.rs
+++ b/tests/integration/src/http.rs
@@ -57,7 +57,6 @@ fn fetch_asset(canister_id: Principal, port: u16, path: &str, expected: &str) {
     let url = format!("http://{}.localhost:{}{}", canister_id, port, path);
     let res = client.get(url).send().unwrap();
     let page = String::from_utf8(res.bytes().unwrap().to_vec()).unwrap();
-    println!("page: {}", page);
     assert!(page.contains(expected));
 }
 

--- a/tests/integration/src/http.rs
+++ b/tests/integration/src/http.rs
@@ -51,3 +51,31 @@ fn test_http_request_deconding_quota() {
 
     test_candid_decoding_quota(&env, canister_ids.station);
 }
+
+fn fetch_asset(canister_id: Principal, port: u16, path: &str, expected: &str) {
+    let client = reqwest::blocking::Client::new();
+    let url = format!("http://{}.localhost:{}{}", canister_id, port, path);
+    let res = client.get(url).send().unwrap();
+    let page = String::from_utf8(res.bytes().unwrap().to_vec()).unwrap();
+    println!("page: {}", page);
+    assert!(page.contains(expected));
+}
+
+#[test]
+fn test_skip_asset_certification() {
+    let TestEnv {
+        mut env,
+        canister_ids,
+        ..
+    } = setup_new_env();
+
+    let port = env.make_live(None).port_or_known_default().unwrap();
+
+    fetch_asset(
+        canister_ids.station,
+        port,
+        "/metrics",
+        "# HELP station_total_policies The total number of policies that are available.",
+    );
+    fetch_asset(canister_ids.control_panel, port, "/metrics", "# HELP control_panel_active_users Total number of active users in the system, labeled by the time interval.");
+}


### PR DESCRIPTION
This PR certifies that asset certification is skipped in the control panel and station canisters so that the canisters' `http_request` endpoint can be accessed without using the raw endpoint.