### PR TITLE
feat(wallet): add asset managament UI

### DIFF
--- a/apps/wallet/src/components/assets/AssetDialog.spec.ts
+++ b/apps/wallet/src/components/assets/AssetDialog.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import AssetDialog from './AssetDialog.vue';
+import { mount } from '~/test.utils';
+import { StationService } from '~/services/station.service';
+import { Capabilities, GetAssetResult } from '~/generated/station/station.did';
+import { ExtractOk } from '~/types/helper.types';
+import { services } from '~/plugins/services.plugin';
+import AssetForm from './AssetForm.vue';
+import { flushPromises } from '@vue/test-utils';
+import { VCard } from 'vuetify/components';
+
+vi.mock('~/services/station.service', () => {
+  const mock: Partial<StationService> = {
+    withStationId: vi.fn().mockReturnThis(),
+    capabilities: vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        supported_blockchains: [
+          {
+            blockchain: 'icp',
+            supported_standards: [{ standard: 'native' }],
+          },
+        ],
+      } as Capabilities),
+    ),
+    addAsset: vi.fn().mockImplementation(() => Promise.resolve({} as Request)),
+    getAsset: vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        asset: {
+          id: '1',
+          blockchain: 'icp',
+          decimals: 8,
+          metadata: [
+            {
+              key: 'ledger_canister_id',
+              value: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
+            },
+            {
+              key: 'index_canister_id',
+              value: 'qhbym-qaaaa-aaaaa-aaafq-cai',
+            },
+          ],
+          standards: ['native'],
+          name: 'Test',
+          symbol: 'TEST',
+        },
+        privileges: {},
+      } as ExtractOk<GetAssetResult>),
+    ),
+  };
+
+  return {
+    StationService: vi.fn(() => mock),
+  };
+});
+
+describe('AssetDialog', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(AssetDialog, {
+      props: {
+        open: true,
+      },
+    });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('loads and displays existing asset', async () => {
+    const wrapper = mount(AssetDialog, {
+      props: {
+        open: true,
+        assetId: '1',
+      },
+    });
+
+    await flushPromises();
+
+    // expect getAsset to be called
+    expect(services().station.getAsset).toHaveBeenCalled();
+
+    const form = wrapper.findComponent(AssetForm);
+
+    const name = form.find('input[name="name"]').element as HTMLInputElement;
+    const symbol = form.find('input[name="symbol"]').element as HTMLInputElement;
+    const decimals = form.find('input[name="decimals"]').element as HTMLInputElement;
+    const ledger = form.find('input[name="metadata_ledger_canister_id"]')
+      .element as HTMLInputElement;
+    const index = form.find('input[name="metadata_index_canister_id"]').element as HTMLInputElement;
+
+    expect(name.value).toBe('Test');
+    expect(symbol.value).toBe('TEST');
+    expect(decimals.value).toBe('8');
+    expect(ledger.value).toBe('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    expect(index.value).toBe('qhbym-qaaaa-aaaaa-aaafq-cai');
+  });
+
+  it('creates new asset', async () => {
+    const wrapper = mount(AssetDialog, {
+      props: {
+        open: true,
+      },
+    });
+
+    await flushPromises();
+
+    const dialogContents = wrapper.findComponent(VCard);
+
+    const form = wrapper.findComponent(AssetForm);
+
+    await form
+      .findComponent({ name: 'BlockchainAutocomplete' })
+      .vm.$emit('update:modelValue', 'icp');
+
+    await form
+      .findComponent({ name: 'StandardsAutocomplete' })
+      .vm.$emit('update:modelValue', ['native']);
+
+    // fill out form
+    await form.find('input[name="name"]').setValue('Test');
+    await form.find('input[name="symbol"]').setValue('TEST');
+    await form.find('input[name="decimals"]').setValue('8');
+    await form
+      .find('input[name="metadata_ledger_canister_id"]')
+      .setValue('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    await form
+      .find('input[name="metadata_index_canister_id"]')
+      .setValue('qhbym-qaaaa-aaaaa-aaafq-cai');
+
+    await flushPromises();
+
+    const saveButton = dialogContents.find('[data-test-id="save-asset"]');
+
+    await saveButton.trigger('click');
+
+    await flushPromises();
+
+    expect(services().station.addAsset).toHaveBeenCalled();
+  });
+});

--- a/apps/wallet/src/components/assets/AssetDialog.vue
+++ b/apps/wallet/src/components/assets/AssetDialog.vue
@@ -43,6 +43,7 @@
             color="primary"
             variant="elevated"
             @click="triggerSubmit = true"
+            data-test-id="save-asset"
           >
             {{ props.assetId.value ? $t('terms.save') : $t('terms.create') }}
           </VBtn>

--- a/apps/wallet/src/components/assets/AssetDialog.vue
+++ b/apps/wallet/src/components/assets/AssetDialog.vue
@@ -42,8 +42,8 @@
             :loading="saving"
             color="primary"
             variant="elevated"
-            @click="triggerSubmit = true"
             data-test-id="save-asset"
+            @click="triggerSubmit = true"
           >
             {{ props.assetId.value ? $t('terms.save') : $t('terms.create') }}
           </VBtn>

--- a/apps/wallet/src/components/assets/AssetDialog.vue
+++ b/apps/wallet/src/components/assets/AssetDialog.vue
@@ -1,0 +1,178 @@
+<template>
+  <VDialog
+    v-model="openModel"
+    :persistent="loading || saving"
+    transition="dialog-bottom-transition"
+    scrollable
+    :max-width="props.dialogMaxWidth.value"
+  >
+    <DataLoader
+      v-slot="{ data }"
+      :load="loadAsset"
+      @loading="loading = $event"
+      @loaded="asset = $event.asset"
+    >
+      <VCard>
+        <VToolbar color="background">
+          <VToolbarTitle>{{ $t('app.asset') }}</VToolbarTitle>
+          <VBtn :disabled="loading || saving" :icon="mdiClose" @click="openModel = false" />
+        </VToolbar>
+        <VCardText v-if="loading" class="py-8">
+          <LoadingMessage />
+        </VCardText>
+        <VCardText v-else>
+          <AssetForm
+            v-if="data"
+            v-model="asset"
+            v-model:trigger-submit="triggerSubmit"
+            :display="{
+              id: true,
+            }"
+            :disabled="props.readonly.value"
+            @submit="save"
+            @valid="valid = $event"
+          />
+        </VCardText>
+        <VDivider />
+        <VCardActions class="pa-3">
+          <VSpacer />
+          <VBtn
+            v-if="!props.readonly.value"
+            :disabled="!canSave"
+            :loading="saving"
+            color="primary"
+            variant="elevated"
+            @click="triggerSubmit = true"
+          >
+            {{ props.assetId.value ? $t('terms.save') : $t('terms.create') }}
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </DataLoader>
+  </VDialog>
+</template>
+<script lang="ts" setup>
+import { mdiClose } from '@mdi/js';
+import { computed, ref, toRefs } from 'vue';
+import {
+  VBtn,
+  VCard,
+  VCardActions,
+  VCardText,
+  VDialog,
+  VDivider,
+  VSpacer,
+  VToolbar,
+  VToolbarTitle,
+} from 'vuetify/components';
+import DataLoader from '~/components/DataLoader.vue';
+import LoadingMessage from '~/components/LoadingMessage.vue';
+import {
+  useOnFailedOperation,
+  useOnSuccessfulOperation,
+} from '~/composables/notifications.composable';
+import logger from '~/core/logger.core';
+import { Asset, UUID } from '~/generated/station/station.did';
+import { useStationStore } from '~/stores/station.store';
+import { assertAndReturn } from '~/utils/helper.utils';
+import AssetForm from './AssetForm.vue';
+
+const input = withDefaults(
+  defineProps<{
+    assetId?: UUID;
+    open?: boolean;
+    dialogMaxWidth?: number;
+    readonly?: boolean;
+  }>(),
+  {
+    assetId: undefined,
+    open: false,
+    dialogMaxWidth: 800,
+    readonly: false,
+  },
+);
+
+const emit = defineEmits<{
+  (event: 'update:open', payload: boolean): void;
+}>();
+
+const props = toRefs(input);
+const valid = ref(true);
+const loading = ref(false);
+const saving = ref(false);
+const asset = ref<Partial<Asset>>({});
+const openModel = computed({
+  get: () => props.open.value,
+  set: value => emit('update:open', value),
+});
+
+const station = useStationStore();
+
+const loadAsset = async (): Promise<{
+  asset: Partial<Asset>;
+}> => {
+  if (props.assetId.value === undefined) {
+    const createModel: Partial<Asset> = {};
+
+    return { asset: createModel };
+  }
+
+  const result = await station.service.getAsset(
+    {
+      asset_id: props.assetId.value,
+    },
+    true,
+  );
+
+  return { asset: result.asset };
+};
+
+const canSave = computed(() => {
+  return valid.value && !loading.value;
+});
+
+const triggerSubmit = ref(false);
+
+const save = async (): Promise<void> => {
+  if (!canSave.value) {
+    return;
+  }
+  try {
+    saving.value = true;
+    if (asset.value.id) {
+      const request = await station.service.editAsset({
+        asset_id: asset.value.id,
+        change_metadata: [
+          {
+            ReplaceAllBy: asset.value.metadata ?? [],
+          },
+        ],
+        blockchain: [assertAndReturn(asset.value.blockchain, 'blockchain')],
+        decimals: [assertAndReturn(asset.value.decimals, 'decimals')],
+        name: [assertAndReturn(asset.value.name, 'name')],
+        symbol: [assertAndReturn(asset.value.symbol, 'symbol')],
+        standards: [assertAndReturn(asset.value.standards, 'standards')],
+      });
+      useOnSuccessfulOperation(request);
+      openModel.value = false;
+      return;
+    }
+
+    const request = await station.service.addAsset({
+      blockchain: assertAndReturn(asset.value.blockchain, 'blockchain'),
+      metadata: asset.value.metadata ?? [],
+      decimals: assertAndReturn(asset.value.decimals, 'decimals'),
+      name: assertAndReturn(asset.value.name, 'name'),
+      symbol: assertAndReturn(asset.value.symbol, 'symbol'),
+      standards: assertAndReturn(asset.value.standards, 'standards'),
+    });
+    useOnSuccessfulOperation(request);
+    openModel.value = false;
+  } catch (error) {
+    logger.error(`Failed to save asset ${error}`);
+    useOnFailedOperation();
+  } finally {
+    saving.value = false;
+  }
+};
+</script>

--- a/apps/wallet/src/components/assets/AssetDialogBtn.vue
+++ b/apps/wallet/src/components/assets/AssetDialogBtn.vue
@@ -1,0 +1,66 @@
+<template>
+  <VBtn
+    v-bind="$attrs"
+    :size="props.size.value"
+    :variant="props.variant.value"
+    :icon="props.icon.value && !props.text.value"
+    :color="props.color.value"
+    @click="open = true"
+  >
+    <VIcon v-if="props.icon.value" class="mr-1" :icon="props.icon.value" />
+    <slot name="default">
+      <span v-if="props.text">{{ props.text.value }}</span>
+    </slot>
+    <VIcon v-if="props.appendIcon.value" class="ml-1" :icon="props.appendIcon.value" />
+  </VBtn>
+
+  <AssetDialog
+    :open="open"
+    :asset-id="props.assetId.value"
+    :readonly="props.readonly.value"
+    @update:open="
+      openEvent => {
+        open = openEvent;
+
+        emit('opened', openEvent);
+      }
+    "
+  />
+</template>
+<script lang="ts" setup>
+import { ref, toRefs } from 'vue';
+import { VBtn, VIcon } from 'vuetify/components';
+import { UUID } from '~/generated/station/station.did';
+import AssetDialog from './AssetDialog.vue';
+
+const input = withDefaults(
+  defineProps<{
+    assetId?: UUID;
+    icon?: string;
+    text?: string;
+    size?: 'x-small' | 'small' | 'default' | 'medium' | 'large' | 'x-large';
+    variant?: 'flat' | 'text' | 'outlined' | 'elevated';
+    color?: string;
+    readonly?: boolean;
+    appendIcon?: string;
+  }>(),
+  {
+    assetId: undefined,
+    icon: undefined,
+    text: undefined,
+    size: 'default',
+    variant: 'elevated',
+    color: 'primary',
+    readonly: false,
+    appendIcon: undefined,
+  },
+);
+
+const open = ref(false);
+
+const emit = defineEmits<{
+  (event: 'opened', payload: boolean): void;
+}>();
+
+const props = toRefs(input);
+</script>

--- a/apps/wallet/src/components/assets/AssetForm.spec.ts
+++ b/apps/wallet/src/components/assets/AssetForm.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import AssetForm from './AssetForm.vue';
+import { mount } from '~/test.utils';
+
+describe('AssetForm', () => {
+  it('renders correctly for creation', () => {
+    const wrapper = mount(AssetForm, {
+      props: {
+        modelValue: {},
+      },
+    });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('shows custom metadata form for ICP', async () => {
+    const wrapper = mount(AssetForm, {
+      props: {
+        modelValue: {
+          blockchain: 'icp',
+          standards: ['native'],
+          metadata: [],
+        },
+      },
+    });
+
+    expect(wrapper.find('input[name="metadata_ledger_canister_id"]').exists()).toBe(true);
+    expect(wrapper.find('input[name="metadata_index_canister_id"]').exists()).toBe(true);
+  });
+
+  it('emits valid form', async () => {
+    const wrapper = mount(AssetForm, {
+      props: {
+        modelValue: {
+          blockchain: 'icp',
+          standards: ['native'],
+          metadata: [],
+          decimals: 8,
+          name: 'Test',
+          symbol: 'TEST',
+        },
+      },
+    });
+
+    // has not emitted "valid" event
+    expect(wrapper.emitted('valid')).toBeUndefined();
+
+    // fill out metadata for ICP
+    await wrapper
+      .find('input[name="metadata_ledger_canister_id"]')
+      .setValue('ryjl3-tyaaa-aaaaa-aaaba-cai');
+
+    expect(wrapper.emitted('valid')).toEqual([[false]]);
+
+    await wrapper
+      .find('input[name="metadata_index_canister_id"]')
+      .setValue('qhbym-qaaaa-aaaaa-aaafq-cai');
+
+    await wrapper.vm.$nextTick();
+
+    // has emitted "valid" event with value true
+    expect(wrapper.emitted('valid')).toEqual([[false], [true]]);
+  });
+});

--- a/apps/wallet/src/components/assets/AssetForm.vue
+++ b/apps/wallet/src/components/assets/AssetForm.vue
@@ -1,0 +1,173 @@
+<template>
+  <VForm ref="form" @submit.prevent="submit">
+    <VTextField
+      v-if="model.id && props.display.value.id"
+      v-model="model.id"
+      name="id"
+      :label="$t('terms.id')"
+      variant="plain"
+      density="compact"
+      :disabled="isViewMode"
+    />
+    <BlockchainAutocomplete
+      v-if="!isViewMode || model.blockchain"
+      v-model="model.blockchain"
+      class="mb-2"
+      :label="$t('terms.blockchain')"
+      :prepend-icon="mdiTransitConnectionVariant"
+      :rules="[requiredRule]"
+      variant="filled"
+      density="comfortable"
+      :disabled="isViewMode || !!model.id"
+    />
+
+    <StandardsAutocomplete
+      v-if="model.blockchain"
+      v-model="model.standards"
+      class="mb-2"
+      :blockchain="model.blockchain"
+      :label="$t('terms.standards')"
+      :prepend-icon="mdiKeyChain"
+      :rules="[requiredRule]"
+      variant="filled"
+      density="comfortable"
+      :disabled="isViewMode || !!model.id"
+      :multiple="true"
+    />
+
+    <InternetComputerNativeStandardForm
+      v-if="model.blockchain === 'icp' && model.standards && model.standards.includes('native')"
+      v-model="model.metadata!"
+      :readonly="isViewMode"
+    ></InternetComputerNativeStandardForm>
+
+    <template v-else-if="model.blockchain && model.standards && model.standards.length > 0">
+      <!-- unknown standard -->
+      <MetadataField
+        v-model="model.metadata"
+        :label="$t('terms.metadata')"
+        :rules="[requiredRule]"
+        :disabled="isViewMode"
+      />
+    </template>
+
+    <template v-if="model.blockchain && model.standards && model.standards.length > 0">
+      <VTextField
+        v-model="model.name"
+        name="name"
+        :label="$t('terms.name')"
+        variant="filled"
+        density="comfortable"
+        :disabled="isViewMode"
+        :prepend-icon="mdiTextBox"
+        :rules="[requiredRule]"
+      />
+      <VTextField
+        v-model="model.symbol"
+        name="symbol"
+        :label="$t('terms.symbol')"
+        variant="filled"
+        density="comfortable"
+        :disabled="isViewMode"
+        :prepend-icon="mdiTag"
+        :rules="[requiredRule]"
+      />
+      <VTextField
+        v-model="decimals"
+        name="decimals"
+        type="number"
+        :label="$t('pages.assets.forms.decimals')"
+        variant="filled"
+        density="comfortable"
+        :disabled="isViewMode"
+        :prepend-icon="mdiDecimal"
+        :rules="[requiredRule]"
+      />
+    </template>
+  </VForm>
+</template>
+
+<script lang="ts" setup>
+import { mdiDecimal, mdiKeyChain, mdiTag, mdiTextBox, mdiTransitConnectionVariant } from '@mdi/js';
+import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import { VForm, VTextField } from 'vuetify/components';
+import BlockchainAutocomplete from '~/components/inputs/BlockchainAutocomplete.vue';
+import MetadataField from '~/components/inputs/MetadataField.vue';
+import { Asset } from '~/generated/station/station.did';
+import { VFormValidation } from '~/types/helper.types';
+import { requiredRule } from '~/utils/form.utils';
+import StandardsAutocomplete from '../inputs/StandardsAutocomplete.vue';
+import InternetComputerNativeStandardForm from './standards/InternetComputerNativeStandardForm.vue';
+
+export type AssetFormProps = {
+  modelValue: Partial<Asset>;
+  triggerSubmit?: boolean;
+  valid?: boolean;
+  mode?: 'view' | 'edit';
+  display?: {
+    id?: boolean;
+  };
+};
+
+const form = ref<VFormValidation | null>(null);
+
+const input = withDefaults(defineProps<AssetFormProps>(), {
+  valid: true,
+  display: () => ({
+    id: true,
+  }),
+  mode: 'edit',
+  triggerSubmit: false,
+});
+const props = toRefs(input);
+
+const isViewMode = computed(() => props.mode.value === 'view');
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload: AssetFormProps['modelValue']): void;
+  (event: 'update:triggerSubmit', payload: boolean): void;
+  (event: 'valid', payload: boolean): void;
+  (event: 'submit', payload: AssetFormProps['modelValue']): void;
+}>();
+
+const model = computed(() => props.modelValue.value);
+
+watch(model.value, newValue => emit('update:modelValue', newValue), { deep: true });
+
+const decimals = computed({
+  get: () => (model.value.decimals === undefined ? '' : model.value.decimals.toString()),
+  set: value => {
+    model.value.decimals = value !== '' ? Number.parseInt(value) : undefined;
+  },
+});
+
+onMounted(() => {
+  if (!model.value.metadata) {
+    model.value.metadata = [];
+  }
+});
+
+const isFormValid = computed(() => (form.value ? form.value.isValid : false));
+watch(
+  () => isFormValid.value,
+  isValid => emit('valid', isValid ?? false),
+);
+
+watch(
+  () => props.triggerSubmit.value,
+  () => {
+    if (props.triggerSubmit.value) {
+      emit('update:triggerSubmit', false);
+      submit();
+    }
+  },
+);
+
+const submit = async () => {
+  const { valid } = form.value ? await form.value.validate() : { valid: false };
+
+  if (valid) {
+    emit('submit', model.value);
+  }
+};
+</script>

--- a/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.spec.ts
+++ b/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '~/test.utils';
+import InternetComputerNativeStandardForm from './InternetComputerNativeStandardForm.vue';
+
+describe('InternetComputerNativeStandardForm', () => {
+  it('renders correctly for creation', () => {
+    const wrapper = mount(InternetComputerNativeStandardForm, {
+      props: {
+        modelValue: [],
+        readonly: false,
+      },
+    });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('initializes custom form from metadata', async () => {
+    const wrapper = mount(InternetComputerNativeStandardForm, {
+      props: {
+        modelValue: [
+          {
+            key: 'ledger_canister_id',
+            value: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
+          },
+          {
+            key: 'index_canister_id',
+            value: 'qhbym-qaaaa-aaaaa-aaafq-cai',
+          },
+        ],
+        readonly: false,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const ledgerInput = wrapper.find('input[name="metadata_ledger_canister_id"]')
+      .element as HTMLInputElement;
+    const indexInput = wrapper.find('input[name="metadata_index_canister_id"]')
+      .element as HTMLInputElement;
+
+    expect(ledgerInput.value).toBe('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    expect(indexInput.value).toBe('qhbym-qaaaa-aaaaa-aaafq-cai');
+  });
+});

--- a/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.vue
+++ b/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.vue
@@ -1,7 +1,7 @@
 <template>
   <VTextField
-    name="metadata_ledger_canister_id"
     v-model="ledgerId"
+    name="metadata_ledger_canister_id"
     :label="$t('pages.assets.forms.ledger_canister_id')"
     variant="filled"
     density="comfortable"
@@ -10,8 +10,8 @@
     :rules="[requiredRule, validCanisterId]"
   />
   <VTextField
-    name="metadata_index_canister_id"
     v-model="indexId"
+    name="metadata_index_canister_id"
     :label="$t('pages.assets.forms.index_canister_id')"
     variant="filled"
     density="comfortable"

--- a/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.vue
+++ b/apps/wallet/src/components/assets/standards/InternetComputerNativeStandardForm.vue
@@ -1,0 +1,70 @@
+<template>
+  <VTextField
+    name="metadata_ledger_canister_id"
+    v-model="ledgerId"
+    :label="$t('pages.assets.forms.ledger_canister_id')"
+    variant="filled"
+    density="comfortable"
+    :disabled="props.readonly"
+    :prepend-icon="mdiDatabase"
+    :rules="[requiredRule, validCanisterId]"
+  />
+  <VTextField
+    name="metadata_index_canister_id"
+    v-model="indexId"
+    :label="$t('pages.assets.forms.index_canister_id')"
+    variant="filled"
+    density="comfortable"
+    :disabled="props.readonly"
+    :prepend-icon="mdiDatabase"
+    :rules="[requiredRule, validCanisterId]"
+  />
+</template>
+<script lang="ts" setup>
+import { mdiDatabase } from '@mdi/js';
+import { computed, onMounted, ref, watch } from 'vue';
+import { VTextField } from 'vuetify/components';
+import { AssetMetadata } from '~/generated/station/station.did';
+import { requiredRule, validCanisterId } from '~/utils/form.utils';
+
+const props = defineProps<{
+  modelValue: AssetMetadata[];
+  readonly: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [AssetMetadata[]];
+}>();
+
+const ledgerId = ref();
+const indexId = ref();
+
+const model = computed({
+  get: () => props.modelValue,
+  set: (value: AssetMetadata[]) => {
+    emit('update:modelValue', value);
+  },
+});
+
+onMounted(() => {
+  const ledger = props.modelValue.find(m => m.key === 'ledger_canister_id');
+  const index = props.modelValue.find(m => m.key === 'index_canister_id');
+
+  ledgerId.value = ledger?.value;
+  indexId.value = index?.value;
+});
+
+watch(ledgerId, () => {
+  const newValue = model.value.filter(m => m.key !== 'ledger_canister_id');
+  newValue.push({ key: 'ledger_canister_id', value: ledgerId.value });
+
+  model.value = newValue;
+});
+
+watch(indexId, () => {
+  const newValue = model.value.filter(m => m.key !== 'index_canister_id');
+  newValue.push({ key: 'index_canister_id', value: indexId.value });
+
+  model.value = newValue;
+});
+</script>

--- a/apps/wallet/src/components/inputs/AssetAutocomplete.spec.ts
+++ b/apps/wallet/src/components/inputs/AssetAutocomplete.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StationService } from '~/services/station.service';
+import { mount } from '~/test.utils';
+import AssetAutocomplete from './AssetAutocomplete.vue';
+
+vi.mock('~/services/station.service', () => {
+  const mock: Partial<StationService> = {
+    withStationId: vi.fn().mockReturnThis(),
+    listAssets: vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        assets: [],
+        next_offset: [BigInt(0)],
+        total: BigInt(0),
+      }),
+    ),
+  };
+
+  return {
+    StationService: vi.fn(() => mock),
+  };
+});
+
+describe('AssetAutocomplete', () => {
+  it('renders with selected ids', () => {
+    const wrapper = mount(AssetAutocomplete, {
+      props: {
+        modelValue: ['1'],
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+
+    const autocomplete = wrapper.findComponent({ name: 'VAutocomplete' });
+    expect(autocomplete.exists()).toBe(true);
+
+    expect(autocomplete.props('modelValue')).toEqual(['1']);
+  });
+
+  it('renders with empty list of assets', async () => {
+    const wrapper = mount(AssetAutocomplete);
+    const autocomplete = wrapper.findComponent({ name: 'VAutocomplete' });
+
+    expect(autocomplete.exists()).toBe(true);
+
+    await wrapper.vm.$nextTick();
+
+    expect(autocomplete.props('items')).toEqual([]);
+  });
+});

--- a/apps/wallet/src/components/inputs/AssetAutocomplete.vue
+++ b/apps/wallet/src/components/inputs/AssetAutocomplete.vue
@@ -1,0 +1,90 @@
+<template>
+  <VAutocomplete
+    v-model="model"
+    :multiple="props.multiple.value"
+    :label="props.label.value"
+    item-value="value"
+    item-title="text"
+    :items="items"
+    :variant="props.variant.value"
+    :density="props.density.value"
+    :readonly="props.readonly.value"
+    :disabled="props.disabled.value"
+    @update:search="autocomplete.search"
+  />
+</template>
+<script setup lang="ts">
+import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import { useAssetAutocomplete } from '~/composables/autocomplete.composable';
+import { UUID } from '~/generated/station/station.did';
+import { SelectItem } from '~/types/helper.types';
+
+const input = withDefaults(
+  defineProps<{
+    modelValue?: UUID[] | UUID;
+    label?: string;
+    variant?: 'underlined' | 'outlined';
+    density?: 'comfortable' | 'compact';
+    multiple?: boolean;
+    readonly?: boolean;
+    disabled?: boolean;
+  }>(),
+  {
+    modelValue: () => [],
+    label: undefined,
+    variant: 'underlined',
+    density: 'comfortable',
+    multiple: false,
+    readonly: false,
+    disabled: false,
+  },
+);
+
+const props = toRefs(input);
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload: UUID[] | UUID): void;
+  (event: 'remove', payload: void): void;
+}>();
+
+const model = computed({
+  get: () => props.modelValue.value,
+  set: value => emit('update:modelValue', value),
+});
+
+const items = ref<SelectItem[]>([]);
+
+const autocomplete = useAssetAutocomplete();
+
+const updateAvailableItemsList = (results: SelectItem[] = []) => {
+  const selectedItems = Array.isArray(model.value) ? model.value : [model.value];
+  for (const item of selectedItems) {
+    const found = results.find(i => i.value === item);
+    if (!found) {
+      results.push({
+        value: item,
+        text: item,
+      });
+    }
+  }
+
+  items.value = results;
+};
+
+onMounted(() => {
+  updateAvailableItemsList();
+  autocomplete.searchItems();
+});
+
+watch(
+  () => autocomplete.results.value,
+  results => {
+    const updatedItems = results.map(result => ({
+      value: result.id,
+      text: result.name,
+    }));
+
+    updateAvailableItemsList(updatedItems);
+  },
+);
+</script>

--- a/apps/wallet/src/components/inputs/StandardsAutocomplete.spec.ts
+++ b/apps/wallet/src/components/inputs/StandardsAutocomplete.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '~/test.utils';
+import StandardsAutocomplete from './StandardsAutocomplete.vue';
+
+describe('StandardsAutocomplete', () => {
+  it('renders with selected ids', () => {
+    const wrapper = mount(StandardsAutocomplete, {
+      props: {
+        modelValue: ['1'],
+        blockchain: 'icp',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+
+    const autocomplete = wrapper.findComponent({ name: 'VCombobox' });
+    expect(autocomplete.exists()).toBe(true);
+
+    expect(autocomplete.props('modelValue')).toEqual(['1']);
+  });
+
+  it('renders with empty list of standards', async () => {
+    const wrapper = mount(StandardsAutocomplete, {
+      props: {
+        blockchain: 'icp',
+      },
+    });
+    const autocomplete = wrapper.findComponent({ name: 'VCombobox' });
+
+    expect(autocomplete.exists()).toBe(true);
+
+    await wrapper.vm.$nextTick();
+
+    expect(autocomplete.props('items')).toEqual([]);
+  });
+});

--- a/apps/wallet/src/components/inputs/StandardsAutocomplete.vue
+++ b/apps/wallet/src/components/inputs/StandardsAutocomplete.vue
@@ -1,27 +1,27 @@
 <template>
   <VCombobox
     v-model="model"
-    :multiple="props.multiple.value"
-    :label="props.label.value"
+    :multiple="props.multiple"
+    :label="props.label"
     item-value="value"
     item-title="text"
     :items="items"
-    :variant="props.variant.value"
-    :density="props.density.value"
-    :readonly="props.readonly.value"
-    :disabled="props.disabled.value"
-    :rules="props.rules.value"
+    :variant="props.variant"
+    :density="props.density"
+    :readonly="props.readonly"
+    :disabled="props.disabled"
+    :rules="props.rules"
   />
 </template>
 
 <script setup lang="ts">
-import { computed, toRefs } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { VCombobox } from 'vuetify/components';
 import { useStationStore } from '~/stores/station.store';
 import { FormValidationRuleFn } from '~/types/helper.types';
 
-const input = withDefaults(
+const props = withDefaults(
   defineProps<{
     modelValue?: string[];
     blockchain: string;
@@ -45,18 +45,17 @@ const input = withDefaults(
   },
 );
 
-const props = toRefs(input);
+// const props = toRefs(input);
 const i18n = useI18n();
 const station = useStationStore();
 const standardsData = computed(
   () =>
-    station.configuration.details.supported_blockchains.find(
-      b => b.blockchain === props.blockchain.value,
-    )?.supported_standards || [],
+    station.configuration.details.supported_blockchains.find(b => b.blockchain === props.blockchain)
+      ?.supported_standards || [],
 );
 
 const model = computed({
-  get: () => props.modelValue.value,
+  get: () => props.modelValue,
   set: value => {
     const standards = value as { value: string; text: string }[] | undefined;
 
@@ -74,7 +73,7 @@ const emit = defineEmits<{
 const items = computed(() =>
   standardsData.value.map(data => ({
     value: data.standard,
-    text: i18n.t(`blockchains.${props.blockchain.value}.standards.${data.standard}`),
+    text: i18n.t(`blockchains.${props.blockchain}.standards.${data.standard}`),
   })),
 );
 </script>

--- a/apps/wallet/src/components/inputs/StandardsAutocomplete.vue
+++ b/apps/wallet/src/components/inputs/StandardsAutocomplete.vue
@@ -1,0 +1,80 @@
+<template>
+  <VCombobox
+    v-model="model"
+    :multiple="props.multiple.value"
+    :label="props.label.value"
+    item-value="value"
+    item-title="text"
+    :items="items"
+    :variant="props.variant.value"
+    :density="props.density.value"
+    :readonly="props.readonly.value"
+    :disabled="props.disabled.value"
+    :rules="props.rules.value"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { VCombobox } from 'vuetify/components';
+import { useStationStore } from '~/stores/station.store';
+import { FormValidationRuleFn } from '~/types/helper.types';
+
+const input = withDefaults(
+  defineProps<{
+    modelValue?: string[];
+    blockchain: string;
+    label?: string;
+    variant?: 'underlined' | 'outlined' | 'filled';
+    density?: 'comfortable' | 'compact';
+    multiple?: boolean;
+    readonly?: boolean;
+    disabled?: boolean;
+    rules?: FormValidationRuleFn[];
+  }>(),
+  {
+    modelValue: undefined,
+    label: undefined,
+    variant: 'filled',
+    density: 'comfortable',
+    multiple: false,
+    readonly: false,
+    disabled: false,
+    rules: undefined,
+  },
+);
+
+const props = toRefs(input);
+const i18n = useI18n();
+const station = useStationStore();
+const standardsData = computed(
+  () =>
+    station.configuration.details.supported_blockchains.find(
+      b => b.blockchain === props.blockchain.value,
+    )?.supported_standards || [],
+);
+
+const model = computed({
+  get: () => props.modelValue.value,
+  set: value => {
+    const standards = value as { value: string; text: string }[] | undefined;
+
+    emit(
+      'update:modelValue',
+      standards?.map(v => v.value),
+    );
+  },
+});
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload?: string[]): void;
+}>();
+
+const items = computed(() =>
+  standardsData.value.map(data => ({
+    value: data.standard,
+    text: i18n.t(`blockchains.${props.blockchain.value}.standards.${data.standard}`),
+  })),
+);
+</script>

--- a/apps/wallet/src/components/request-policies/specifier/AssetSpecifier.vue
+++ b/apps/wallet/src/components/request-policies/specifier/AssetSpecifier.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="d-flex ga-4 flex-column">
+    <div v-if="!props.readonly.value" class="d-flex ga-2">
+      <VBtn
+        :active="isAny"
+        :disabled="props.disabled.value"
+        variant="outlined"
+        size="small"
+        @click="setSelectionMode('Any')"
+      >
+        {{ $t('terms.all') }}
+      </VBtn>
+      <VBtn
+        :active="isIds"
+        :disabled="props.disabled.value"
+        variant="outlined"
+        size="small"
+        @click="setSelectionMode('Ids')"
+      >
+        {{ $t('terms.subset') }}
+      </VBtn>
+    </div>
+    <AssetAutocomplete
+      v-if="isIds"
+      v-model="idsModel"
+      :label="$t('terms.assets')"
+      variant="underlined"
+      density="comfortable"
+      multiple
+      :disabled="props.disabled.value || props.readonly.value"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, toRefs } from 'vue';
+import AssetAutocomplete from '~/components/inputs/AssetAutocomplete.vue';
+import { ResourceIds } from '~/generated/station/station.did';
+import { variantIs } from '~/utils/helper.utils';
+
+const input = withDefaults(
+  defineProps<{
+    modelValue?: ResourceIds;
+    disabled?: boolean;
+    readonly?: boolean;
+  }>(),
+  {
+    modelValue: () => ({ Any: null }),
+    disabled: false,
+    readonly: false,
+  },
+);
+
+const props = toRefs(input);
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', payload: ResourceIds): void;
+}>();
+
+const model = computed({
+  get: () => props.modelValue.value,
+  set: value => emit('update:modelValue', value),
+});
+
+const isAny = computed(() => variantIs(model.value, 'Any'));
+const isIds = computed(() => variantIs(model.value, 'Ids'));
+
+const idsModel = computed({
+  get: () => (variantIs(model.value, 'Ids') ? model.value.Ids : []),
+  set: value => {
+    if (variantIs(model.value, 'Ids')) {
+      model.value.Ids = value;
+    }
+  },
+});
+
+const setSelectionMode = (variant: 'Any' | 'Ids'): void => {
+  if (variantIs(model.value, variant)) {
+    return;
+  }
+
+  if (variant === 'Any') {
+    model.value = { Any: null };
+    return;
+  }
+
+  if (variant === 'Ids') {
+    model.value = { Ids: [] };
+    return;
+  }
+};
+</script>

--- a/apps/wallet/src/components/request-policies/specifier/SpecifierSelector.vue
+++ b/apps/wallet/src/components/request-policies/specifier/SpecifierSelector.vue
@@ -37,6 +37,7 @@ import UserGroupSpecifier from './UserGroupSpecifier.vue';
 import UserSpecifier from './UserSpecifier.vue';
 import UnsupportedSpecifier from './UnsupportedSpecifier.vue';
 import { VAutocomplete } from 'vuetify/components';
+import AssetSpecifier from './AssetSpecifier.vue';
 
 const input = withDefaults(
   defineProps<{
@@ -70,6 +71,8 @@ const componentsMap: {
 } = {
   AddUser: null,
   AddUserGroup: null,
+  AddAsset: null,
+
   AddAccount: null,
   AddRequestPolicy: null,
   AddAddressBookEntry: null,
@@ -83,6 +86,9 @@ const componentsMap: {
   EditUser: UserSpecifier,
   EditAddressBookEntry: AddressBookEntrySpecifier,
   RemoveAddressBookEntry: AddressBookEntrySpecifier,
+  EditAsset: AssetSpecifier,
+  RemoveAsset: AssetSpecifier,
+
   // below variants are not supported yet
   EditPermission: UnsupportedSpecifier,
   EditRequestPolicy: UnsupportedSpecifier,
@@ -92,9 +98,6 @@ const componentsMap: {
   CallExternalCanister: UnsupportedSpecifier,
   SetDisasterRecovery: UnsupportedSpecifier,
   FundExternalCanister: UnsupportedSpecifier,
-  AddAsset: UnsupportedSpecifier,
-  RemoveAsset: UnsupportedSpecifier,
-  EditAsset: UnsupportedSpecifier,
 };
 
 function isKeyOfRequestSpecifier(key: string): key is keyof RequestSpecifier {

--- a/apps/wallet/src/components/requests/RequestDetailView.vue
+++ b/apps/wallet/src/components/requests/RequestDetailView.vue
@@ -239,6 +239,7 @@ import RequestMetadata from './RequestMetadata.vue';
 import RequestStatusChip from './RequestStatusChip.vue';
 import AddAccountOperation from './operations/AddAccountOperation.vue';
 import AddAddressBookEntryOperation from './operations/AddAddressBookEntryOperation.vue';
+import AddAssetOperation from './operations/AddAssetOperation.vue';
 import AddRequestPolicyOperation from './operations/AddRequestPolicyOperation.vue';
 import AddUserGroupOperation from './operations/AddUserGroupOperation.vue';
 import AddUserOperation from './operations/AddUserOperation.vue';
@@ -255,6 +256,8 @@ import RemoveRequestPolicyOperation from './operations/RemoveRequestPolicyOperat
 import RemoveUserGroupOperation from './operations/RemoveUserGroupOperation.vue';
 import TransferOperation from './operations/TransferOperation.vue';
 import UnsupportedOperation from './operations/UnsupportedOperation.vue';
+import EditAssetOperation from './operations/EditAssetOperation.vue';
+import RemoveAssetOperation from './operations/RemoveAssetOperation.vue';
 
 const i18n = useI18n();
 
@@ -291,15 +294,17 @@ const componentsMap: {
   SystemUpgrade: SystemUpgradeOperation,
   EditPermission: EditPermissionOperation,
   ManageSystemInfo: ManageSystemInfoOperation,
+  AddAsset: AddAssetOperation,
+  EditAsset: EditAssetOperation,
+  RemoveAsset: RemoveAssetOperation,
+
+  // below variants are not supported yet
   ChangeExternalCanister: UnsupportedOperation,
   CreateExternalCanister: UnsupportedOperation,
   CallExternalCanister: UnsupportedOperation,
   ConfigureExternalCanister: UnsupportedOperation,
   SetDisasterRecovery: UnsupportedOperation,
   FundExternalCanister: UnsupportedOperation,
-  AddAsset: UnsupportedOperation,
-  EditAsset: UnsupportedOperation,
-  RemoveAsset: UnsupportedOperation,
 };
 
 defineEmits<{

--- a/apps/wallet/src/components/requests/RequestListItem.vue
+++ b/apps/wallet/src/components/requests/RequestListItem.vue
@@ -42,6 +42,7 @@ import { KeysOfUnion } from '~/utils/helper.utils';
 import RequestStatusChip from './RequestStatusChip.vue';
 import ReviewRequestBtn from './ReviewRequestBtn.vue';
 import AddAccountOperation from './operations/AddAccountOperation.vue';
+import AddAssetOperation from './operations/AddAssetOperation.vue';
 import AddAddressBookEntryOperation from './operations/AddAddressBookEntryOperation.vue';
 import AddRequestPolicyOperation from './operations/AddRequestPolicyOperation.vue';
 import AddUserGroupOperation from './operations/AddUserGroupOperation.vue';
@@ -59,6 +60,8 @@ import RemoveRequestPolicyOperation from './operations/RemoveRequestPolicyOperat
 import RemoveUserGroupOperation from './operations/RemoveUserGroupOperation.vue';
 import TransferOperation from './operations/TransferOperation.vue';
 import UnsupportedOperation from './operations/UnsupportedOperation.vue';
+import EditAssetOperation from './operations/EditAssetOperation.vue';
+import RemoveAssetOperation from './operations/RemoveAssetOperation.vue';
 
 const props = withDefaults(
   defineProps<{
@@ -93,15 +96,17 @@ const componentsMap: {
   SystemUpgrade: SystemUpgradeOperation,
   EditPermission: EditPermissionOperation,
   ManageSystemInfo: ManageSystemInfoOperation,
+  AddAsset: AddAssetOperation,
+  EditAsset: EditAssetOperation,
+  RemoveAsset: RemoveAssetOperation,
+
+  // below variants are not supported yet
   ChangeExternalCanister: UnsupportedOperation,
   CreateExternalCanister: UnsupportedOperation,
   CallExternalCanister: UnsupportedOperation,
   ConfigureExternalCanister: UnsupportedOperation,
   SetDisasterRecovery: UnsupportedOperation,
   FundExternalCanister: UnsupportedOperation,
-  AddAsset: UnsupportedOperation,
-  EditAsset: UnsupportedOperation,
-  RemoveAsset: UnsupportedOperation,
 };
 
 defineEmits<{

--- a/apps/wallet/src/components/requests/operations/AddAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/AddAssetOperation.vue
@@ -1,0 +1,53 @@
+<template>
+  <div v-if="isListMode" class="d-flex flex-column ga-0 text-caption">
+    <RequestOperationListRow>
+      <template #name>{{ $t('terms.symbol') }}</template>
+      <template #content> {{ formValue.symbol }} ({{ formValue.name }}) </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow>
+      <template #name>{{ $t('terms.standards') }}</template>
+      <template #content>
+        {{ $t(`blockchains.${formValue.blockchain!}.name`) }}:
+        {{
+          formValue.standards
+            ?.map(standard => $t(`blockchains.${formValue.blockchain!}.standards.${standard}`))
+            .join(', ')
+        }}
+      </template>
+    </RequestOperationListRow>
+  </div>
+  <AssetForm v-else :model-value="formValue" mode="view" />
+</template>
+
+<script setup lang="ts">
+import { Ref, computed, onBeforeMount, ref } from 'vue';
+import { AddAssetOperation, Asset, Request } from '~/generated/station/station.did';
+import RequestOperationListRow from '../RequestOperationListRow.vue';
+import AssetForm from '~/components/assets/AssetForm.vue';
+
+const props = withDefaults(
+  defineProps<{
+    request: Request;
+    operation: AddAssetOperation;
+    mode?: 'list' | 'detail';
+  }>(),
+  {
+    mode: 'list',
+  },
+);
+
+const isListMode = computed(() => props.mode === 'list');
+const formValue: Ref<Partial<Asset>> = ref({});
+
+onBeforeMount(() => {
+  const entry: Partial<Asset> = {};
+  entry.blockchain = props.operation.input.blockchain;
+  entry.metadata = props.operation.input.metadata;
+  entry.symbol = props.operation.input.symbol;
+  entry.decimals = props.operation.input.decimals;
+  entry.standards = props.operation.input.standards;
+  entry.name = props.operation.input.name;
+
+  formValue.value = entry;
+});
+</script>

--- a/apps/wallet/src/components/requests/operations/EditAddressBookEntryOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditAddressBookEntryOperation.vue
@@ -19,7 +19,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular indeterminate v-else-if="loading" />
+  <VProgressCircular v-else-if="loading" indeterminate />
   <AddressBookForm v-else :model-value="formValue" mode="view" />
 </template>
 

--- a/apps/wallet/src/components/requests/operations/EditAddressBookEntryOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditAddressBookEntryOperation.vue
@@ -19,7 +19,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular v-else-if="loading" />
+  <VProgressCircular indeterminate v-else-if="loading" />
   <AddressBookForm v-else :model-value="formValue" mode="view" />
 </template>
 
@@ -35,6 +35,7 @@ import {
 import { useStationStore } from '~/stores/station.store';
 import { variantIs } from '~/utils/helper.utils';
 import RequestOperationListRow from '../RequestOperationListRow.vue';
+import { VProgressCircular } from 'vuetify/components';
 
 const props = withDefaults(
   defineProps<{

--- a/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
@@ -11,7 +11,7 @@
       <template #content> {{ blockchain_standards }} </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular indeterminate v-else-if="loading" />
+  <VProgressCircular v-else-if="loading" indeterminate />
   <AssetForm v-else :model-value="formValue" mode="view" />
 </template>
 
@@ -112,7 +112,6 @@ const fetchDetails = async () => {
 };
 
 onBeforeMount(() => {
-
   const symbol = props.operation.input.symbol?.length > 0 ? props.operation.input.symbol[0] : '';
   const name = props.operation.input.name?.length > 0 ? props.operation.input.name[0] : '';
   const blockchain =

--- a/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
@@ -112,21 +112,6 @@ const fetchDetails = async () => {
 };
 
 onBeforeMount(() => {
-  // const entry: Partial<Asset> = {};
-  // entry.id = props.operation.input.asset_id;
-
-  // if (props.operation.input.symbol?.[0]) {
-  //   entry.symbol = props.operation.input.symbol[0];
-  // }
-  // if (props.operation.input.name?.[0]) {
-  //   entry.name = props.operation.input.name[0];
-  // }
-  // if (props.operation.input.standards?.[0]) {
-  //   entry.standards = props.operation.input.standards[0];
-  // }
-  // if (props.operation.input.blockchain?.[0]) {
-  //   entry.blockchain = props.operation.input.blockchain[0];
-  // }
 
   const symbol = props.operation.input.symbol?.length > 0 ? props.operation.input.symbol[0] : '';
   const name = props.operation.input.name?.length > 0 ? props.operation.input.name[0] : '';

--- a/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditAssetOperation.vue
@@ -1,0 +1,162 @@
+<template>
+  <div v-if="isListMode" class="d-flex flex-column ga-0 text-caption">
+    <RequestOperationListRow v-if="symbol_name">
+      <template #name>{{ $t('terms.symbol') }}</template>
+      <template #content>
+        {{ symbol_name }}
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow v-if="blockchain_standards">
+      <template #name>{{ $t('terms.standards') }}</template>
+      <template #content> {{ blockchain_standards }} </template>
+    </RequestOperationListRow>
+  </div>
+  <VProgressCircular indeterminate v-else-if="loading" />
+  <AssetForm v-else :model-value="formValue" mode="view" />
+</template>
+
+<script setup lang="ts">
+import { Ref, computed, onBeforeMount, ref } from 'vue';
+import { Asset, EditAssetOperation, Request } from '~/generated/station/station.did';
+import RequestOperationListRow from '../RequestOperationListRow.vue';
+import AssetForm from '~/components/assets/AssetForm.vue';
+import { useStationStore } from '~/stores/station.store';
+import { unreachable, variantIs } from '~/utils/helper.utils';
+import { VProgressCircular } from 'vuetify/components';
+import { useI18n } from 'vue-i18n';
+const i18n = useI18n();
+
+const props = withDefaults(
+  defineProps<{
+    request: Request;
+    operation: EditAssetOperation;
+    mode?: 'list' | 'detail';
+  }>(),
+  {
+    mode: 'list',
+  },
+);
+
+const isListMode = computed(() => props.mode === 'list');
+const formValue: Ref<Partial<Asset>> = ref({});
+const station = useStationStore();
+const loading = ref(false);
+
+const symbol_name = ref('');
+const blockchain_standards = ref('');
+
+const fetchDetails = async () => {
+  loading.value = true;
+
+  const entry: Partial<Asset> = await station.service
+    .getAsset(
+      {
+        asset_id: props.operation.input.asset_id,
+      },
+      true,
+    )
+    .then(({ asset }) => asset as Partial<Asset>)
+    .catch(
+      () =>
+        ({
+          id: props.operation.input.asset_id,
+          metadata: [],
+        }) satisfies Partial<Asset>,
+    );
+
+  if (props.operation.input.blockchain && props.operation.input.blockchain.length > 0) {
+    entry.blockchain = props.operation.input.blockchain[0];
+  }
+
+  if (props.operation.input.change_metadata?.[0]) {
+    const changeMetadata = props.operation.input.change_metadata[0];
+    if (variantIs(changeMetadata, 'ReplaceAllBy')) {
+      entry.metadata = changeMetadata.ReplaceAllBy;
+    } else if (variantIs(changeMetadata, 'OverrideSpecifiedBy')) {
+      changeMetadata.OverrideSpecifiedBy.forEach(metadata => {
+        const existingValue = entry.metadata!.find(m => m.key === metadata.key);
+        if (existingValue) {
+          existingValue.value = metadata.value;
+        }
+      });
+    } else if (variantIs(changeMetadata, 'RemoveKeys')) {
+      changeMetadata.RemoveKeys.forEach(metadata => {
+        const existingValueIndex = entry.metadata!.findIndex(m => m.key === metadata);
+        if (existingValueIndex !== -1) {
+          entry.metadata!.splice(existingValueIndex, 1);
+        }
+      });
+    } else {
+      return unreachable(changeMetadata);
+    }
+  }
+
+  if (props.operation.input.symbol && props.operation.input.symbol.length > 0) {
+    entry.symbol = props.operation.input.symbol[0];
+  }
+
+  if (props.operation.input.decimals !== undefined) {
+    entry.decimals = props.operation.input.decimals[0];
+  }
+
+  if (props.operation.input.standards && props.operation.input.standards.length > 0) {
+    entry.standards = props.operation.input.standards[0];
+  }
+
+  if (props.operation.input.name && props.operation.input.name.length > 0) {
+    entry.name = props.operation.input.name[0];
+  }
+
+  formValue.value = entry;
+  loading.value = false;
+};
+
+onBeforeMount(() => {
+  // const entry: Partial<Asset> = {};
+  // entry.id = props.operation.input.asset_id;
+
+  // if (props.operation.input.symbol?.[0]) {
+  //   entry.symbol = props.operation.input.symbol[0];
+  // }
+  // if (props.operation.input.name?.[0]) {
+  //   entry.name = props.operation.input.name[0];
+  // }
+  // if (props.operation.input.standards?.[0]) {
+  //   entry.standards = props.operation.input.standards[0];
+  // }
+  // if (props.operation.input.blockchain?.[0]) {
+  //   entry.blockchain = props.operation.input.blockchain[0];
+  // }
+
+  const symbol = props.operation.input.symbol?.length > 0 ? props.operation.input.symbol[0] : '';
+  const name = props.operation.input.name?.length > 0 ? props.operation.input.name[0] : '';
+  const blockchain =
+    props.operation.input.blockchain?.length > 0 ? props.operation.input.blockchain[0] : '';
+  const standards: string[] =
+    props.operation.input.standards?.length > 0 ? props.operation.input.standards[0]! : [];
+
+  if (symbol && name) {
+    symbol_name.value = `${symbol} (${name})`;
+  } else if (symbol) {
+    symbol_name.value = symbol;
+  } else if (name) {
+    symbol_name.value = name;
+  }
+
+  if (blockchain && standards.length > 0) {
+    blockchain_standards.value = `${i18n.t(`blockchains.${blockchain}.name`)}: ${standards
+      .map(standard => i18n.t(`blockchains.${blockchain}.standards.${standard}`))
+      .join(', ')}`;
+  } else if (blockchain) {
+    blockchain_standards.value = i18n.t(`blockchains.${blockchain}.name`);
+  } else if (standards) {
+    blockchain_standards.value = standards.join(', ');
+  }
+
+  if (!isListMode.value) {
+    fetchDetails();
+  }
+
+  // formValue.value = entry;
+});
+</script>

--- a/apps/wallet/src/components/requests/operations/EditPermissionOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditPermissionOperation.vue
@@ -11,7 +11,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular v-else-if="loading" />
+  <VProgressCircular indeterminate v-else-if="loading" />
   <PermissionForm v-else :model-value="permission" mode="view" />
 </template>
 

--- a/apps/wallet/src/components/requests/operations/EditPermissionOperation.vue
+++ b/apps/wallet/src/components/requests/operations/EditPermissionOperation.vue
@@ -11,7 +11,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular indeterminate v-else-if="loading" />
+  <VProgressCircular v-else-if="loading" indeterminate />
   <PermissionForm v-else :model-value="permission" mode="view" />
 </template>
 

--- a/apps/wallet/src/components/requests/operations/RemoveAddressBookEntryOperation.vue
+++ b/apps/wallet/src/components/requests/operations/RemoveAddressBookEntryOperation.vue
@@ -7,7 +7,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular indeterminate v-else-if="loading" />
+  <VProgressCircular v-else-if="loading" indeterminate />
   <AddressBookForm v-else :model-value="formValue" mode="view" />
 </template>
 

--- a/apps/wallet/src/components/requests/operations/RemoveAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/RemoveAssetOperation.vue
@@ -8,26 +8,22 @@
     </RequestOperationListRow>
   </div>
   <VProgressCircular indeterminate v-else-if="loading" />
-  <AddressBookForm v-else :model-value="formValue" mode="view" />
+  <AssetForm v-else :model-value="formValue" mode="view" />
 </template>
 
 <script setup lang="ts">
 import { Ref, computed, onBeforeMount, ref } from 'vue';
-import AddressBookForm from '~/components/address-book/AddressBookForm.vue';
 import logger from '~/core/logger.core';
-import {
-  AddressBookEntry,
-  Request,
-  RemoveAddressBookEntryOperation,
-} from '~/generated/station/station.did';
+import { Asset, RemoveAssetOperation, Request } from '~/generated/station/station.did';
 import { useStationStore } from '~/stores/station.store';
 import RequestOperationListRow from '../RequestOperationListRow.vue';
+import AssetForm from '~/components/assets/AssetForm.vue';
 import { VProgressCircular } from 'vuetify/components';
 
 const props = withDefaults(
   defineProps<{
     request: Request;
-    operation: RemoveAddressBookEntryOperation;
+    operation: RemoveAssetOperation;
     mode?: 'list' | 'detail';
   }>(),
   {
@@ -36,35 +32,43 @@ const props = withDefaults(
 );
 
 const isListMode = computed(() => props.mode === 'list');
-const formValue: Ref<Partial<AddressBookEntry>> = ref({});
+const formValue: Ref<Partial<Asset>> = ref({});
 const loading = ref(false);
+const assetLoadingFailed = ref(false);
 const station = useStationStore();
 
 const fetchDetails = async () => {
+  assetLoadingFailed.value = false;
   try {
     if (loading.value || isListMode.value) {
       return;
     }
 
     loading.value = true;
-    const currentEntry = await station.service.getAddressBookEntry(
-      {
-        address_book_entry_id: props.operation.input.address_book_entry_id,
-      },
-      true,
-    );
+    const currentEntry: Partial<Asset> = await station.service
+      .getAsset(
+        {
+          asset_id: props.operation.input.asset_id,
+        },
+        true,
+      )
+      .then(response => response.asset)
+      .catch(() => ({
+        id: props.operation.input.asset_id,
+      }));
 
-    formValue.value = currentEntry.address_book_entry;
+    formValue.value = currentEntry;
   } catch (e) {
-    logger.error('Failed to fetch address book entry details', e);
+    logger.error('Failed to fetch asset details', e);
+    assetLoadingFailed.value = true;
   } finally {
     loading.value = false;
   }
 };
 
 onBeforeMount(() => {
-  const entry: Partial<AddressBookEntry> = {};
-  entry.id = props.operation.input.address_book_entry_id;
+  const entry: Partial<Asset> = {};
+  entry.id = props.operation.input.asset_id;
 
   formValue.value = entry;
 

--- a/apps/wallet/src/components/requests/operations/RemoveAssetOperation.vue
+++ b/apps/wallet/src/components/requests/operations/RemoveAssetOperation.vue
@@ -7,7 +7,7 @@
       </template>
     </RequestOperationListRow>
   </div>
-  <VProgressCircular indeterminate v-else-if="loading" />
+  <VProgressCircular v-else-if="loading" indeterminate />
   <AssetForm v-else :model-value="formValue" mode="view" />
 </template>
 

--- a/apps/wallet/src/composables/autocomplete.composable.ts
+++ b/apps/wallet/src/composables/autocomplete.composable.ts
@@ -101,3 +101,18 @@ export const useAddressBookAutocomplete = () => {
 
   return autocomplete;
 };
+
+export const useAssetAutocomplete = () => {
+  const station = useStationStore();
+
+  const autocomplete = useAutocomplete(async () => {
+    const results = await station.service.listAssets({
+      limit: 100,
+      offset: 0,
+    });
+
+    return results.assets;
+  });
+
+  return autocomplete;
+};

--- a/apps/wallet/src/composables/request.composable.ts
+++ b/apps/wallet/src/composables/request.composable.ts
@@ -57,6 +57,13 @@ export const useAvailableDomains = (): Ref<AvailableDomain[]> => {
     });
   }
 
+  if (hasRequiredPrivilege({ anyOf: [Privilege.ListAssets] })) {
+    domains.value.push({
+      id: RequestDomains.Assets,
+      types: [{ AddAsset: null }, { EditAsset: null }, { RemoveAsset: null }],
+    });
+  }
+
   domains.value.push({
     id: RequestDomains.System,
     types: [

--- a/apps/wallet/src/configs/permissions.config.ts
+++ b/apps/wallet/src/configs/permissions.config.ts
@@ -357,6 +357,48 @@ export const globalPermissions = (): AggregatedResoucePermissions[] => [
       return false;
     },
   },
+  {
+    resourceType: ResourceTypeEnum.Asset,
+    resources: [
+      {
+        action: ResourceActionEnum.List,
+        resource: { Asset: { List: null } },
+        allow: defaultAllowLevels(),
+        canEdit: false,
+      },
+      {
+        action: ResourceActionEnum.Create,
+        resource: { Asset: { Create: null } },
+        allow: defaultAllowLevels(),
+        canEdit: false,
+      },
+      {
+        action: ResourceActionEnum.Read,
+        resource: { Asset: { Read: { Any: null } } },
+        allow: defaultAllowLevels(),
+        canEdit: false,
+      },
+      {
+        action: ResourceActionEnum.Update,
+        resource: { Asset: { Update: { Any: null } } },
+        allow: defaultAllowLevels(),
+        canEdit: false,
+      },
+      {
+        action: ResourceActionEnum.Delete,
+        resource: { Asset: { Delete: { Any: null } } },
+        allow: defaultAllowLevels(),
+        canEdit: false,
+      },
+    ],
+    match(specifier: Resource, resource: Resource): boolean {
+      if (variantIs(specifier, 'Asset') && variantIs(resource, 'Asset')) {
+        return isResourceActionContained(specifier.Asset, resource.Asset);
+      }
+
+      return false;
+    },
+  },
 ];
 
 export const getAccountPermissions = (accountId: UUID): AggregatedResoucePermissions[] => {

--- a/apps/wallet/src/configs/routes.config.ts
+++ b/apps/wallet/src/configs/routes.config.ts
@@ -14,6 +14,7 @@ export enum Routes {
   Initialization = 'Initialization',
   AddStation = 'AddStation',
   Permissions = 'Permissions',
+  Assets = 'Assets',
   // Request Pages
   Requests = 'Requests',
   TransferRequests = 'TransferRequests',

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1684,6 +1684,24 @@ type Asset = record {
   decimals : nat32;
 };
 
+// Describes a standard suported by a blockchain.
+type StandardData = record {
+  // The standard name.
+  standard : text;
+  // Required metadata fields for the standard (e.g. `["ledger_canister_id"]`).
+  required_metadata_fields : vec text;
+  // Supported operations for the standard (e.g. `["transfer", "list_transfers", "balance"]`).
+  supported_operations : vec text;
+};
+
+// Describes a blockchain and its standards supported by the station.
+type SupportedBlockchain = record {
+  // The blockchain name.
+  blockchain : text;
+  // The supported standards for the blockchain.
+  supported_standards : vec StandardData;
+};
+
 // A record type that is used to show the current capabilities of the station.
 type Capabilities = record {
   // The name of the station.
@@ -1692,6 +1710,8 @@ type Capabilities = record {
   version : text;
   // The list of supported assets.
   supported_assets : vec Asset;
+  // The list of supported blockchains and standards.
+  supported_blockchains : vec SupportedBlockchain;
 };
 
 // Result type for getting the current config.
@@ -2261,6 +2281,8 @@ type UserPrivilege = variant {
   ListRequests;
   CreateExternalCanister;
   ListExternalCanisters;
+  ListAssets;
+  AddAsset;
 };
 
 type MeResult = variant {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -193,6 +193,7 @@ export interface Capabilities {
   'name' : string,
   'version' : string,
   'supported_assets' : Array<Asset>,
+  'supported_blockchains' : Array<SupportedBlockchain>,
 }
 export type CapabilitiesResult = { 'Ok' : { 'capabilities' : Capabilities } } |
   { 'Err' : Error };
@@ -1080,6 +1081,11 @@ export interface SetDisasterRecoveryOperationInput {
 export type Sha256Hash = string;
 export type SortByDirection = { 'Asc' : null } |
   { 'Desc' : null };
+export interface StandardData {
+  'supported_operations' : Array<string>,
+  'required_metadata_fields' : Array<string>,
+  'standard' : string,
+}
 export interface SubmitRequestApprovalInput {
   'request_id' : UUID,
   'decision' : RequestApprovalStatus,
@@ -1093,6 +1099,10 @@ export type SubmitRequestApprovalResult = {
     }
   } |
   { 'Err' : Error };
+export interface SupportedBlockchain {
+  'blockchain' : string,
+  'supported_standards' : Array<StandardData>,
+}
 export interface SystemInfo {
   'disaster_recovery' : [] | [DisasterRecovery],
   'name' : string,
@@ -1206,8 +1216,10 @@ export type UserPrivilege = { 'AddUserGroup' : null } |
   { 'ListUserGroups' : null } |
   { 'AddUser' : null } |
   { 'ListUsers' : null } |
+  { 'AddAsset' : null } |
   { 'SystemUpgrade' : null } |
   { 'CreateExternalCanister' : null } |
+  { 'ListAssets' : null } |
   { 'ManageSystemInfo' : null } |
   { 'AddAddressBookEntry' : null } |
   { 'ListAccounts' : null } |

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -78,10 +78,20 @@ export const idlFactory = ({ IDL }) => {
     'blockchain' : IDL.Text,
     'symbol' : AssetSymbol,
   });
+  const StandardData = IDL.Record({
+    'supported_operations' : IDL.Vec(IDL.Text),
+    'required_metadata_fields' : IDL.Vec(IDL.Text),
+    'standard' : IDL.Text,
+  });
+  const SupportedBlockchain = IDL.Record({
+    'blockchain' : IDL.Text,
+    'supported_standards' : IDL.Vec(StandardData),
+  });
   const Capabilities = IDL.Record({
     'name' : IDL.Text,
     'version' : IDL.Text,
     'supported_assets' : IDL.Vec(Asset),
+    'supported_blockchains' : IDL.Vec(SupportedBlockchain),
   });
   const CapabilitiesResult = IDL.Variant({
     'Ok' : IDL.Record({ 'capabilities' : Capabilities }),
@@ -1297,8 +1307,10 @@ export const idlFactory = ({ IDL }) => {
     'ListUserGroups' : IDL.Null,
     'AddUser' : IDL.Null,
     'ListUsers' : IDL.Null,
+    'AddAsset' : IDL.Null,
     'SystemUpgrade' : IDL.Null,
     'CreateExternalCanister' : IDL.Null,
+    'ListAssets' : IDL.Null,
     'ManageSystemInfo' : IDL.Null,
     'AddAddressBookEntry' : IDL.Null,
     'ListAccounts' : IDL.Null,

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -94,6 +94,7 @@ export default {
       verify_instructions:
         'To verify the update, open the terminal and follow the instructions bellow:',
     },
+    asset: 'Asset',
   },
   alpha_warning: {
     version: 'This is an alpha version.',
@@ -162,6 +163,7 @@ export default {
       system: 'System',
       transfers: 'Transfers',
       users: 'Users',
+      assets: 'Assets',
     },
     headers: {
       id: 'ID',
@@ -273,6 +275,18 @@ export default {
       managesysteminfo: {
         title: 'Manage system info',
         request_title: 'Manage system info request',
+      },
+      addasset: {
+        title: 'Add asset',
+        request_title: 'Add asset request',
+      },
+      editasset: {
+        title: 'Edit asset',
+        request_title: 'Edit asset request',
+      },
+      removeasset: {
+        title: 'Remove asset',
+        request_title: 'Remove asset request',
       },
       unknown: {
         title: 'Unknown',
@@ -538,6 +552,9 @@ export default {
     version: 'Version',
     continue: 'Continue',
     cycle_obtain_strategy: 'Wallet top-up method',
+    symbol: 'Symbol',
+    standards: 'Standards',
+    assets: 'Assets',
   },
   forms: {
     create: 'Create',
@@ -574,6 +591,7 @@ export default {
     transfer_requests: 'Transfer Requests',
     permissions: 'Permissions',
     request_policies: 'Request Policies',
+    assets: 'Assets',
   },
   pages: {
     accounts: {
@@ -686,6 +704,17 @@ export default {
       title: 'Request Policies',
       create_label: 'Add Policy',
       dialog_title: 'Policy',
+    },
+    assets: {
+      title: 'Assets',
+      btn_new_entry: 'New asset',
+      no_results_found: 'No assets found.',
+      error_fetching_assets: 'Error fetching assets, please try again.',
+      forms: {
+        ledger_canister_id: 'Ledger Canister ID',
+        index_canister_id: 'Index Canister ID',
+        decimals: 'Decimals',
+      },
     },
     not_found: {
       title: 'Whoops, 404',
@@ -804,6 +833,9 @@ export default {
       setdisasterrecovery: 'Configure disaster recovery',
       callexternalcanister: 'Call canister',
       createexternalcanister: 'Create canister',
+      addasset: 'Add asset',
+      editasset: 'Edit asset',
+      removeasset: 'Remove asset',
     },
   },
   cycle_obtain_strategies: {

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -726,6 +726,7 @@ export default {
     select_resource: 'Resource Type',
     resources: {
       account: 'Account',
+      asset: 'Asset',
       user: 'User',
       usergroup: 'User Group',
       permission: 'Access Policy',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -96,6 +96,7 @@ export default {
       verify_instructions:
         'Pour vérifier la mise à jour, ouvrez le terminal et suivez les instructions ci-dessous:',
     },
+    asset: 'Actif',
   },
   alpha_warning: {
     version: 'Ceci est une version alpha.',
@@ -172,6 +173,7 @@ export default {
       system: 'Système',
       transfers: 'Transferts',
       users: 'Usagers',
+      assets: 'Actifs',
     },
     headers: {
       id: 'ID',
@@ -283,6 +285,18 @@ export default {
       managesysteminfo: {
         title: 'Gérer les informations système',
         request_title: 'Demande de gérer les informations système',
+      },
+      addasset: {
+        title: 'Ajouter un actif',
+        request_title: 'Demande d ajouter un actif',
+      },
+      editasset: {
+        title: 'Modifier un actif',
+        request_title: 'Demande de modifier un actif',
+      },
+      removeasset: {
+        title: 'Supprimer un actif',
+        request_title: 'Demande de supprimer un actif',
       },
       unknown: {
         title: 'Inconnu',
@@ -543,6 +557,9 @@ export default {
     version: 'Version',
     continue: 'Continuer',
     cycle_obtain_strategy: 'Méthode de recharge du portefeuille',
+    symbol: 'Symbole',
+    standards: 'Standards',
+    assets: 'Actifs',
   },
   forms: {
     create: 'Créer',
@@ -579,6 +596,7 @@ export default {
     transfer_requests: 'Demandes de Transfert',
     permissions: "Polices d'Accés",
     request_policies: "Polices d'Aprobation",
+    assets: 'Actifs',
   },
   pages: {
     accounts: {
@@ -697,6 +715,17 @@ export default {
       create_label: 'Ajouter un police',
       dialog_title: 'Police',
     },
+    assets: {
+      title: 'Actifs',
+      btn_new_asset: 'Nouvel Actif',
+      no_results_found: 'Pas d actif trouvé.',
+      error_fetching_assets: 'Erreur lors du chargement des actifs, veuillez essayer de nouveau.',
+      forms: {
+        ledger_canister_id: 'ID du Canister Ledger',
+        index_canister_id: 'ID du Canister Index',
+        decimals: 'Décimales',
+      },
+    },
     not_found: {
       title: 'Oulala, 404',
       subtitle: "La page que vous cherchez n'existe pas.",
@@ -736,6 +765,7 @@ export default {
     select_resource: 'Type de Resource',
     resources: {
       account: 'Compte',
+      asset: 'Actif',
       user: 'Usager',
       usergroup: "Groupe d'Usagers",
       permission: "Police d'Accés",
@@ -813,6 +843,9 @@ export default {
       setdisasterrecovery: 'Définir la récupération après sinistre',
       callexternalcanister: 'Appeler un canister',
       createexternalcanister: 'Créer un canister',
+      addasset: 'Ajouter un actif',
+      editasset: 'Modifier un actif',
+      removeasset: 'Éffacer un actif',
     },
   },
   cycle_obtain_strategies: {

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -95,6 +95,7 @@ export default {
       verify_instructions:
         'Para verificar a atualização, abra o terminal e siga as instruções abaixo:',
     },
+    assets: 'Ativos',
   },
   alpha_warning: {
     version: 'Esta é uma versão alfa.',
@@ -171,6 +172,7 @@ export default {
       system: 'Sistema',
       transfers: 'Transferências',
       users: 'Usuários',
+      assets: 'Ativos',
     },
     download: {
       user_group: 'Grupos de usuários',
@@ -282,6 +284,18 @@ export default {
       managesysteminfo: {
         title: 'Gerir informações do sistema',
         request_title: 'Pedido de alteração de informações do sistema',
+      },
+      addasset: {
+        title: 'Adicionar ativo',
+        request_title: 'Pedido de adição de ativo',
+      },
+      editasset: {
+        title: 'Editar ativo',
+        request_title: 'Pedido de alteração de ativo',
+      },
+      removeasset: {
+        title: 'Remover ativo',
+        request_title: 'Pedido de remoção de ativo',
       },
       unknown: {
         title: 'Desconhecido',
@@ -540,6 +554,9 @@ export default {
     version: 'Versão',
     continue: 'Continuar',
     cycle_obtain_strategy: 'Método de recarga da carteira',
+    symbol: 'Símbolo',
+    standards: 'Padrões',
+    assets: 'Ativos',
   },
   forms: {
     create: 'Criar',
@@ -576,6 +593,7 @@ export default {
     transfer_requests: 'Pedidos de transferência',
     permissions: 'Permissões',
     request_policies: 'Regras de aprovação',
+    assets: 'Ativos',
   },
   pages: {
     accounts: {
@@ -694,6 +712,17 @@ export default {
       create_label: 'Criar Regra',
       dialog_title: 'Regra',
     },
+    assets: {
+      title: 'Ativos',
+      btn_new_entry: 'Novo ativo',
+      no_results_found: 'Nenhum ativo encontrado.',
+      error_fetching_assets: 'Erro ao carregar os ativos, por favor, tente novamente.',
+      forms: {
+        ledger_canister_id: 'ID do canister de contabilidade',
+        index_canister_id: 'ID do canister de índice',
+        decimals: 'Decimais',
+      },
+    },
     not_found: {
       title: 'Ups, 404',
       subtitle: 'A página que está a tentar aceder não existe.',
@@ -733,6 +762,7 @@ export default {
     select_resource: 'Selecione o tipo de recurso',
     resources: {
       account: 'Conta',
+      asset: 'Ativo',
       user: 'Usuário',
       usergroup: 'Grupo de usuários',
       permission: 'Regra de acesso',
@@ -809,6 +839,9 @@ export default {
       fundexternalcanister: 'Financiar canister',
       setdisasterrecovery: 'Recuperação de sistema',
       callexternalcanister: 'Interagir com canister',
+      addasset: 'Adicionar ativo',
+      editasset: 'Editar ativo',
+      removeasset: 'Remover ativo',
     },
   },
   cycle_obtain_strategies: {

--- a/apps/wallet/src/pages/AssetsPage.vue
+++ b/apps/wallet/src/pages/AssetsPage.vue
@@ -1,0 +1,170 @@
+<template>
+  <PageLayout>
+    <template #main-header>
+      <PageHeader :title="pageTitle" :breadcrumbs="props.breadcrumbs">
+        <template #actions>
+          <AuthCheck :privileges="[Privilege.AddAsset]">
+            <AssetDialogBtn :text="$t('pages.assets.btn_new_entry')" />
+          </AuthCheck>
+        </template>
+      </PageHeader>
+    </template>
+    <template #main-body>
+      <PageBody>
+        <AuthCheck :privileges="[Privilege.ListRequests]">
+          <RecentRequests
+            class="mb-4"
+            :see-all-link="{
+              name: Routes.Requests,
+              query: { group_by: RequestDomains.Assets },
+            }"
+            :types="[{ AddAsset: null }, { EditAsset: null }, { RemoveAsset: null }]"
+            hide-not-found
+          />
+        </AuthCheck>
+
+        <DataLoader
+          v-slot="{ loading }"
+          v-model:force-reload="forceReload"
+          :disable-refresh="disableRefresh"
+          :load="fetchList"
+          :refresh-interval-ms="5000"
+          @loaded="
+            result => {
+              assets = result.assets;
+              privileges = result.privileges;
+            }
+          "
+        >
+          <VDataTable
+            class="elevation-2 rounded"
+            :loading="loading"
+            :headers="headers"
+            :items="assets"
+            :items-per-page="-1"
+            :hover="true"
+          >
+            <template #bottom>
+              <!--this hides the footer as pagination is not required-->
+            </template>
+            <template #item.symbol="{ item: asset }">
+              {{ asset.symbol }} ({{ asset.name }})
+            </template>
+            <template #item.blockchain="{ item: asset }">
+              {{ $t(`blockchains.${asset.blockchain.toLowerCase()}.name`) }}
+            </template>
+            <template #item.standards="{ item: asset }">
+              {{ asset.standards.join(', ') }}
+            </template>
+
+            <template #item.actions="{ item: asset }">
+              <div class="d-flex justify-end">
+                <ActionBtn
+                  v-if="hasDeletePrivilege(asset.id)"
+                  v-model="asset.id"
+                  :icon="mdiTrashCanOutline"
+                  :submit="id => station.service.removeAsset({ asset_id: id })"
+                  @failed="useOnFailedOperation"
+                  @submitted="useOnSuccessfulOperation"
+                />
+                <AssetDialogBtn
+                  :icon="!hasEditPrivilege(asset.id) ? mdiEye : mdiPencil"
+                  :asset-id="asset.id"
+                  :readonly="!hasEditPrivilege(asset.id)"
+                  variant="flat"
+                  color="default"
+                  size="small"
+                  @opened="disableRefresh = $event"
+                />
+              </div>
+            </template>
+          </VDataTable>
+        </DataLoader>
+        <VPagination
+          v-model="pagination.selectedPage"
+          class="mt-2"
+          :length="pagination.totalPages"
+          rounded
+          density="comfortable"
+          @update:model-value="triggerSearch"
+        />
+      </PageBody>
+    </template>
+  </PageLayout>
+</template>
+
+<script lang="ts" setup>
+import { mdiEye, mdiPencil, mdiTrashCanOutline } from '@mdi/js';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { VDataTable, VPagination } from 'vuetify/components';
+import AuthCheck from '~/components/AuthCheck.vue';
+import DataLoader from '~/components/DataLoader.vue';
+import PageLayout from '~/components/PageLayout.vue';
+import AssetDialogBtn from '~/components/assets/AssetDialogBtn.vue';
+import ActionBtn from '~/components/buttons/ActionBtn.vue';
+import PageBody from '~/components/layouts/PageBody.vue';
+import PageHeader from '~/components/layouts/PageHeader.vue';
+import RecentRequests from '~/components/requests/RecentRequests.vue';
+import { useFetchList, usePagination } from '~/composables/lists.composable';
+import {
+  useOnFailedOperation,
+  useOnSuccessfulOperation,
+} from '~/composables/notifications.composable';
+import { Routes } from '~/configs/routes.config';
+import { Asset, AssetCallerPrivileges, UUID } from '~/generated/station/station.did';
+import { useStationStore } from '~/stores/station.store';
+import type { PageProps, TableHeader } from '~/types/app.types';
+import { Privilege } from '~/types/auth.types';
+import { RequestDomains } from '~/types/station.types';
+import { throttle } from '~/utils/helper.utils';
+
+const props = withDefaults(defineProps<PageProps>(), { title: undefined, breadcrumbs: () => [] });
+const station = useStationStore();
+const i18n = useI18n();
+const pageTitle = computed(() => props.title || i18n.t('pages.assets.title'));
+const assets = ref<Asset[]>([]);
+const privileges = ref<AssetCallerPrivileges[]>([]);
+const disableRefresh = ref(false);
+const forceReload = ref(false);
+const pagination = usePagination();
+const triggerSearch = throttle(() => (forceReload.value = true), 500);
+const headers = ref<TableHeader[]>([
+  { title: i18n.t('terms.symbol'), key: 'symbol', sortable: false },
+  { title: i18n.t('terms.blockchain'), key: 'blockchain', sortable: false },
+  { title: i18n.t('terms.standards'), key: 'standards', sortable: false },
+  { title: '', key: 'actions', sortable: false },
+]);
+
+const hasEditPrivilege = (id: UUID): boolean => {
+  const privilege = privileges.value.find(p => p.id === id);
+  return !!privilege?.can_edit;
+};
+
+const hasDeletePrivilege = (id: UUID): boolean => {
+  const privilege = privileges.value.find(p => p.id === id);
+  return !!privilege?.can_delete;
+};
+
+let useVerifiedCall = false;
+
+const fetchList = useFetchList(
+  (offset, limit) => {
+    const results = station.service.listAssets(
+      {
+        offset,
+        limit,
+      },
+      useVerifiedCall,
+    );
+
+    useVerifiedCall = true;
+
+    return results;
+  },
+  {
+    pagination,
+    getTotal: res => Number(res.total),
+  },
+);
+</script>

--- a/apps/wallet/src/plugins/navigation.plugin.ts
+++ b/apps/wallet/src/plugins/navigation.plugin.ts
@@ -163,6 +163,19 @@ const sections = (): NavigationSections => ({
             route: Routes.Requests,
           },
         },
+        {
+          name: 'assets',
+          localeKey: 'navigation.assets',
+          action: {
+            type: NavigationActionType.To,
+            handle: route =>
+              route.params.locale ? `/${route.params.locale}/settings/assets` : '/settings/assets',
+          },
+          auth: {
+            type: NavigastionAuthType.Route,
+            route: Routes.Assets,
+          },
+        },
       ],
     },
   ],

--- a/apps/wallet/src/plugins/router.plugin.ts
+++ b/apps/wallet/src/plugins/router.plugin.ts
@@ -337,6 +337,29 @@ const router = createRouter({
                 },
               },
             },
+            {
+              path: 'assets',
+              name: Routes.Assets,
+              component: () => import('~/pages/AssetsPage.vue'),
+              props: () => {
+                return {
+                  title: i18n.global.t('pages.assets.title'),
+                  breadcrumbs: [
+                    { title: i18n.global.t('navigation.home'), to: { name: defaultHomeRoute } },
+                    { title: i18n.global.t('navigation.settings') },
+                    { title: i18n.global.t('navigation.assets') },
+                  ],
+                };
+              },
+              meta: {
+                auth: {
+                  check: {
+                    session: RequiredSessionState.ConnectedToStation,
+                    privileges: [Privilege.ListAssets],
+                  },
+                },
+              },
+            },
           ],
         },
         {

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -5,6 +5,7 @@ import {
   AccountBalance,
   AddAccountOperationInput,
   AddAddressBookEntryOperationInput,
+  AddAssetOperationInput,
   AddRequestPolicyOperationInput,
   AddUserGroupOperationInput,
   AddUserOperationInput,
@@ -13,6 +14,7 @@ import {
   DisasterRecoveryCommittee,
   EditAccountOperationInput,
   EditAddressBookEntryOperationInput,
+  EditAssetOperationInput,
   EditPermissionOperationInput,
   EditRequestPolicyOperationInput,
   EditUserGroupOperationInput,
@@ -22,6 +24,8 @@ import {
   GetAccountResult,
   GetAddressBookEntryInput,
   GetAddressBookEntryResult,
+  GetAssetInput,
+  GetAssetResult,
   GetNextApprovableRequestResult,
   GetPermissionInput,
   GetPermissionResult,
@@ -36,6 +40,7 @@ import {
   ListAccountTransfersInput,
   ListAccountsResult,
   ListAddressBookEntriesResult,
+  ListAssetsResult,
   ListNotificationsInput,
   ListPermissionsInput,
   ListPermissionsResult,
@@ -48,6 +53,7 @@ import {
   MarkNotificationsReadInput,
   Notification,
   PaginationInput,
+  RemoveAssetOperationInput,
   RemoveUserGroupOperationInput,
   Request,
   SubmitRequestApprovalInput,
@@ -67,6 +73,7 @@ import {
   GetNextApprovableRequestArgs,
   ListAccountsArgs,
   ListAddressBookEntriesArgs,
+  ListAssetsArgs,
   ListRequestsArgs,
 } from '~/types/station.types';
 import { transformIdlWithOnlyVerifiedCalls, variantIs } from '~/utils/helper.utils';
@@ -554,6 +561,82 @@ export class StationService {
     }
 
     return result.Ok;
+  }
+
+  async getAsset(input: GetAssetInput, verifiedCall = false): Promise<ExtractOk<GetAssetResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.get_asset(input);
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
+  }
+  async listAssets(
+    { limit, offset }: ListAssetsArgs = {},
+    verifiedCall = false,
+  ): Promise<ExtractOk<ListAssetsResult>> {
+    const actor = verifiedCall ? this.verified_actor : this.actor;
+    const result = await actor.list_assets({
+      paginate: [
+        {
+          limit: limit !== undefined ? [limit] : [],
+          offset: offset !== undefined ? [BigInt(offset)] : [],
+        },
+      ],
+    });
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok;
+  }
+
+  async addAsset(input: AddAssetOperationInput): Promise<Request> {
+    const result = await this.actor.create_request({
+      execution_plan: [{ Immediate: null }],
+      title: [],
+      summary: [],
+      operation: { AddAsset: input },
+    });
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok.request;
+  }
+
+  async editAsset(input: EditAssetOperationInput): Promise<Request> {
+    const result = await this.actor.create_request({
+      execution_plan: [{ Immediate: null }],
+      title: [],
+      summary: [],
+      operation: { EditAsset: input },
+    });
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok.request;
+  }
+
+  async removeAsset(input: RemoveAssetOperationInput): Promise<Request> {
+    const result = await this.actor.create_request({
+      execution_plan: [{ Immediate: null }],
+      title: [],
+      summary: [],
+      operation: { RemoveAsset: input },
+    });
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok.request;
   }
 
   async getAccount(

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -123,6 +123,7 @@ const initialStoreState = (): StationStoreState => {
         name: '',
         version: '',
         supported_assets: [],
+        supported_blockchains: [],
       },
       cycleObtainStrategy: { Disabled: null },
     },

--- a/apps/wallet/src/types/auth.types.ts
+++ b/apps/wallet/src/types/auth.types.ts
@@ -15,6 +15,8 @@ export enum Privilege {
   ListRequests = 'ListRequests',
   SystemUpgrade = 'SystemUpgrade',
   ManageSystemInfo = 'ManageSystemInfo',
+  ListAssets = 'ListAssets',
+  AddAsset = 'AddAsset',
 }
 
 export enum RequiredSessionState {

--- a/apps/wallet/src/types/station.types.ts
+++ b/apps/wallet/src/types/station.types.ts
@@ -71,6 +71,7 @@ export enum RequestDomains {
   Transfers = 'transfers',
   Users = 'users',
   System = 'system',
+  Assets = 'assets',
 }
 
 export interface ListAccountsArgs {
@@ -136,6 +137,11 @@ export interface ListAddressBookEntriesArgs {
   blockchain?: string;
   labels?: [];
   ids?: UUID[];
+}
+
+export interface ListAssetsArgs {
+  limit?: number;
+  offset?: number;
 }
 
 export type MetadataItem = { key: string; value: string };

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1684,6 +1684,24 @@ type Asset = record {
   decimals : nat32;
 };
 
+// Describes a standard suported by a blockchain.
+type StandardData = record {
+  // The standard name.
+  standard : text;
+  // Required metadata fields for the standard (e.g. `["ledger_canister_id"]`).
+  required_metadata_fields : vec text;
+  // Supported operations for the standard (e.g. `["transfer", "list_transfers", "balance"]`).
+  supported_operations : vec text;
+};
+
+// Describes a blockchain and its standards supported by the station.
+type SupportedBlockchain = record {
+  // The blockchain name.
+  blockchain : text;
+  // The supported standards for the blockchain.
+  supported_standards : vec StandardData;
+};
+
 // A record type that is used to show the current capabilities of the station.
 type Capabilities = record {
   // The name of the station.
@@ -1692,6 +1710,8 @@ type Capabilities = record {
   version : text;
   // The list of supported assets.
   supported_assets : vec Asset;
+  // The list of supported blockchains and standards.
+  supported_blockchains : vec SupportedBlockchain;
 };
 
 // Result type for getting the current config.
@@ -2261,6 +2281,8 @@ type UserPrivilege = variant {
   ListRequests;
   CreateExternalCanister;
   ListExternalCanisters;
+  ListAssets;
+  AddAsset;
 };
 
 type MeResult = variant {

--- a/core/station/api/src/capabilities.rs
+++ b/core/station/api/src/capabilities.rs
@@ -10,9 +10,24 @@ pub struct CapabilitiesDTO {
     pub version: String,
     /// The list of assets that are supported by the canister (e.g. `ICP`, `BTC`, `ETH`, etc.)
     pub supported_assets: Vec<AssetDTO>,
+    /// The list of blockchains and standards that are supported by the canister (e.g. `ethereum`, `bitcoin`, `icp`, etc.)
+    pub supported_blockchains: Vec<SupportedBlockchainDTO>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct CapabilitiesResponse {
     pub capabilities: CapabilitiesDTO,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
+pub struct SupportedBlockchainDTO {
+    pub blockchain: String,
+    pub supported_standards: Vec<StandardDataDTO>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
+pub struct StandardDataDTO {
+    pub standard: String,
+    pub required_metadata_fields: Vec<String>,
+    pub supported_operations: Vec<String>,
 }

--- a/core/station/api/src/user.rs
+++ b/core/station/api/src/user.rs
@@ -112,6 +112,8 @@ pub enum UserPrivilege {
     ListRequests,
     CreateExternalCanister,
     ListExternalCanisters,
+    ListAssets,
+    AddAsset,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/controllers/capabilities.rs
+++ b/core/station/impl/src/controllers/capabilities.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{
         middlewares::{authorize, call_context},
-        read_system_info,
+        read_system_info, SUPPORTED_BLOCKCHAINS,
     },
     models::resource::{Resource, SystemResourceAction},
     repositories::ASSET_REPOSITORY,
@@ -11,7 +11,7 @@ use ic_cdk_macros::query;
 use lazy_static::lazy_static;
 use orbit_essentials::with_middleware;
 use orbit_essentials::{api::ApiResult, repository::Repository};
-use station_api::{CapabilitiesDTO, CapabilitiesResponse};
+use station_api::{CapabilitiesDTO, CapabilitiesResponse, StandardDataDTO, SupportedBlockchainDTO};
 
 #[query(name = "capabilities")]
 async fn capabilities() -> ApiResult<CapabilitiesResponse> {
@@ -43,6 +43,25 @@ impl CapabilitiesController {
                     .list()
                     .into_iter()
                     .map(|asset| asset.into())
+                    .collect(),
+                supported_blockchains: SUPPORTED_BLOCKCHAINS
+                    .iter()
+                    .map(|suported_blockchain| SupportedBlockchainDTO {
+                        blockchain: suported_blockchain.blockchain.to_string(),
+                        supported_standards: suported_blockchain
+                            .supported_standards
+                            .iter()
+                            .map(|data| StandardDataDTO {
+                                required_metadata_fields: data.required_metadata_fields.clone(),
+                                standard: data.standard.to_string(),
+                                supported_operations: data
+                                    .supported_operations
+                                    .iter()
+                                    .map(|operation| operation.to_string())
+                                    .collect(),
+                            })
+                            .collect(),
+                    })
                     .collect(),
             },
         })

--- a/core/station/impl/src/controllers/capabilities.rs
+++ b/core/station/impl/src/controllers/capabilities.rs
@@ -51,11 +51,10 @@ impl CapabilitiesController {
                         supported_standards: suported_blockchain
                             .supported_standards
                             .iter()
-                            .map(|data| StandardDataDTO {
-                                required_metadata_fields: data.standard.get_required_metadata(),
-                                standard: data.standard.to_string(),
-                                supported_operations: data
-                                    .standard
+                            .map(|standard| StandardDataDTO {
+                                required_metadata_fields: standard.get_required_metadata(),
+                                standard: standard.to_string(),
+                                supported_operations: standard
                                     .get_supported_operations()
                                     .iter()
                                     .map(|operation| operation.to_string())

--- a/core/station/impl/src/controllers/capabilities.rs
+++ b/core/station/impl/src/controllers/capabilities.rs
@@ -52,10 +52,11 @@ impl CapabilitiesController {
                             .supported_standards
                             .iter()
                             .map(|data| StandardDataDTO {
-                                required_metadata_fields: data.required_metadata_fields.clone(),
+                                required_metadata_fields: data.standard.get_required_metadata(),
                                 standard: data.standard.to_string(),
                                 supported_operations: data
-                                    .supported_operations
+                                    .standard
+                                    .get_supported_operations()
                                     .iter()
                                     .map(|operation| operation.to_string())
                                     .collect(),

--- a/core/station/impl/src/core/mod.rs
+++ b/core/station/impl/src/core/mod.rs
@@ -13,7 +13,9 @@ pub use call_context::*;
 
 pub mod middlewares;
 pub mod observer;
+pub mod standards;
 pub mod validation;
+pub use standards::*;
 
 #[cfg(not(test))]
 pub use orbit_essentials::cdk as ic_cdk;

--- a/core/station/impl/src/core/standards.rs
+++ b/core/station/impl/src/core/standards.rs
@@ -2,22 +2,16 @@ use lazy_static::lazy_static;
 
 use crate::models::{Blockchain, BlockchainStandard};
 
-pub struct StandardData {
-    pub standard: BlockchainStandard,
-}
-
 pub struct SupportedBlockchain {
     pub blockchain: Blockchain,
-    pub supported_standards: Vec<StandardData>,
+    pub supported_standards: Vec<BlockchainStandard>,
 }
 
 lazy_static! {
     pub static ref SUPPORTED_BLOCKCHAINS: Vec<SupportedBlockchain> = {
         vec![SupportedBlockchain {
             blockchain: Blockchain::InternetComputer,
-            supported_standards: vec![StandardData {
-                standard: BlockchainStandard::Native,
-            }],
+            supported_standards: vec![BlockchainStandard::Native],
         }]
     };
 }

--- a/core/station/impl/src/core/standards.rs
+++ b/core/station/impl/src/core/standards.rs
@@ -1,0 +1,49 @@
+use lazy_static::lazy_static;
+
+use crate::models::{Blockchain, BlockchainStandard};
+
+pub struct StandardData {
+    pub standard: BlockchainStandard,
+    pub required_metadata_fields: Vec<String>,
+    pub supported_operations: Vec<StandardOperation>,
+}
+
+pub enum StandardOperation {
+    Balance,
+    Transfer,
+    ListTransfers,
+}
+impl std::fmt::Display for StandardOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StandardOperation::Balance => write!(f, "balance"),
+            StandardOperation::Transfer => write!(f, "transfer"),
+            StandardOperation::ListTransfers => write!(f, "list_transfers"),
+        }
+    }
+}
+
+pub struct SupportedBlockchain {
+    pub blockchain: Blockchain,
+    pub supported_standards: Vec<StandardData>,
+}
+
+lazy_static! {
+    pub static ref SUPPORTED_BLOCKCHAINS: Vec<SupportedBlockchain> = {
+        vec![SupportedBlockchain {
+            blockchain: Blockchain::InternetComputer,
+            supported_standards: vec![StandardData {
+                standard: BlockchainStandard::Native,
+                required_metadata_fields: vec![
+                    "ledger_canister_id".to_string(),
+                    "index_canister_id".to_string(),
+                ],
+                supported_operations: vec![
+                    StandardOperation::Balance,
+                    StandardOperation::Transfer,
+                    StandardOperation::ListTransfers,
+                ],
+            }],
+        }]
+    };
+}

--- a/core/station/impl/src/core/standards.rs
+++ b/core/station/impl/src/core/standards.rs
@@ -4,23 +4,6 @@ use crate::models::{Blockchain, BlockchainStandard};
 
 pub struct StandardData {
     pub standard: BlockchainStandard,
-    pub required_metadata_fields: Vec<String>,
-    pub supported_operations: Vec<StandardOperation>,
-}
-
-pub enum StandardOperation {
-    Balance,
-    Transfer,
-    ListTransfers,
-}
-impl std::fmt::Display for StandardOperation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StandardOperation::Balance => write!(f, "balance"),
-            StandardOperation::Transfer => write!(f, "transfer"),
-            StandardOperation::ListTransfers => write!(f, "list_transfers"),
-        }
-    }
 }
 
 pub struct SupportedBlockchain {
@@ -34,15 +17,6 @@ lazy_static! {
             blockchain: Blockchain::InternetComputer,
             supported_standards: vec![StandardData {
                 standard: BlockchainStandard::Native,
-                required_metadata_fields: vec![
-                    "ledger_canister_id".to_string(),
-                    "index_canister_id".to_string(),
-                ],
-                supported_operations: vec![
-                    StandardOperation::Balance,
-                    StandardOperation::Transfer,
-                    StandardOperation::ListTransfers,
-                ],
             }],
         }]
     };

--- a/core/station/impl/src/mappers/authorization.rs
+++ b/core/station/impl/src/mappers/authorization.rs
@@ -1,7 +1,6 @@
 use super::HelperMapper;
 use crate::{
-    core::ic_cdk::api::trap,
-    core::CallContext,
+    core::{ic_cdk::api::trap, CallContext},
     models::{
         resource::{
             AccountResourceAction, CallExternalCanisterResourceTarget, ExternalCanisterId,
@@ -17,7 +16,7 @@ use orbit_essentials::repository::Repository;
 use orbit_essentials::types::UUID;
 use station_api::{RequestOperationInput, UserPrivilege};
 
-pub const USER_PRIVILEGES: [UserPrivilege; 18] = [
+pub const USER_PRIVILEGES: [UserPrivilege; 20] = [
     UserPrivilege::Capabilities,
     UserPrivilege::SystemInfo,
     UserPrivilege::ManageSystemInfo,
@@ -36,6 +35,8 @@ pub const USER_PRIVILEGES: [UserPrivilege; 18] = [
     UserPrivilege::ListRequests,
     UserPrivilege::CreateExternalCanister,
     UserPrivilege::ListExternalCanisters,
+    UserPrivilege::AddAsset,
+    UserPrivilege::ListAssets,
 ];
 
 impl From<UserPrivilege> for Resource {
@@ -65,6 +66,8 @@ impl From<UserPrivilege> for Resource {
             UserPrivilege::ListExternalCanisters => {
                 Resource::ExternalCanister(ExternalCanisterResourceAction::List)
             }
+            UserPrivilege::AddAsset => Resource::Asset(ResourceAction::Create),
+            UserPrivilege::ListAssets => Resource::Asset(ResourceAction::List),
         }
     }
 }

--- a/core/station/impl/src/models/blockchain_standard.rs
+++ b/core/station/impl/src/models/blockchain_standard.rs
@@ -13,6 +13,22 @@ pub enum BlockchainStandard {
     ERC20,
 }
 
+impl BlockchainStandard {
+    pub fn get_required_metadata(&self) -> Vec<String> {
+        match self {
+            BlockchainStandard::Native => vec![
+                "ledger_canister_id".to_string(),
+                "index_canister_id".to_string(),
+            ],
+            BlockchainStandard::ICRC1 => vec![
+                "ledger_canister_id".to_string(),
+                "index_canister_id".to_string(),
+            ],
+            BlockchainStandard::ERC20 => vec!["contract_address".to_string()],
+        }
+    }
+}
+
 impl FromStr for BlockchainStandard {
     type Err = ();
 

--- a/core/station/impl/src/models/blockchain_standard.rs
+++ b/core/station/impl/src/models/blockchain_standard.rs
@@ -13,6 +13,21 @@ pub enum BlockchainStandard {
     ERC20,
 }
 
+pub enum StandardOperation {
+    Balance,
+    Transfer,
+    ListTransfers,
+}
+impl std::fmt::Display for StandardOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StandardOperation::Balance => write!(f, "balance"),
+            StandardOperation::Transfer => write!(f, "transfer"),
+            StandardOperation::ListTransfers => write!(f, "list_transfers"),
+        }
+    }
+}
+
 impl BlockchainStandard {
     pub fn get_required_metadata(&self) -> Vec<String> {
         match self {
@@ -25,6 +40,18 @@ impl BlockchainStandard {
                 "index_canister_id".to_string(),
             ],
             BlockchainStandard::ERC20 => vec!["contract_address".to_string()],
+        }
+    }
+
+    pub fn get_supported_operations(&self) -> Vec<StandardOperation> {
+        match self {
+            BlockchainStandard::Native => vec![
+                StandardOperation::Balance,
+                StandardOperation::Transfer,
+                StandardOperation::ListTransfers,
+            ],
+            BlockchainStandard::ICRC1 => vec![],
+            BlockchainStandard::ERC20 => vec![],
         }
     }
 }

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -539,7 +539,7 @@ mod init_canister_sync_handlers {
         }];
 
         for asset in initial_assets {
-            ic_cdk::api::print(format!("Adding initial asset: {}", asset.name));
+            print(format!("Adding initial asset: {}", asset.name));
             ASSET_REPOSITORY.insert(asset.key(), asset);
         }
     }

--- a/scripts/approve-user.sh
+++ b/scripts/approve-user.sh
@@ -1,0 +1,2 @@
+PRINCIPAL=$1
+dfx canister call control_panel update_waiting_list 'record { users = vec { principal "'$PRINCIPAL'" }; new_status = variant {Approved} }'

--- a/scripts/approve-user.sh
+++ b/scripts/approve-user.sh
@@ -1,2 +1,0 @@
-PRINCIPAL=$1
-dfx canister call control_panel update_waiting_list 'record { users = vec { principal "'$PRINCIPAL'" }; new_status = variant {Approved} }'


### PR DESCRIPTION
Add asset management UI:
- assets page
- asset create/edit dialog
- asset request operation components
- UI tests

Limitations / known issues:
- Standards autocomplete picker shows the code vs. the localized name of the standard.
- new Accounts are created for ICP, even if another asset is selected, thats because it is hard coded currently

---

Added to the sidebar:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/9ec840ba-c105-44f5-89ec-442cbbb4c4f8">

Assets page:
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/904e00b9-fbed-48b5-b091-9fc3a37b7164">

Add new asset:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/5cab6d89-da51-4f1a-a6c5-e5c8c56b02c6">

Edit asset:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/6acb7cb8-d712-4dda-8f43-14dfd1352e9c">

Peding edit request:
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/8ed708f1-4f17-4adb-8b94-b6aee5511333">

Peding edit request details:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/a2fc01dd-e258-4278-ae40-fa282157a93f">
