### PR TITLE
fix(station): bound the maximum number of processing requests

### DIFF
--- a/core/station/impl/src/repositories/request.rs
+++ b/core/station/impl/src/repositories/request.rs
@@ -231,6 +231,13 @@ impl RequestRepository {
             .collect::<Vec<Request>>()
     }
 
+    /// Get the number of all processing requests.
+    pub fn get_num_processing(&self) -> usize {
+        self.index
+            .find_by_status(RequestStatusCode::Processing, None)
+            .len()
+    }
+
     /// Get the list of Resource for a request id.
     pub fn get_resources(&self, request_id: &RequestId) -> Vec<Resource> {
         self.resource_index


### PR DESCRIPTION
This PR bounds the maximum number of processing requests to 400. Having more than 500 processing requests could lead to spurious failures since the queue capacity between any pair of canisters is 500 and thus, e.g., there cannot be more than 500 ICP ledger transfers processing concurrently. With a value of 400, we also leave some slack.