### PR TITLE
feat(station): support large station wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5215,6 +5215,7 @@ dependencies = [
  "mockall",
  "orbit-essentials",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.8",

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -555,11 +555,22 @@ type SystemUpgradeTarget = variant {
   UpgradeUpgrader;
 };
 
+type WasmModuleExtraChunks = record {
+  // The asset canister from which the chunks are to be retrieved.
+  store_canister : principal;
+  // The list of chunk hashes in the order they should be appended to the wasm module.
+  chunk_hashes_list : vec blob;
+  // The hash of the assembled wasm module.
+  wasm_module_hash : blob;
+};
+
 type SystemUpgradeOperationInput = record {
   // The target to change.
   target : SystemUpgradeTarget;
   // The wasm module to install.
   module : blob;
+  // Additional wasm module chunks to append to the wasm module.
+  module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
 };

--- a/core/station/api/src/system.rs
+++ b/core/station/api/src/system.rs
@@ -112,10 +112,20 @@ pub enum SystemUpgradeTargetDTO {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct WasmModuleExtraChunks {
+    pub store_canister: Principal,
+    // TODO: deserialize_with
+    pub chunk_hashes_list: Vec<Vec<u8>>,
+    #[serde(with = "serde_bytes")]
+    pub wasm_module_hash: Vec<u8>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct SystemUpgradeOperationInput {
     pub target: SystemUpgradeTargetDTO,
     #[serde(with = "serde_bytes")]
     pub module: Vec<u8>,
+    pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
     pub arg: Option<Vec<u8>>,
 }

--- a/core/station/impl/src/factories/requests/system_upgrade.rs
+++ b/core/station/impl/src/factories/requests/system_upgrade.rs
@@ -111,6 +111,12 @@ impl Execute for SystemUpgradeRequestExecute<'_, '_> {
             }
 
             SystemUpgradeTarget::UpgradeUpgrader => {
+                if self.operation.input.module_extra_chunks.is_some() {
+                    return Err(RequestExecuteError::Failed {
+                        reason: "Installing upgrader from chunks is not supported.".to_string(),
+                    });
+                }
+
                 self.system_service
                     .upgrade_upgrader(
                         &self.operation.input.module,

--- a/core/station/impl/src/factories/requests/system_upgrade.rs
+++ b/core/station/impl/src/factories/requests/system_upgrade.rs
@@ -89,7 +89,11 @@ impl Execute for SystemUpgradeRequestExecute<'_, '_> {
                 let arg = self.operation.input.arg.as_ref().unwrap_or(&default_arg);
                 let out = self
                     .system_service
-                    .upgrade_station(&self.operation.input.module, arg)
+                    .upgrade_station(
+                        &self.operation.input.module,
+                        &self.operation.input.module_extra_chunks,
+                        arg,
+                    )
                     .await
                     .map_err(|err| RequestExecuteError::Failed {
                         reason: format!("failed to upgrade station: {}", err),

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -29,7 +29,7 @@ use crate::{
         RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, RemoveUserGroupOperation,
         RequestOperation, SetDisasterRecoveryOperation, SetDisasterRecoveryOperationInput,
         SystemUpgradeOperation, SystemUpgradeOperationInput, SystemUpgradeTarget,
-        TransferOperation, User,
+        TransferOperation, User, WasmModuleExtraChunks,
     },
     repositories::{
         AccountRepository, AddressBookRepository, UserRepository, ACCOUNT_REPOSITORY,
@@ -345,11 +345,42 @@ impl From<station_api::SystemUpgradeTargetDTO> for SystemUpgradeTarget {
     }
 }
 
+impl From<WasmModuleExtraChunks> for station_api::WasmModuleExtraChunks {
+    fn from(input: WasmModuleExtraChunks) -> station_api::WasmModuleExtraChunks {
+        station_api::WasmModuleExtraChunks {
+            store_canister: input.store_canister,
+            chunk_hashes_list: input.chunk_hashes_list,
+            wasm_module_hash: input.wasm_module_hash,
+        }
+    }
+}
+
+impl From<WasmModuleExtraChunks> for upgrader_api::WasmModuleExtraChunks {
+    fn from(input: WasmModuleExtraChunks) -> upgrader_api::WasmModuleExtraChunks {
+        upgrader_api::WasmModuleExtraChunks {
+            store_canister: input.store_canister,
+            chunk_hashes_list: input.chunk_hashes_list,
+            wasm_module_hash: input.wasm_module_hash,
+        }
+    }
+}
+
+impl From<station_api::WasmModuleExtraChunks> for WasmModuleExtraChunks {
+    fn from(input: station_api::WasmModuleExtraChunks) -> WasmModuleExtraChunks {
+        WasmModuleExtraChunks {
+            store_canister: input.store_canister,
+            chunk_hashes_list: input.chunk_hashes_list,
+            wasm_module_hash: input.wasm_module_hash,
+        }
+    }
+}
+
 impl From<SystemUpgradeOperationInput> for station_api::SystemUpgradeOperationInput {
     fn from(input: SystemUpgradeOperationInput) -> station_api::SystemUpgradeOperationInput {
         station_api::SystemUpgradeOperationInput {
             target: input.target.into(),
             module: input.module,
+            module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
         }
     }
@@ -360,6 +391,7 @@ impl From<station_api::SystemUpgradeOperationInput> for SystemUpgradeOperationIn
         SystemUpgradeOperationInput {
             target: input.target.into(),
             module: input.module,
+            module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
         }
     }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -262,11 +262,20 @@ pub enum SystemUpgradeTarget {
 }
 
 #[storable]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WasmModuleExtraChunks {
+    pub store_canister: Principal,
+    pub chunk_hashes_list: Vec<Vec<u8>>,
+    pub wasm_module_hash: Vec<u8>,
+}
+
+#[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SystemUpgradeOperationInput {
     pub target: SystemUpgradeTarget,
     /// The module is only available while the operation is not finalized.
     pub module: Vec<u8>,
+    pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     pub arg: Option<Vec<u8>>,
 }
 

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -13,7 +13,7 @@ use crate::{
         system::{DisasterRecoveryCommittee, SystemInfo, SystemState},
         CanisterInstallMode, CanisterUpgradeModeArgs, CycleObtainStrategy,
         ManageSystemInfoOperationInput, RequestId, RequestKey, RequestOperation, RequestStatus,
-        SystemUpgradeTarget,
+        SystemUpgradeTarget, WasmModuleExtraChunks,
     },
     repositories::{
         permission::PERMISSION_REPOSITORY, RequestRepository, REQUEST_REPOSITORY,
@@ -137,7 +137,12 @@ impl SystemService {
     }
 
     /// Execute an upgrade of the station by requesting the upgrader to perform it on our behalf.
-    pub async fn upgrade_station(&self, module: &[u8], arg: &[u8]) -> ServiceResult<()> {
+    pub async fn upgrade_station(
+        &self,
+        module: &[u8],
+        module_extra_chunks: &Option<WasmModuleExtraChunks>,
+        arg: &[u8],
+    ) -> ServiceResult<()> {
         let upgrader_canister_id = self.get_upgrader_canister_id();
 
         ic_cdk::call(
@@ -145,6 +150,7 @@ impl SystemService {
             "trigger_upgrade",
             (UpgradeParams {
                 module: module.to_owned(),
+                module_extra_chunks: module_extra_chunks.clone().map(|c| c.into()),
                 arg: arg.to_owned(),
             },),
         )

--- a/core/upgrader/api/spec.did
+++ b/core/upgrader/api/spec.did
@@ -12,9 +12,20 @@ type InitArg = record {
   target_canister : principal;
 };
 
+type WasmModuleExtraChunks = record {
+  // The asset canister from which the chunks are to be retrieved.
+  store_canister : principal;
+  // The list of chunk hashes in the order they should be appended to the wasm module.
+  chunk_hashes_list : vec blob;
+  // The hash of the assembled wasm module.
+  wasm_module_hash : blob;
+};
+
 type UpgradeParams = record {
   // The wasm module to upgrade to.
   module : blob;
+  // Additional wasm module chunks to append to the wasm module.
+  module_extra_chunks : opt WasmModuleExtraChunks;
   // The argument to be passed to upgrade.
   arg : blob;
 };

--- a/core/upgrader/api/src/lib.rs
+++ b/core/upgrader/api/src/lib.rs
@@ -3,9 +3,19 @@ use station_api::TimestampRfc3339;
 pub use station_api::{MetadataDTO, UuidDTO};
 
 #[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize, PartialEq)]
+pub struct WasmModuleExtraChunks {
+    pub store_canister: Principal,
+    // TODO: deserialize_with
+    pub chunk_hashes_list: Vec<Vec<u8>>,
+    #[serde(with = "serde_bytes")]
+    pub wasm_module_hash: Vec<u8>,
+}
+
+#[derive(Clone, Debug, CandidType, serde::Serialize, Deserialize, PartialEq)]
 pub struct UpgradeParams {
     #[serde(with = "serde_bytes")]
     pub module: Vec<u8>,
+    pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
 }

--- a/core/upgrader/impl/Cargo.toml
+++ b/core/upgrader/impl/Cargo.toml
@@ -24,6 +24,7 @@ ic-stable-structures = { workspace = true }
 lazy_static = { workspace = true }
 mockall = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
+serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
 serde_json = { workspace = true }
 station-api = { path = '../../station/api', version = '0.0.2-alpha.4' }

--- a/core/upgrader/impl/src/lib.rs
+++ b/core/upgrader/impl/src/lib.rs
@@ -78,6 +78,7 @@ lazy_static! {
 async fn trigger_upgrade(params: upgrader_api::UpgradeParams) -> Result<(), TriggerUpgradeError> {
     let input: UpgradeParams = UpgradeParams {
         module: params.module,
+        module_extra_chunks: params.module_extra_chunks,
         arg: params.arg,
         install_mode: CanisterInstallMode::Upgrade(None),
     };

--- a/tests/integration/src/dfx_orbit/assets.rs
+++ b/tests/integration/src/dfx_orbit/assets.rs
@@ -34,7 +34,7 @@ fn assets_upload() {
     let (dfx_principal, _dfx_user) = setup_dfx_user(&env, &canister_ids);
 
     // Install the assets canister under orbit control
-    let asset_canister = create_canister(&mut env, canister_ids.station);
+    let asset_canister = create_canister(&env, canister_ids.station);
     let asset_canister_wasm = get_canister_wasm("assetstorage");
     env.install_canister(
         asset_canister,

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -25,13 +25,11 @@ use station_api::{
 #[test]
 fn successful_four_eyes_upgrade() {
     let TestEnv {
-        mut env,
-        canister_ids,
-        ..
+        env, canister_ids, ..
     } = setup_new_env();
 
     // create and install the counter canister
-    let canister_id = create_canister(&mut env, canister_ids.station);
+    let canister_id = create_canister(&env, canister_ids.station);
     let module_bytes = wat::parse_str(COUNTER_WAT).unwrap();
     let mut sha256 = Sha256::new();
     sha256.update(module_bytes.clone());
@@ -195,13 +193,11 @@ fn successful_four_eyes_upgrade() {
 #[test]
 fn upgrade_reinstall_list_test() {
     let TestEnv {
-        mut env,
-        canister_ids,
-        ..
+        env, canister_ids, ..
     } = setup_new_env();
 
     // create and install the counter canister
-    let canister_id = create_canister(&mut env, canister_ids.station);
+    let canister_id = create_canister(&env, canister_ids.station);
     let module_bytes = wat::parse_str(COUNTER_WAT).unwrap();
     let mut sha256 = Sha256::new();
     sha256.update(module_bytes.clone());
@@ -630,13 +626,11 @@ fn call_external_canister_test() {
     const T: u128 = 1_000_000_000_000;
 
     let TestEnv {
-        mut env,
-        canister_ids,
-        ..
+        env, canister_ids, ..
     } = setup_new_env();
 
     // create and install the counter canister (validation)
-    let validation_canister_id = create_canister(&mut env, Principal::anonymous());
+    let validation_canister_id = create_canister(&env, Principal::anonymous());
     let module_bytes = wat::parse_str(COUNTER_WAT).unwrap();
     let mut sha256 = Sha256::new();
     sha256.update(module_bytes.clone());
@@ -644,7 +638,7 @@ fn call_external_canister_test() {
     env.install_canister(validation_canister_id, module_bytes.clone(), vec![], None);
 
     // create and install the counter canister (execution)
-    let execution_canister_id = create_canister(&mut env, Principal::anonymous());
+    let execution_canister_id = create_canister(&env, Principal::anonymous());
     let module_bytes = wat::parse_str(COUNTER_WAT).unwrap();
     env.install_canister(execution_canister_id, module_bytes.clone(), vec![], None);
 

--- a/tests/integration/src/notification.rs
+++ b/tests/integration/src/notification.rs
@@ -23,6 +23,7 @@ fn notification_authorization() {
     let change_canister_operation_input = SystemUpgradeOperationInput {
         target: SystemUpgradeTargetDTO::UpgradeUpgrader,
         module: vec![],
+        module_extra_chunks: None,
         arg: None,
     };
     let request_status = execute_request_with_extra_ticks(

--- a/tests/integration/src/setup.rs
+++ b/tests/integration/src/setup.rs
@@ -100,12 +100,12 @@ pub fn setup_new_env_with_config(config: SetupConfig) -> TestEnv {
     }
 }
 
-pub fn create_canister(env: &mut PocketIc, controller: Principal) -> Principal {
+pub fn create_canister(env: &PocketIc, controller: Principal) -> Principal {
     create_canister_with_cycles(env, controller, CANISTER_INITIAL_CYCLES)
 }
 
 pub fn create_canister_with_cycles(
-    env: &mut PocketIc,
+    env: &PocketIc,
     controller: Principal,
     cycles: u128,
 ) -> Principal {

--- a/tests/integration/src/test_data/system_upgrade.rs
+++ b/tests/integration/src/test_data/system_upgrade.rs
@@ -18,6 +18,7 @@ pub fn perform_upgrader_update(
             station_api::SystemUpgradeOperationInput {
                 target: station_api::SystemUpgradeTargetDTO::UpgradeUpgrader,
                 module: upgrader_wasm.clone(),
+                module_extra_chunks: None,
                 arg: None,
             },
         ),
@@ -46,6 +47,7 @@ pub fn perform_station_update(
             station_api::SystemUpgradeOperationInput {
                 target: station_api::SystemUpgradeTargetDTO::UpgradeStation,
                 module: station_wasm.clone(),
+                module_extra_chunks: None,
                 arg: None,
             },
         ),

--- a/tests/integration/src/upgrade_station_tests.rs
+++ b/tests/integration/src/upgrade_station_tests.rs
@@ -1,17 +1,70 @@
-use crate::setup::{get_canister_wasm, setup_new_env, WALLET_ADMIN_USER};
+use crate::setup::{create_canister, get_canister_wasm, setup_new_env, WALLET_ADMIN_USER};
 use crate::utils::{
-    canister_status, execute_request_with_extra_ticks, get_core_canister_health_status,
-    get_system_info, NNS_ROOT_CANISTER_ID,
+    execute_request_with_extra_ticks, get_core_canister_health_status, get_system_info,
 };
-use crate::TestEnv;
-use candid::{Encode, Principal};
+use crate::{CanisterIds, TestEnv};
+use candid::{CandidType, Encode, Principal};
 use orbit_essentials::api::ApiResult;
-use pocket_ic::update_candid_as;
+use pocket_ic::{update_candid_as, PocketIc};
 use sha2::{Digest, Sha256};
 use station_api::{
     HealthStatus, NotifyFailedStationUpgradeInput, RequestOperationInput, RequestStatusDTO,
     SystemInstall, SystemUpgrade, SystemUpgradeOperationInput, SystemUpgradeTargetDTO,
+    WasmModuleExtraChunks,
 };
+
+const EXTRA_TICKS: u64 = 50;
+
+fn do_successful_station_upgrade(
+    env: &PocketIc,
+    canister_ids: CanisterIds,
+    station_upgrade_operation: RequestOperationInput,
+) {
+    // check if canister is healthy
+    let health_status =
+        get_core_canister_health_status(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert_eq!(health_status, HealthStatus::Healthy);
+
+    // submit station upgrade request
+    // extra ticks are necessary to prevent polling on the request status
+    // before the station canister has been restarted
+    execute_request_with_extra_ticks(
+        env,
+        WALLET_ADMIN_USER,
+        canister_ids.station,
+        station_upgrade_operation.clone(),
+        EXTRA_TICKS,
+    )
+    .unwrap();
+
+    // check the status after the upgrade
+    let health_status =
+        get_core_canister_health_status(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert_eq!(health_status, HealthStatus::Healthy);
+
+    let system_info = get_system_info(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert!(system_info.raw_rand_successful);
+    let last_uprade_timestamp = system_info.last_upgrade_timestamp;
+
+    // submit one more station upgrade request with no changes
+    execute_request_with_extra_ticks(
+        env,
+        WALLET_ADMIN_USER,
+        canister_ids.station,
+        station_upgrade_operation,
+        EXTRA_TICKS,
+    )
+    .unwrap();
+
+    // check the status after the upgrade
+    let health_status =
+        get_core_canister_health_status(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert_eq!(health_status, HealthStatus::Healthy);
+
+    let system_info = get_system_info(env, WALLET_ADMIN_USER, canister_ids.station);
+    // check if the last upgrade timestamp is updated
+    assert!(system_info.last_upgrade_timestamp > last_uprade_timestamp);
+}
 
 #[test]
 fn successful_station_upgrade() {
@@ -21,72 +74,152 @@ fn successful_station_upgrade() {
 
     // get station wasm
     let station_wasm = get_canister_wasm("station").to_vec();
-    let mut hasher = Sha256::new();
-    hasher.update(&station_wasm);
-    let station_wasm_hash = hasher.finalize().to_vec();
 
-    // check if canister is healthy
-    let health_status =
-        get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert_eq!(health_status, HealthStatus::Healthy);
-
-    // submit station upgrade request
+    // create station upgrade request
     let station_init_arg = SystemInstall::Upgrade(SystemUpgrade { name: None });
     let station_init_arg_bytes = Encode!(&station_init_arg).unwrap();
     let station_upgrade_operation =
         RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
             target: SystemUpgradeTargetDTO::UpgradeStation,
-            module: station_wasm.clone(),
+            module: station_wasm,
+            module_extra_chunks: None,
             arg: Some(station_init_arg_bytes),
         });
-    // extra ticks are necessary to prevent polling on the request status
-    // before the station canister is upgraded and running
-    execute_request_with_extra_ticks(
-        &env,
-        WALLET_ADMIN_USER,
-        canister_ids.station,
-        station_upgrade_operation,
-        10,
-    )
-    .unwrap();
 
-    // check the status after the upgrade
-    let health_status =
-        get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert_eq!(health_status, HealthStatus::Healthy);
+    do_successful_station_upgrade(&env, canister_ids, station_upgrade_operation);
+}
 
-    let system_info = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert!(system_info.raw_rand_successful);
-    let last_uprade_timestamp = system_info.last_upgrade_timestamp;
+#[derive(CandidType)]
+struct StoreArg {
+    pub key: String,
+    pub content: Vec<u8>,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub sha256: Option<Vec<u8>>,
+}
 
-    // submit one more station upgrade request with no changes
+fn hash(data: Vec<u8>) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+fn upload_station_chunks_to_asset_canister(env: &PocketIc) -> (Vec<u8>, WasmModuleExtraChunks) {
+    // create and install the asset canister
+    let asset_canister_id = create_canister(env, Principal::anonymous());
+    env.install_canister(
+        asset_canister_id,
+        get_canister_wasm("assetstorage"),
+        Encode!(&()).unwrap(),
+        None,
+    );
+
+    // get station wasm
+    let station_wasm = get_canister_wasm("station").to_vec();
+    let mut hasher = Sha256::new();
+    hasher.update(&station_wasm);
+    let station_wasm_hash = hasher.finalize().to_vec();
+
+    // chunk station
+    let mut chunks = station_wasm.chunks(200_000);
+    let base_chunk: &[u8] = chunks.next().unwrap();
+    assert!(!base_chunk.is_empty());
+    let chunks: Vec<&[u8]> = chunks.collect();
+    assert!(chunks.len() >= 2);
+
+    // upload chunks to asset canister
+    for chunk in &chunks {
+        let chunk_hash = hash(chunk.to_vec());
+        let store_arg = StoreArg {
+            key: hex::encode(chunk_hash.clone()),
+            content: chunk.to_vec(),
+            content_type: "application/octet-stream".to_string(),
+            content_encoding: "identity".to_string(),
+            sha256: Some(chunk_hash),
+        };
+        update_candid_as::<_, ((),)>(
+            env,
+            asset_canister_id,
+            Principal::anonymous(),
+            "store",
+            (store_arg,),
+        )
+        .unwrap();
+    }
+
+    let module_extra_chunks = WasmModuleExtraChunks {
+        store_canister: asset_canister_id,
+        chunk_hashes_list: chunks.iter().map(|c| hash(c.to_vec())).collect(),
+        wasm_module_hash: station_wasm_hash,
+    };
+
+    (base_chunk.to_vec(), module_extra_chunks)
+}
+
+#[test]
+fn successful_station_upgrade_from_chunks() {
+    let TestEnv {
+        env, canister_ids, ..
+    } = setup_new_env();
+
+    // create station upgrade request from chunks
+    let (base_chunk, module_extra_chunks) = upload_station_chunks_to_asset_canister(&env);
+    let station_init_arg = SystemInstall::Upgrade(SystemUpgrade { name: None });
+    let station_init_arg_bytes = Encode!(&station_init_arg).unwrap();
     let station_upgrade_operation =
         RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
             target: SystemUpgradeTargetDTO::UpgradeStation,
-            module: station_wasm.clone(),
-            arg: None,
+            module: base_chunk.to_owned(),
+            module_extra_chunks: Some(module_extra_chunks),
+            arg: Some(station_init_arg_bytes),
         });
 
-    execute_request_with_extra_ticks(
-        &env,
+    do_successful_station_upgrade(&env, canister_ids, station_upgrade_operation);
+}
+
+fn do_failed_station_upgrade(
+    env: &PocketIc,
+    canister_ids: CanisterIds,
+    station_upgrade_operation: RequestOperationInput,
+    expected_reason: &str,
+) {
+    // check if station is healthy
+    let health_status =
+        get_core_canister_health_status(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert_eq!(health_status, HealthStatus::Healthy);
+
+    let system_info = get_system_info(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert!(system_info.raw_rand_successful);
+    let last_uprade_timestamp = system_info.last_upgrade_timestamp;
+
+    // submit invalid station upgrade request
+    // extra ticks are necessary to prevent polling on the request status
+    // before the station canister has been restarted
+    let request_status = execute_request_with_extra_ticks(
+        env,
         WALLET_ADMIN_USER,
         canister_ids.station,
         station_upgrade_operation,
-        10,
+        EXTRA_TICKS,
     )
+    .unwrap_err()
     .unwrap();
 
-    // check the status after the upgrade
+    // check that the station upgrade request is failed
+    match request_status {
+        RequestStatusDTO::Failed { reason } => assert!(reason.unwrap().contains(expected_reason)),
+        _ => panic!("Unexpected request status: {:?}", request_status),
+    };
+
+    // check the station status after the failed upgrade
     let health_status =
-        get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
+        get_core_canister_health_status(env, WALLET_ADMIN_USER, canister_ids.station);
     assert_eq!(health_status, HealthStatus::Healthy);
 
-    let system_info = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station);
-    // check if the last upgrade timestamp is updated
-    assert!(system_info.last_upgrade_timestamp > last_uprade_timestamp);
-
-    let status = canister_status(&env, Some(NNS_ROOT_CANISTER_ID), canister_ids.station);
-    assert_eq!(status.module_hash.unwrap(), station_wasm_hash);
+    // the last upgrade timestamp did not change after a failed upgrade
+    let system_info = get_system_info(env, WALLET_ADMIN_USER, canister_ids.station);
+    assert!(system_info.raw_rand_successful);
+    assert_eq!(last_uprade_timestamp, system_info.last_upgrade_timestamp);
 }
 
 #[test]
@@ -95,50 +228,48 @@ fn failed_station_upgrade() {
         env, canister_ids, ..
     } = setup_new_env();
 
-    // check if station is healthy
-    let health_status =
-        get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert_eq!(health_status, HealthStatus::Healthy);
-
-    let system_info = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert!(system_info.raw_rand_successful);
-    let last_uprade_timestamp = system_info.last_upgrade_timestamp;
-
-    // submit station upgrade request with an invalid WASM
     let station_upgrade_operation =
         RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
             target: SystemUpgradeTargetDTO::UpgradeStation,
             module: vec![],
+            module_extra_chunks: None,
             arg: None,
         });
-    // extra ticks are necessary to prevent polling on the request status
-    // before the station canister is upgraded and running
-    let request_status = execute_request_with_extra_ticks(
+
+    do_failed_station_upgrade(
         &env,
-        WALLET_ADMIN_USER,
-        canister_ids.station,
+        canister_ids,
         station_upgrade_operation,
-        10,
-    )
-    .unwrap_err()
-    .unwrap();
-    // check that the station upgrade request is failed
-    match request_status {
-        RequestStatusDTO::Failed { reason } => assert!(reason
-            .unwrap()
-            .contains("Canister's Wasm module is not valid")),
-        _ => panic!("Unexpected request status: {:?}", request_status),
-    };
+        "Canister's Wasm module is not valid",
+    );
+}
 
-    // check the station status after the failed upgrade
-    let health_status =
-        get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert_eq!(health_status, HealthStatus::Healthy);
+#[test]
+fn failed_station_upgrade_from_chunks() {
+    let TestEnv {
+        env, canister_ids, ..
+    } = setup_new_env();
 
-    // the last upgrade timestamp did not change after a failed upgrade
-    let system_info = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station);
-    assert!(system_info.raw_rand_successful);
-    assert_eq!(last_uprade_timestamp, system_info.last_upgrade_timestamp);
+    // create invalid station upgrade request from chunks
+    let (base_chunk, mut module_extra_chunks) = upload_station_chunks_to_asset_canister(&env);
+    let actual_wasm_module_hash = module_extra_chunks.wasm_module_hash.clone();
+    module_extra_chunks.wasm_module_hash[0] ^= 1;
+    let station_init_arg = SystemInstall::Upgrade(SystemUpgrade { name: None });
+    let station_init_arg_bytes = Encode!(&station_init_arg).unwrap();
+    let station_upgrade_operation =
+        RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
+            target: SystemUpgradeTargetDTO::UpgradeStation,
+            module: base_chunk.to_owned(),
+            module_extra_chunks: Some(module_extra_chunks.clone()),
+            arg: Some(station_init_arg_bytes),
+        });
+
+    do_failed_station_upgrade(
+        &env,
+        canister_ids,
+        station_upgrade_operation,
+        &format!("failed to install code from chunks: Error from Wasm chunk store: Wasm module hash {:?} does not match given hash WasmHash({:?}).", actual_wasm_module_hash, module_extra_chunks.wasm_module_hash)
+    );
 }
 
 #[test]

--- a/tests/integration/src/upgrade_station_tests.rs
+++ b/tests/integration/src/upgrade_station_tests.rs
@@ -301,7 +301,7 @@ fn upgrader_upgrade_from_chunks() {
     .unwrap_err()
     .unwrap();
 
-    // check that the station upgrade request is failed
+    // check that the upgrader upgrade request is failed
     match request_status {
         RequestStatusDTO::Failed { reason } => assert!(reason
             .unwrap()

--- a/tests/integration/src/user.rs
+++ b/tests/integration/src/user.rs
@@ -59,6 +59,7 @@ fn cancel_pending_requests() {
     let station_upgrade = RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
         target: SystemUpgradeTargetDTO::UpgradeStation,
         module: vec![],
+        module_extra_chunks: None,
         arg: None,
     });
     let mut alice_request_dtos = vec![];


### PR DESCRIPTION
This PR adds support for upgrading the station canister to a WASM exceeding the 2MiB message size limit by supplying extra WASM chunks fetched from an asset canister.