### PR TITLE
chore(control-panel): upload station and upgrader separately

### DIFF
--- a/apps/wallet/src/generated/control-panel/control_panel.did
+++ b/apps/wallet/src/generated/control-panel/control_panel.did
@@ -248,9 +248,9 @@ type CanDeployStationResult = variant {
 // The canister modules required for the control panel.
 type UploadCanisterModulesInput = record {
   // The upgrader wasm module to use for the station canister.
-  upgrader_wasm_module : blob;
+  upgrader_wasm_module : opt blob;
   // The station wasm module to use.
-  station_wasm_module : blob;
+  station_wasm_module : opt blob;
 };
 
 // The result of uploading canister modules.

--- a/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
@@ -178,8 +178,8 @@ export interface UpdateWaitingListInput {
 export type UpdateWaitingListResult = { 'Ok' : null } |
   { 'Err' : ApiError };
 export interface UploadCanisterModulesInput {
-  'station_wasm_module' : Uint8Array | number[],
-  'upgrader_wasm_module' : Uint8Array | number[],
+  'station_wasm_module' : [] | [Uint8Array | number[]],
+  'upgrader_wasm_module' : [] | [Uint8Array | number[]],
 }
 export type UploadUploadCanisterModulesInputResult = { 'Ok' : null } |
   { 'Err' : ApiError };

--- a/apps/wallet/src/generated/control-panel/control_panel.did.js
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.js
@@ -246,8 +246,8 @@ export const idlFactory = ({ IDL }) => {
     'Err' : ApiError,
   });
   const UploadCanisterModulesInput = IDL.Record({
-    'station_wasm_module' : IDL.Vec(IDL.Nat8),
-    'upgrader_wasm_module' : IDL.Vec(IDL.Nat8),
+    'station_wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'upgrader_wasm_module' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const UploadUploadCanisterModulesInputResult = IDL.Variant({
     'Ok' : IDL.Null,

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -248,9 +248,9 @@ type CanDeployStationResult = variant {
 // The canister modules required for the control panel.
 type UploadCanisterModulesInput = record {
   // The upgrader wasm module to use for the station canister.
-  upgrader_wasm_module : blob;
+  upgrader_wasm_module : opt blob;
   // The station wasm module to use.
-  station_wasm_module : blob;
+  station_wasm_module : opt blob;
 };
 
 // The result of uploading canister modules.

--- a/core/control-panel/api/src/canister.rs
+++ b/core/control-panel/api/src/canister.rs
@@ -2,8 +2,8 @@ use candid::{CandidType, Deserialize};
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UploadCanisterModulesInput {
-    #[serde(with = "serde_bytes")]
-    pub upgrader_wasm_module: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub station_wasm_module: Vec<u8>,
+    #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
+    pub upgrader_wasm_module: Option<Vec<u8>>,
+    #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
+    pub station_wasm_module: Option<Vec<u8>>,
 }

--- a/core/control-panel/impl/src/services/canister.rs
+++ b/core/control-panel/impl/src/services/canister.rs
@@ -51,8 +51,12 @@ impl CanisterService {
         self.assert_controller(&CallContext::get(), "upload_canister_modules".to_string())?;
 
         let mut config = canister_config().unwrap_or_default();
-        config.upgrader_wasm_module = input.upgrader_wasm_module;
-        config.station_wasm_module = input.station_wasm_module;
+        if let Some(upgrader_wasm_module) = input.upgrader_wasm_module {
+            config.upgrader_wasm_module = upgrader_wasm_module;
+        }
+        if let Some(station_wasm_module) = input.station_wasm_module {
+            config.station_wasm_module = station_wasm_module;
+        }
         write_canister_config(config);
 
         Ok(())

--- a/orbit
+++ b/orbit
@@ -165,7 +165,8 @@ function install_control_panel() {
   dfx canister create --specified-id $CANISTER_ID_CONTROL_PANEL control_panel
   dfx build control_panel
   dfx canister install control_panel
-  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = blob \"$station_wasm_module_bytes\"; })")
+  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = opt blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = null; })")
+  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = opt blob \"$station_wasm_module_bytes\"; })")
 }
 
 function setup_control_panel() {
@@ -183,7 +184,8 @@ function upgrade_control_panel() {
 
   dfx build control_panel
   dfx canister install control_panel --mode upgrade --yes
-  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = blob \"$station_wasm_module_bytes\"; })")
+  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = opt blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = null; })")
+  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = opt blob \"$station_wasm_module_bytes\"; })")
 }
 
 function uninstall_app_wallet() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -199,7 +199,8 @@ function deploy_control_panel() {
   fi
 
   echo "Updating the control_panel canister with the new station and upgrader WASM modules..."
-  dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = blob \"$station_wasm_module_bytes\"; })")
+  dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = opt blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = null; })")
+  dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = opt blob \"$station_wasm_module_bytes\"; })")
 }
 
 function deploy_app_wallet() {

--- a/tests/integration/src/control_panel_tests.rs
+++ b/tests/integration/src/control_panel_tests.rs
@@ -1,7 +1,7 @@
-use crate::setup::{
-    get_canister_wasm, setup_new_env, setup_new_env_with_config, SetupConfig, WALLET_ADMIN_USER,
+use crate::setup::{setup_new_env, setup_new_env_with_config, SetupConfig, WALLET_ADMIN_USER};
+use crate::utils::{
+    controller_test_id, upload_canister_modules, user_test_id, NNS_ROOT_CANISTER_ID,
 };
-use crate::utils::{controller_test_id, user_test_id, NNS_ROOT_CANISTER_ID};
 use crate::TestEnv;
 use candid::Principal;
 use control_panel_api::{
@@ -478,22 +478,7 @@ fn no_upload_canister_modules() {
         .unwrap()
         .contains("Canister config not initialized"));
 
-    // upload canister modules
-    let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
-    let station_wasm = get_canister_wasm("station").to_vec();
-    let upload_canister_modules_args = UploadCanisterModulesInput {
-        station_wasm_module: station_wasm.to_owned(),
-        upgrader_wasm_module: upgrader_wasm.to_owned(),
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller,
-        "upload_canister_modules",
-        (upload_canister_modules_args.clone(),),
-    )
-    .unwrap();
-    res.0.unwrap();
+    upload_canister_modules(&env, canister_ids.control_panel, controller);
 
     // deploying user station succeeds after uploading canister modules
     let deploy_station_args = DeployStationInput {
@@ -524,22 +509,12 @@ fn upload_canister_modules_authorization() {
         ..
     } = setup_new_env();
 
-    let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
-    let station_wasm = get_canister_wasm("station").to_vec();
-    let upload_canister_modules_args = UploadCanisterModulesInput {
-        station_wasm_module: station_wasm.to_owned(),
-        upgrader_wasm_module: upgrader_wasm.to_owned(),
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller,
-        "upload_canister_modules",
-        (upload_canister_modules_args.clone(),),
-    )
-    .unwrap();
-    res.0.unwrap();
+    upload_canister_modules(&env, canister_ids.control_panel, controller);
 
+    let upload_canister_modules_args = UploadCanisterModulesInput {
+        station_wasm_module: None,
+        upgrader_wasm_module: None,
+    };
     let res: (ApiResult<()>,) = update_candid_as(
         &env,
         canister_ids.control_panel,

--- a/tests/integration/src/setup.rs
+++ b/tests/integration/src/setup.rs
@@ -1,10 +1,12 @@
 use crate::interfaces::{
     NnsIndexCanisterInitPayload, NnsLedgerCanisterInitPayload, NnsLedgerCanisterPayload,
 };
-use crate::utils::{controller_test_id, minter_test_id, set_controllers, NNS_ROOT_CANISTER_ID};
+use crate::utils::{
+    controller_test_id, minter_test_id, set_controllers, upload_canister_modules,
+    NNS_ROOT_CANISTER_ID,
+};
 use crate::{CanisterIds, TestEnv};
 use candid::{CandidType, Encode, Principal};
-use control_panel_api::UploadCanisterModulesInput;
 use ic_ledger_types::{AccountIdentifier, Tokens, DEFAULT_SUBACCOUNT};
 use pocket_ic::{query_candid_as, PocketIc, PocketIcBuilder};
 use serde::Serialize;
@@ -235,17 +237,7 @@ fn install_canisters(
     let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
     let station_wasm = get_canister_wasm("station").to_vec();
     if config.upload_canister_modules {
-        let upload_canister_modules_args = UploadCanisterModulesInput {
-            station_wasm_module: station_wasm.to_owned(),
-            upgrader_wasm_module: upgrader_wasm.to_owned(),
-        };
-        env.update_call(
-            control_panel,
-            controller,
-            "upload_canister_modules",
-            Encode!(&upload_canister_modules_args).unwrap(),
-        )
-        .unwrap();
+        upload_canister_modules(env, control_panel, controller);
     }
 
     let station_init_args = SystemInstallArg::Init(SystemInitArg {

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -1,5 +1,6 @@
-use crate::setup::WALLET_ADMIN_USER;
+use crate::setup::{get_canister_wasm, WALLET_ADMIN_USER};
 use candid::Principal;
+use control_panel_api::UploadCanisterModulesInput;
 use flate2::{write::GzEncoder, Compression};
 use ic_cdk::api::management_canister::main::CanisterStatusResponse;
 use orbit_essentials::api::ApiResult;
@@ -705,4 +706,38 @@ pub fn sha256_hex(data: &[u8]) -> String {
     let result = hasher.finalize();
 
     hex::encode(result)
+}
+
+pub fn upload_canister_modules(env: &PocketIc, control_panel_id: Principal, controller: Principal) {
+    // upload upgrader
+    let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
+    let upload_canister_modules_args = UploadCanisterModulesInput {
+        station_wasm_module: None,
+        upgrader_wasm_module: Some(upgrader_wasm.to_owned()),
+    };
+    let res: (ApiResult<()>,) = update_candid_as(
+        env,
+        control_panel_id,
+        controller,
+        "upload_canister_modules",
+        (upload_canister_modules_args.clone(),),
+    )
+    .unwrap();
+    res.0.unwrap();
+
+    // upload station
+    let station_wasm = get_canister_wasm("station").to_vec();
+    let upload_canister_modules_args = UploadCanisterModulesInput {
+        station_wasm_module: Some(station_wasm.to_owned()),
+        upgrader_wasm_module: None,
+    };
+    let res: (ApiResult<()>,) = update_candid_as(
+        env,
+        control_panel_id,
+        controller,
+        "upload_canister_modules",
+        (upload_canister_modules_args.clone(),),
+    )
+    .unwrap();
+    res.0.unwrap();
 }


### PR DESCRIPTION
This PR refactors the `upload_canister_modules` of the control panel to allow uploading the station and upgrader separately so that they don't have to jointly fit into the ingress message size limit of 2MiB on application subnets.