### PR TITLE
feat(station): serve metrics as properly certified HTTP asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-asset-certification"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f#eefc99e2a0041ae46873864e6e2f7aa8506a361f"
+dependencies = [
+ "globset",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "thiserror",
+]
+
+[[package]]
 name = "ic-cbor"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "ic-certification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+source = "git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f#eefc99e2a0041ae46873864e6e2f7aa8506a361f"
 dependencies = [
  "hex",
  "serde",
@@ -2310,12 +2321,12 @@ dependencies = [
 [[package]]
 name = "ic-http-certification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+source = "git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f#eefc99e2a0041ae46873864e6e2f7aa8506a361f"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
- "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
  "serde",
  "thiserror",
  "urlencoding",
@@ -2362,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "ic-representation-independent-hash"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
+source = "git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f#eefc99e2a0041ae46873864e6e2f7aa8506a361f"
 dependencies = [
  "leb128",
  "sha2 0.10.8",
@@ -3131,9 +3142,9 @@ dependencies = [
  "hex",
  "ic-cdk 0.13.5",
  "ic-cdk-timers",
- "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
- "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
- "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "ic-representation-independent-hash 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
  "ic-stable-structures",
  "orbit-essentials-macros",
  "prometheus",
@@ -4543,7 +4554,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4558,6 +4569,7 @@ version = "0.0.2-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "byteorder",
  "canbench-rs",
  "candid",
@@ -4566,8 +4578,11 @@ dependencies = [
  "deunicode",
  "futures",
  "hex",
+ "ic-asset-certification",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
+ "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
+ "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=eefc99e2a0041ae46873864e6e2f7aa8506a361f)",
  "ic-ledger-types",
  "ic-stable-structures",
  "lazy_static",
@@ -5458,7 +5473,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,11 @@ hex = "0.4"
 # The ic-agent matches the one sed by bthe 
 ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 ic-asset = { git = "https://github.com/dfinity/sdk.git", rev = "75c080ebae22a70578c06ddf1eda0b18ef091845" }
-ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+ic-asset-certification = { git = "https://github.com/dfinity/response-verification", rev = "eefc99e2a0041ae46873864e6e2f7aa8506a361f" }
+ic-certification = { git = "https://github.com/dfinity/response-verification", rev = "eefc99e2a0041ae46873864e6e2f7aa8506a361f" }
 ic-certified-assets = { git = "https://github.com/dfinity/sdk.git", rev = "75c080ebae22a70578c06ddf1eda0b18ef091845" }
-ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
-ic-representation-independent-hash = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
+ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "eefc99e2a0041ae46873864e6e2f7aa8506a361f" }
+ic-representation-independent-hash = { git = "https://github.com/dfinity/response-verification", rev = "eefc99e2a0041ae46873864e6e2f7aa8506a361f" }
 ic-cdk = "0.13.2"
 ic-cdk-macros = "0.9"
 ic-cdk-timers = "0.7.0"

--- a/core/station/impl/Cargo.toml
+++ b/core/station/impl/Cargo.toml
@@ -18,6 +18,7 @@ canbench = ['canbench-rs']
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 deunicode = { workspace = true }
 async-trait = { workspace = true }
 byteorder = { workspace = true }
@@ -27,8 +28,11 @@ canfund = { path = '../../../libs/canfund', version = '0.0.2-alpha.3' }
 futures = { workspace = true }
 hex = { workspace = true }
 orbit-essentials = { path = '../../../libs/orbit-essentials', version = '0.0.2-alpha.4' }
+ic-asset-certification = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-certification = { workspace = true }
+ic-http-certification = { workspace = true }
 ic-ledger-types = { workspace = true }
 ic-stable-structures = { workspace = true }
 lazy_static = { workspace = true }

--- a/core/station/impl/src/controllers/http.rs
+++ b/core/station/impl/src/controllers/http.rs
@@ -1,64 +1,139 @@
-use crate::{core::ic_cdk::api::canister_balance, SERVICE_NAME};
+use crate::core::ic_cdk::api::{
+    canister_balance, data_certificate, print, set_certified_data, time, trap,
+};
+use crate::SERVICE_NAME;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use ic_asset_certification::{Asset, AssetConfig, AssetEncoding, AssetRouter};
 use ic_cdk_macros::query;
-use lazy_static::lazy_static;
-use orbit_essentials::api::{HeaderField, HttpRequest, HttpResponse};
-use orbit_essentials::http::add_skip_certification_headers;
+use ic_certification::HashTree;
+use ic_http_certification::{HeaderField, HttpCertificationTree, HttpRequest, HttpResponse};
 use orbit_essentials::metrics::with_metrics_registry;
+use serde::Serialize;
+use std::{cell::RefCell, rc::Rc};
 
-// Canister entrypoints for the controller.
-#[query(name = "http_request", decoding_quota = 10000)]
-async fn http_request(request: HttpRequest) -> HttpResponse {
-    let mut resp = CONTROLLER.router(request).await;
-    add_skip_certification_headers(&mut resp);
-    resp
+#[query(decoding_quota = 10000)]
+fn http_request(req: HttpRequest) -> HttpResponse {
+    serve_asset(&req)
 }
 
-// Controller initialization and implementation.
-lazy_static! {
-    static ref CONTROLLER: HttpController = HttpController::new();
+thread_local! {
+    static HTTP_TREE: Rc<RefCell<HttpCertificationTree>> = Default::default();
+    static ASSET_ROUTER: RefCell<AssetRouter<'static>> = RefCell::new(AssetRouter::with_tree(HTTP_TREE.with(|tree| tree.clone())));
 }
 
-#[derive(Debug)]
-pub struct HttpController {}
+// Certification
+pub fn certify_metrics() {
+    // 1. Define the asset certification configurations.
+    let encodings = vec![
+        AssetEncoding::Brotli.default_config(),
+        AssetEncoding::Gzip.default_config(),
+    ];
 
-impl HttpController {
-    fn new() -> Self {
-        Self {}
-    }
+    let asset_configs = vec![AssetConfig::File {
+        path: "metrics".to_string(),
+        content_type: Some("text/plain".to_string()),
+        headers: get_asset_headers(vec![(
+            "cache-control".to_string(),
+            "public, no-cache, no-store".to_string(),
+        )]),
+        fallback_for: vec![],
+        aliased_by: vec![],
+        encodings: encodings.clone(),
+    }];
 
-    async fn router(&self, request: HttpRequest) -> HttpResponse {
-        if request.url == "/metrics" || request.url == "/metrics/" {
-            return self.metrics(request).await;
+    // 2. Collect all assets from the frontend build directory.
+    let mut assets = Vec::new();
+    with_metrics_registry(SERVICE_NAME, |registry| {
+        registry
+            .gauge_mut(
+                "canister_cycles_balance",
+                "cycles balance available to the canister",
+            )
+            .set(canister_balance() as f64);
+    });
+    with_metrics_registry(SERVICE_NAME, |registry| {
+        registry
+            .gauge_mut(
+                "metrics_timestamp",
+                "UNIX timestamp in nanoseconds when the metrics were exported",
+            )
+            .set(time() as f64);
+    });
+    let metrics_contents =
+        with_metrics_registry(SERVICE_NAME, |registry| registry.export_metrics());
+    assets.push(Asset::new(
+        "/metrics",
+        metrics_contents.unwrap_or_else(|e| e.to_string().as_bytes().to_vec()),
+    ));
+
+    ASSET_ROUTER.with_borrow_mut(|asset_router| {
+        // 3. Certify the assets using the `certify_assets` function from the `ic-asset-certification` crate.
+        if let Err(err) = asset_router.certify_assets(assets, asset_configs) {
+            print(format!("Failed to certify assets: {}", err));
+        } else {
+            // 4. Set the canister's certified data.
+            set_certified_data(&asset_router.root_hash());
         }
+    });
+}
 
-        return HttpResponse {
-            status_code: 404,
-            headers: vec![HeaderField("Content-Type".into(), "text/plain".into())],
-            body: "404 Not Found".as_bytes().to_owned(),
-        };
-    }
+// Handlers
+fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
+    ASSET_ROUTER.with_borrow(|asset_router| {
+        if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
+            add_certificate_header(&mut response, &witness, &expr_path);
 
-    async fn metrics(&self, request: HttpRequest) -> HttpResponse {
-        if request.method.to_lowercase() != "get" {
-            return HttpResponse {
-                status_code: 405,
-                headers: vec![HeaderField("Allow".into(), "GET".into())],
-                body: "405 Method Not Allowed".as_bytes().to_owned(),
-            };
+            response
+        } else {
+            trap("Failed to serve asset");
         }
+    })
+}
 
-        // Add dynamic metrics, dropped after the request since query calls don't save state changes.
-        with_metrics_registry(SERVICE_NAME, |registry| {
-            registry
-                .gauge_mut(
-                    "canister_cycles_balance",
-                    "cycles balance available to the canister",
-                )
-                .set(canister_balance() as f64);
-        });
+fn get_asset_headers(additional_headers: Vec<HeaderField>) -> Vec<HeaderField> {
+    // set up the default headers and include additional headers provided by the caller
+    let mut headers = vec![
+        ("strict-transport-security".to_string(), "max-age=31536000; includeSubDomains".to_string()),
+        ("x-frame-options".to_string(), "DENY".to_string()),
+        ("x-content-type-options".to_string(), "nosniff".to_string()),
+        ("content-security-policy".to_string(), "default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content".to_string()),
+        ("referrer-policy".to_string(), "no-referrer".to_string()),
+        ("permissions-policy".to_string(), "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()".to_string()),
+        ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
+        ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
+    ];
+    headers.extend(additional_headers);
 
-        with_metrics_registry(SERVICE_NAME, |registry| {
-            registry.export_metrics_as_http_response()
-        })
+    headers
+}
+
+const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
+fn add_certificate_header(response: &mut HttpResponse, witness: &HashTree, expr_path: &[String]) {
+    if let Some(certified_data) = data_certificate() {
+        let witness = cbor_encode(witness);
+        let expr_path = cbor_encode(&expr_path);
+
+        response.add_header((
+            IC_CERTIFICATE_HEADER.to_string(),
+            format!(
+                "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+                BASE64.encode(certified_data),
+                BASE64.encode(witness),
+                BASE64.encode(expr_path)
+            ),
+        ));
     }
+}
+
+// Encoding
+fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
+    let mut serializer = serde_cbor::Serializer::new(Vec::new());
+    serializer
+        .self_describe()
+        .expect("Failed to self describe CBOR");
+    value
+        .serialize(&mut serializer)
+        .expect("Failed to serialize value");
+    serializer.into_inner()
 }

--- a/core/station/impl/src/core/middlewares.rs
+++ b/core/station/impl/src/core/middlewares.rs
@@ -1,5 +1,6 @@
 use super::authorization::Authorization;
 use super::CallContext;
+use crate::controllers::certify_metrics;
 use crate::core::ic_cdk::api::trap;
 use crate::models::resource::Resource;
 use crate::services::SYSTEM_SERVICE;
@@ -65,4 +66,5 @@ where
             .with(&labels! { "status" => status, "method" => called_method })
             .inc();
     });
+    certify_metrics();
 }

--- a/tests/integration/src/http.rs
+++ b/tests/integration/src/http.rs
@@ -39,12 +39,11 @@ fn test_candid_decoding_quota(env: &PocketIc, canister_id: Principal) {
             large_http_request_bytes,
         )
         .unwrap_err();
-    println!("desc: {}", err.description);
     assert!(err.description.contains("Decoding cost exceeds the limit"));
 }
 
 #[test]
-fn test_http_request_deconding_quota() {
+fn test_http_request_decoding_quota() {
     let TestEnv {
         env, canister_ids, ..
     } = setup_new_env();
@@ -53,16 +52,18 @@ fn test_http_request_deconding_quota() {
     test_candid_decoding_quota(&env, canister_ids.control_panel);
 }
 
-fn fetch_asset(canister_id: Principal, port: u16, path: &str, expected: &str) {
+fn fetch_asset(canister_id: Principal, port: u16, path: &str, expected: Vec<&str>) {
     let client = reqwest::blocking::Client::new();
     let url = format!("http://{}.localhost:{}{}", canister_id, port, path);
     let res = client.get(url).send().unwrap();
     let page = String::from_utf8(res.bytes().unwrap().to_vec()).unwrap();
-    assert!(page.contains(expected));
+    for exp in expected {
+        assert!(page.contains(exp));
+    }
 }
 
 #[test]
-fn test_skip_asset_certification() {
+fn test_asset_certification() {
     let TestEnv {
         mut env,
         canister_ids,
@@ -75,7 +76,7 @@ fn test_skip_asset_certification() {
         canister_ids.station,
         port,
         "/metrics",
-        "# HELP station_total_policies The total number of policies that are available.",
+        vec!["# HELP station_total_users The total number of users that are registered, labeled by their status.", "# HELP station_metrics_timestamp UNIX timestamp in nanoseconds when the metrics were exported"],
     );
-    fetch_asset(canister_ids.control_panel, port, "/metrics", "# HELP control_panel_active_users Total number of active users in the system, labeled by the time interval.");
+    fetch_asset(canister_ids.control_panel, port, "/metrics", vec!["# HELP control_panel_active_users Total number of active users in the system, labeled by the time interval."]);
 }


### PR DESCRIPTION
This PR serves station metrics as a properly certified HTTP asset. The metrics include the timestamp at which they were exported. The metrics are exported every time the metrics change, but they are not exported if only the canister cycles balance changes.

This PR is currently blocked on installing canisters via the chunk API as the joint size of the station and upgrade canister WASMs exceed 2MiB.