### PR TITLE
feat(station): external canister input to accept opt policies and permissions by type

### DIFF
--- a/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
@@ -196,14 +196,12 @@ const createNewExternalCanister = async (): Promise<Request> => {
   };
   changes.request_policies = {
     calls: [],
-    change: [
-      wizard.value.approvalPolicy.change
-        .filter(item => item.rule !== undefined)
-        .map(item => ({
-          policy_id: [],
-          rule: item.rule as RequestPolicyRule,
-        })),
-    ],
+    change: wizard.value.approvalPolicy.change
+      .filter(item => item.rule !== undefined)
+      .map(item => ({
+        policy_id: [],
+        rule: item.rule as RequestPolicyRule,
+      })),
   };
   if (wizard.value.configuration.canisterId) {
     changes.kind = {

--- a/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
@@ -156,21 +156,23 @@ const saveChangesToExistingExternalCanister = async (canisterId: Principal): Pro
     : [''];
   settings.permissions = [
     {
-      read: assertAndReturn(wizard.value.permission.read, 'read permission'),
-      change: assertAndReturn(wizard.value.permission.change, 'change permission'),
-      calls: [],
+      read: [assertAndReturn(wizard.value.permission.read, 'read permission')],
+      change: [assertAndReturn(wizard.value.permission.change, 'change permission')],
+      calls: [], // optional field, not updating calls through this dialog
     },
   ];
 
   settings.request_policies = [
     {
-      calls: [],
-      change: wizard.value.approvalPolicy.change
-        .filter(item => item.rule !== undefined)
-        .map(item => ({
-          policy_id: item.policy_id ? [item.policy_id] : [],
-          rule: item.rule as RequestPolicyRule,
-        })),
+      calls: [], // optional field, not updating calls through this dialog
+      change: [
+        wizard.value.approvalPolicy.change
+          .filter(item => item.rule !== undefined)
+          .map(item => ({
+            policy_id: item.policy_id ? [item.policy_id] : [],
+            rule: item.rule as RequestPolicyRule,
+          })),
+      ],
     },
   ];
 
@@ -194,12 +196,14 @@ const createNewExternalCanister = async (): Promise<Request> => {
   };
   changes.request_policies = {
     calls: [],
-    change: wizard.value.approvalPolicy.change
-      .filter(item => item.rule !== undefined)
-      .map(item => ({
-        policy_id: [],
-        rule: item.rule as RequestPolicyRule,
-      })),
+    change: [
+      wizard.value.approvalPolicy.change
+        .filter(item => item.rule !== undefined)
+        .map(item => ({
+          policy_id: [],
+          rule: item.rule as RequestPolicyRule,
+        })),
+    ],
   };
   if (wizard.value.configuration.canisterId) {
     changes.kind = {

--- a/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
@@ -147,6 +147,7 @@ const save = async (): Promise<void> => {
 
 const saveChangesToExistingExternalCanister = async (canisterId: Principal): Promise<Request> => {
   const settings: Partial<ConfigureExternalCanisterSettingsInput> = {};
+  settings.name = [assertAndReturn(wizard.value.configuration.name, 'name')];
   settings.labels = wizard.value.configuration.labels ? [wizard.value.configuration.labels] : [];
   settings.state = wizard.value.configuration.state
     ? [mapExternalCanisterStateEnumToVariant(wizard.value.configuration.state)]

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2318,10 +2318,10 @@ type ExternalCanisterChangeCallPermissionsInput = variant {
   // Replaces all the call permissions with the provided list, if the list is empty
   // all the call permissions will be removed.
   ReplaceAllBy : vec ExternalCanisterCallPermission;
-  // Override the call permissions from the specified methods.
-  OverrideSpecifiedByMethods : vec ExternalCanisterCallPermission;
-  // Remove call permissions of the specified methods.
-  RemoveByMethods : vec text;
+  // Override the call permissions from the specified execution methods.
+  OverrideSpecifiedByExecutionMethods : vec ExternalCanisterCallPermission;
+  // Remove call permissions of the specified execution methods.
+  RemoveByExecutionMethods : vec text;
 };
 
 // The input type for setting the permissions for the external canister.
@@ -2358,8 +2358,8 @@ type ExternalCanisterChangeCallRequestPoliciesInput = variant {
   ReplaceAllBy : vec ExternalCanisterCallRequestPolicyRuleInput;
   // Remove call request policies by the provided ids.
   RemoveByPolicyIds : vec UUID;
-  // Override the request policies for the specified methods.
-  OverrideSpecifiedByMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
+  // Override the request policies for the specified execution methods.
+  OverrideSpecifiedByExecutionMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
 };
 
 // The input type for setting the request policies for an existing external canister.

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -653,7 +653,7 @@ type CreateExternalCanisterOperationInput = record {
   // The labels of the external canister.
   labels : opt vec text;
   // What operations are allowed on the canister.
-  permissions : ExternalCanisterPermissionsInput;
+  permissions : ExternalCanisterPermissionsCreateInput;
   // The request policies for the canister.
   request_policies : ExternalCanisterRequestPoliciesInput;
 };
@@ -665,7 +665,7 @@ type ConfigureExternalCanisterSettingsInput = record {
   // The labels of the external canister.
   labels : opt vec text;
   // What operations are allowed on the canister.
-  permissions : opt ExternalCanisterPermissionsInput;
+  permissions : opt ExternalCanisterPermissionsUpdateInput;
   // The request policies for the canister.
   request_policies : opt ExternalCanisterRequestPoliciesInput;
   // The state of the external canister.
@@ -2310,8 +2310,21 @@ type ExternalCanisterPermissions = record {
   calls : vec ExternalCanisterCallPermission;
 };
 
+// The create input type for setting the permissions for the external canister.
+type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
+
 // The input type for setting the permissions for the external canister.
-type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
+type ExternalCanisterPermissionsUpdateInput = record {
+  // Who can read information about the canister (e.g. canister status),
+  // changes to this permission can be made by the `change` permission.
+  read : opt Allow;
+  // Who can make changes to the canister, includes:
+  // - changing the permissions
+  // - install operations
+  change : opt Allow;
+  // The permissions for the calling methods on the canister.
+  calls : opt vec ExternalCanisterCallPermission;
+};
 
 // The request policy rules for the external canister.
 type ExternalCanisterRequestPolicies = record {
@@ -2324,9 +2337,9 @@ type ExternalCanisterRequestPolicies = record {
 // The input type for setting the request policies for the external canister.
 type ExternalCanisterRequestPoliciesInput = record {
   // The request policy rules for the canister change operation.
-  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  change : opt vec ExternalCanisterChangeRequestPolicyRuleInput;
   // The request policy rules for the calling methods on the canister.
-  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+  calls : opt vec ExternalCanisterCallRequestPolicyRuleInput;
 };
 
 // An external canister that the station can interact with.

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2322,7 +2322,7 @@ type ExternalCanisterPermissionsUpdateInput = record {
   // - changing the permissions
   // - install operations
   change : opt Allow;
-  // The permissions for the calling methods on the canister.
+  // The permissions for calling methods on the canister.
   calls : opt vec ExternalCanisterCallPermission;
 };
 

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -655,7 +655,7 @@ type CreateExternalCanisterOperationInput = record {
   // What operations are allowed on the canister.
   permissions : ExternalCanisterPermissionsCreateInput;
   // The request policies for the canister.
-  request_policies : ExternalCanisterRequestPoliciesInput;
+  request_policies : ExternalCanisterRequestPoliciesCreateInput;
 };
 
 type ConfigureExternalCanisterSettingsInput = record {
@@ -667,7 +667,7 @@ type ConfigureExternalCanisterSettingsInput = record {
   // What operations are allowed on the canister.
   permissions : opt ExternalCanisterPermissionsUpdateInput;
   // The request policies for the canister.
-  request_policies : opt ExternalCanisterRequestPoliciesInput;
+  request_policies : opt ExternalCanisterRequestPoliciesUpdateInput;
   // The state of the external canister.
   state : opt ExternalCanisterState;
 };
@@ -2313,6 +2313,17 @@ type ExternalCanisterPermissions = record {
 // The create input type for setting the permissions for the external canister.
 type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
 
+// The input type for setting call permissions of an existing external canister.
+type ExternalCanisterChangeCallPermissionsInput = variant {
+  // Replaces all the call permissions with the provided list, if the list is empty
+  // all the call permissions will be removed.
+  ReplaceAllBy : vec ExternalCanisterCallPermission;
+  // Override the call permissions from the specified methods.
+  OverrideSpecifiedByMethods : vec ExternalCanisterCallPermission;
+  // Remove call permissions of the specified methods.
+  RemoveByMethods : vec text;
+};
+
 // The input type for setting the permissions for the external canister.
 type ExternalCanisterPermissionsUpdateInput = record {
   // Who can read information about the canister (e.g. canister status),
@@ -2323,7 +2334,7 @@ type ExternalCanisterPermissionsUpdateInput = record {
   // - install operations
   change : opt Allow;
   // The permissions for calling methods on the canister.
-  calls : opt vec ExternalCanisterCallPermission;
+  calls : opt ExternalCanisterChangeCallPermissionsInput;
 };
 
 // The request policy rules for the external canister.
@@ -2334,12 +2345,29 @@ type ExternalCanisterRequestPolicies = record {
   calls : vec ExternalCanisterCallRequestPolicyRule;
 };
 
-// The input type for setting the request policies for the external canister.
-type ExternalCanisterRequestPoliciesInput = record {
+// The input type for setting the request policies for a new external canister.
+type ExternalCanisterRequestPoliciesCreateInput = record {
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  // The request policy rules for the calling methods on the canister.
+  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
+
+type ExternalCanisterChangeCallRequestPoliciesInput = variant {
+  // Replaces all the call request policies with the provided list.
+  ReplaceAllBy : vec ExternalCanisterCallRequestPolicyRuleInput;
+  // Remove call request policies by the provided ids.
+  RemoveByPolicyIds : vec UUID;
+  // Override the request policies for the specified methods.
+  OverrideSpecifiedByMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
+
+// The input type for setting the request policies for an existing external canister.
+type ExternalCanisterRequestPoliciesUpdateInput = record {
   // The request policy rules for the canister change operation.
   change : opt vec ExternalCanisterChangeRequestPolicyRuleInput;
   // The request policy rules for the calling methods on the canister.
-  calls : opt vec ExternalCanisterCallRequestPolicyRuleInput;
+  calls : opt ExternalCanisterChangeCallRequestPoliciesInput;
 };
 
 // An external canister that the station can interact with.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -204,7 +204,7 @@ export type ConfigureExternalCanisterOperationKind = { 'SoftDelete' : null } |
   { 'Delete' : null } |
   { 'NativeSettings' : DefiniteCanisterSettingsInput };
 export interface ConfigureExternalCanisterSettingsInput {
-  'permissions' : [] | [ExternalCanisterPermissionsInput],
+  'permissions' : [] | [ExternalCanisterPermissionsUpdateInput],
   'name' : [] | [string],
   'labels' : [] | [Array<string>],
   'description' : [] | [string],
@@ -216,7 +216,7 @@ export interface CreateExternalCanisterOperation {
   'input' : CreateExternalCanisterOperationInput,
 }
 export interface CreateExternalCanisterOperationInput {
-  'permissions' : ExternalCanisterPermissionsInput,
+  'permissions' : ExternalCanisterPermissionsCreateInput,
   'kind' : CreateExternalCanisterOperationKind,
   'name' : string,
   'labels' : [] | [Array<string>],
@@ -420,14 +420,19 @@ export interface ExternalCanisterPermissions {
   'read' : Allow,
   'change' : Allow,
 }
-export type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
+export type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
+export interface ExternalCanisterPermissionsUpdateInput {
+  'calls' : [] | [Array<ExternalCanisterCallPermission>],
+  'read' : [] | [Allow],
+  'change' : [] | [Allow],
+}
 export interface ExternalCanisterRequestPolicies {
   'calls' : Array<ExternalCanisterCallRequestPolicyRule>,
   'change' : Array<ExternalCanisterChangeRequestPolicyRule>,
 }
 export interface ExternalCanisterRequestPoliciesInput {
-  'calls' : Array<ExternalCanisterCallRequestPolicyRuleInput>,
-  'change' : Array<ExternalCanisterChangeRequestPolicyRuleInput>,
+  'calls' : [] | [Array<ExternalCanisterCallRequestPolicyRuleInput>],
+  'change' : [] | [Array<ExternalCanisterChangeRequestPolicyRuleInput>],
 }
 export type ExternalCanisterResourceAction = {
     'Call' : CallExternalCanisterResourceTarget

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -208,7 +208,7 @@ export interface ConfigureExternalCanisterSettingsInput {
   'name' : [] | [string],
   'labels' : [] | [Array<string>],
   'description' : [] | [string],
-  'request_policies' : [] | [ExternalCanisterRequestPoliciesInput],
+  'request_policies' : [] | [ExternalCanisterRequestPoliciesUpdateInput],
   'state' : [] | [ExternalCanisterState],
 }
 export interface CreateExternalCanisterOperation {
@@ -221,7 +221,7 @@ export interface CreateExternalCanisterOperationInput {
   'name' : string,
   'labels' : [] | [Array<string>],
   'description' : [] | [string],
-  'request_policies' : ExternalCanisterRequestPoliciesInput,
+  'request_policies' : ExternalCanisterRequestPoliciesCreateInput,
 }
 export type CreateExternalCanisterOperationKind = {
     'AddExisting' : CreateExternalCanisterOperationKindAddExisting
@@ -405,6 +405,20 @@ export interface ExternalCanisterCallerPrivileges {
   'can_call' : Array<ExternalCanisterCallerMethodsPrivileges>,
   'can_fund' : boolean,
 }
+export type ExternalCanisterChangeCallPermissionsInput = {
+    'RemoveByMethods' : Array<string>
+  } |
+  { 'OverrideSpecifiedByMethods' : Array<ExternalCanisterCallPermission> } |
+  { 'ReplaceAllBy' : Array<ExternalCanisterCallPermission> };
+export type ExternalCanisterChangeCallRequestPoliciesInput = {
+    'RemoveByPolicyIds' : Array<UUID>
+  } |
+  {
+    'OverrideSpecifiedByMethods' : Array<
+      ExternalCanisterCallRequestPolicyRuleInput
+    >
+  } |
+  { 'ReplaceAllBy' : Array<ExternalCanisterCallRequestPolicyRuleInput> };
 export interface ExternalCanisterChangeRequestPolicyRule {
   'rule' : RequestPolicyRule,
   'policy_id' : UUID,
@@ -422,7 +436,7 @@ export interface ExternalCanisterPermissions {
 }
 export type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
 export interface ExternalCanisterPermissionsUpdateInput {
-  'calls' : [] | [Array<ExternalCanisterCallPermission>],
+  'calls' : [] | [ExternalCanisterChangeCallPermissionsInput],
   'read' : [] | [Allow],
   'change' : [] | [Allow],
 }
@@ -430,8 +444,12 @@ export interface ExternalCanisterRequestPolicies {
   'calls' : Array<ExternalCanisterCallRequestPolicyRule>,
   'change' : Array<ExternalCanisterChangeRequestPolicyRule>,
 }
-export interface ExternalCanisterRequestPoliciesInput {
-  'calls' : [] | [Array<ExternalCanisterCallRequestPolicyRuleInput>],
+export interface ExternalCanisterRequestPoliciesCreateInput {
+  'calls' : Array<ExternalCanisterCallRequestPolicyRuleInput>,
+  'change' : Array<ExternalCanisterChangeRequestPolicyRuleInput>,
+}
+export interface ExternalCanisterRequestPoliciesUpdateInput {
+  'calls' : [] | [ExternalCanisterChangeCallRequestPoliciesInput],
   'change' : [] | [Array<ExternalCanisterChangeRequestPolicyRuleInput>],
 }
 export type ExternalCanisterResourceAction = {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -406,15 +406,17 @@ export interface ExternalCanisterCallerPrivileges {
   'can_fund' : boolean,
 }
 export type ExternalCanisterChangeCallPermissionsInput = {
-    'RemoveByMethods' : Array<string>
+    'OverrideSpecifiedByExecutionMethods' : Array<
+      ExternalCanisterCallPermission
+    >
   } |
-  { 'OverrideSpecifiedByMethods' : Array<ExternalCanisterCallPermission> } |
+  { 'RemoveByExecutionMethods' : Array<string> } |
   { 'ReplaceAllBy' : Array<ExternalCanisterCallPermission> };
 export type ExternalCanisterChangeCallRequestPoliciesInput = {
     'RemoveByPolicyIds' : Array<UUID>
   } |
   {
-    'OverrideSpecifiedByMethods' : Array<
+    'OverrideSpecifiedByExecutionMethods' : Array<
       ExternalCanisterCallRequestPolicyRuleInput
     >
   } |

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -191,12 +191,11 @@ export const idlFactory = ({ IDL }) => {
     'allow' : Allow,
     'validation_method' : ValidationMethodResourceTarget,
   });
-  const ExternalCanisterPermissions = IDL.Record({
-    'calls' : IDL.Vec(ExternalCanisterCallPermission),
-    'read' : Allow,
-    'change' : Allow,
+  const ExternalCanisterPermissionsUpdateInput = IDL.Record({
+    'calls' : IDL.Opt(IDL.Vec(ExternalCanisterCallPermission)),
+    'read' : IDL.Opt(Allow),
+    'change' : IDL.Opt(Allow),
   });
-  const ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
   const UserSpecifier = IDL.Variant({
     'Id' : IDL.Vec(UUID),
     'Any' : IDL.Null,
@@ -237,15 +236,15 @@ export const idlFactory = ({ IDL }) => {
     'policy_id' : IDL.Opt(UUID),
   });
   const ExternalCanisterRequestPoliciesInput = IDL.Record({
-    'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput),
-    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRuleInput),
+    'calls' : IDL.Opt(IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput)),
+    'change' : IDL.Opt(IDL.Vec(ExternalCanisterChangeRequestPolicyRuleInput)),
   });
   const ExternalCanisterState = IDL.Variant({
     'Active' : IDL.Null,
     'Archived' : IDL.Null,
   });
   const ConfigureExternalCanisterSettingsInput = IDL.Record({
-    'permissions' : IDL.Opt(ExternalCanisterPermissionsInput),
+    'permissions' : IDL.Opt(ExternalCanisterPermissionsUpdateInput),
     'name' : IDL.Opt(IDL.Text),
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),
     'description' : IDL.Opt(IDL.Text),
@@ -354,6 +353,12 @@ export const idlFactory = ({ IDL }) => {
   const RemoveAddressBookEntryOperationInput = IDL.Record({
     'address_book_entry_id' : UUID,
   });
+  const ExternalCanisterPermissions = IDL.Record({
+    'calls' : IDL.Vec(ExternalCanisterCallPermission),
+    'read' : Allow,
+    'change' : Allow,
+  });
+  const ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
   const CreateExternalCanisterOperationKindAddExisting = IDL.Record({
     'canister_id' : IDL.Principal,
   });
@@ -365,7 +370,7 @@ export const idlFactory = ({ IDL }) => {
     'CreateNew' : CreateExternalCanisterOperationKindCreateNew,
   });
   const CreateExternalCanisterOperationInput = IDL.Record({
-    'permissions' : ExternalCanisterPermissionsInput,
+    'permissions' : ExternalCanisterPermissionsCreateInput,
     'kind' : CreateExternalCanisterOperationKind,
     'name' : IDL.Text,
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -191,8 +191,13 @@ export const idlFactory = ({ IDL }) => {
     'allow' : Allow,
     'validation_method' : ValidationMethodResourceTarget,
   });
+  const ExternalCanisterChangeCallPermissionsInput = IDL.Variant({
+    'RemoveByMethods' : IDL.Vec(IDL.Text),
+    'OverrideSpecifiedByMethods' : IDL.Vec(ExternalCanisterCallPermission),
+    'ReplaceAllBy' : IDL.Vec(ExternalCanisterCallPermission),
+  });
   const ExternalCanisterPermissionsUpdateInput = IDL.Record({
-    'calls' : IDL.Opt(IDL.Vec(ExternalCanisterCallPermission)),
+    'calls' : IDL.Opt(ExternalCanisterChangeCallPermissionsInput),
     'read' : IDL.Opt(Allow),
     'change' : IDL.Opt(Allow),
   });
@@ -231,12 +236,19 @@ export const idlFactory = ({ IDL }) => {
     'validation_method' : ValidationMethodResourceTarget,
     'policy_id' : IDL.Opt(UUID),
   });
+  const ExternalCanisterChangeCallRequestPoliciesInput = IDL.Variant({
+    'RemoveByPolicyIds' : IDL.Vec(UUID),
+    'OverrideSpecifiedByMethods' : IDL.Vec(
+      ExternalCanisterCallRequestPolicyRuleInput
+    ),
+    'ReplaceAllBy' : IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput),
+  });
   const ExternalCanisterChangeRequestPolicyRuleInput = IDL.Record({
     'rule' : RequestPolicyRule,
     'policy_id' : IDL.Opt(UUID),
   });
-  const ExternalCanisterRequestPoliciesInput = IDL.Record({
-    'calls' : IDL.Opt(IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput)),
+  const ExternalCanisterRequestPoliciesUpdateInput = IDL.Record({
+    'calls' : IDL.Opt(ExternalCanisterChangeCallRequestPoliciesInput),
     'change' : IDL.Opt(IDL.Vec(ExternalCanisterChangeRequestPolicyRuleInput)),
   });
   const ExternalCanisterState = IDL.Variant({
@@ -248,7 +260,7 @@ export const idlFactory = ({ IDL }) => {
     'name' : IDL.Opt(IDL.Text),
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),
     'description' : IDL.Opt(IDL.Text),
-    'request_policies' : IDL.Opt(ExternalCanisterRequestPoliciesInput),
+    'request_policies' : IDL.Opt(ExternalCanisterRequestPoliciesUpdateInput),
     'state' : IDL.Opt(ExternalCanisterState),
   });
   const DefiniteCanisterSettingsInput = IDL.Record({
@@ -369,13 +381,17 @@ export const idlFactory = ({ IDL }) => {
     'AddExisting' : CreateExternalCanisterOperationKindAddExisting,
     'CreateNew' : CreateExternalCanisterOperationKindCreateNew,
   });
+  const ExternalCanisterRequestPoliciesCreateInput = IDL.Record({
+    'calls' : IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput),
+    'change' : IDL.Vec(ExternalCanisterChangeRequestPolicyRuleInput),
+  });
   const CreateExternalCanisterOperationInput = IDL.Record({
     'permissions' : ExternalCanisterPermissionsCreateInput,
     'kind' : CreateExternalCanisterOperationKind,
     'name' : IDL.Text,
     'labels' : IDL.Opt(IDL.Vec(IDL.Text)),
     'description' : IDL.Opt(IDL.Text),
-    'request_policies' : ExternalCanisterRequestPoliciesInput,
+    'request_policies' : ExternalCanisterRequestPoliciesCreateInput,
   });
   const ChangeAddressBookMetadata = IDL.Variant({
     'OverrideSpecifiedBy' : IDL.Vec(AddressBookMetadata),

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -192,8 +192,10 @@ export const idlFactory = ({ IDL }) => {
     'validation_method' : ValidationMethodResourceTarget,
   });
   const ExternalCanisterChangeCallPermissionsInput = IDL.Variant({
-    'RemoveByMethods' : IDL.Vec(IDL.Text),
-    'OverrideSpecifiedByMethods' : IDL.Vec(ExternalCanisterCallPermission),
+    'OverrideSpecifiedByExecutionMethods' : IDL.Vec(
+      ExternalCanisterCallPermission
+    ),
+    'RemoveByExecutionMethods' : IDL.Vec(IDL.Text),
     'ReplaceAllBy' : IDL.Vec(ExternalCanisterCallPermission),
   });
   const ExternalCanisterPermissionsUpdateInput = IDL.Record({
@@ -238,7 +240,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ExternalCanisterChangeCallRequestPoliciesInput = IDL.Variant({
     'RemoveByPolicyIds' : IDL.Vec(UUID),
-    'OverrideSpecifiedByMethods' : IDL.Vec(
+    'OverrideSpecifiedByExecutionMethods' : IDL.Vec(
       ExternalCanisterCallRequestPolicyRuleInput
     ),
     'ReplaceAllBy' : IDL.Vec(ExternalCanisterCallRequestPolicyRuleInput),

--- a/apps/wallet/src/pages/ExternalCanisterDetailPage.vue
+++ b/apps/wallet/src/pages/ExternalCanisterDetailPage.vue
@@ -200,7 +200,7 @@
                             color="default"
                             variant="tonal"
                             class="ml-1 px-2"
-                            :disabled="canisterDetails.moduleHash.loading"
+                            :disabled="!canisterDetails.status.value"
                             :append-icon="mdiDatabaseCog"
                             @click="dialogs.install = true"
                           >

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2318,10 +2318,10 @@ type ExternalCanisterChangeCallPermissionsInput = variant {
   // Replaces all the call permissions with the provided list, if the list is empty
   // all the call permissions will be removed.
   ReplaceAllBy : vec ExternalCanisterCallPermission;
-  // Override the call permissions from the specified methods.
-  OverrideSpecifiedByMethods : vec ExternalCanisterCallPermission;
-  // Remove call permissions of the specified methods.
-  RemoveByMethods : vec text;
+  // Override the call permissions from the specified execution methods.
+  OverrideSpecifiedByExecutionMethods : vec ExternalCanisterCallPermission;
+  // Remove call permissions of the specified execution methods.
+  RemoveByExecutionMethods : vec text;
 };
 
 // The input type for setting the permissions for the external canister.
@@ -2358,8 +2358,8 @@ type ExternalCanisterChangeCallRequestPoliciesInput = variant {
   ReplaceAllBy : vec ExternalCanisterCallRequestPolicyRuleInput;
   // Remove call request policies by the provided ids.
   RemoveByPolicyIds : vec UUID;
-  // Override the request policies for the specified methods.
-  OverrideSpecifiedByMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
+  // Override the request policies for the specified execution methods.
+  OverrideSpecifiedByExecutionMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
 };
 
 // The input type for setting the request policies for an existing external canister.

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -653,7 +653,7 @@ type CreateExternalCanisterOperationInput = record {
   // The labels of the external canister.
   labels : opt vec text;
   // What operations are allowed on the canister.
-  permissions : ExternalCanisterPermissionsInput;
+  permissions : ExternalCanisterPermissionsCreateInput;
   // The request policies for the canister.
   request_policies : ExternalCanisterRequestPoliciesInput;
 };
@@ -665,7 +665,7 @@ type ConfigureExternalCanisterSettingsInput = record {
   // The labels of the external canister.
   labels : opt vec text;
   // What operations are allowed on the canister.
-  permissions : opt ExternalCanisterPermissionsInput;
+  permissions : opt ExternalCanisterPermissionsUpdateInput;
   // The request policies for the canister.
   request_policies : opt ExternalCanisterRequestPoliciesInput;
   // The state of the external canister.
@@ -2310,8 +2310,21 @@ type ExternalCanisterPermissions = record {
   calls : vec ExternalCanisterCallPermission;
 };
 
+// The create input type for setting the permissions for the external canister.
+type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
+
 // The input type for setting the permissions for the external canister.
-type ExternalCanisterPermissionsInput = ExternalCanisterPermissions;
+type ExternalCanisterPermissionsUpdateInput = record {
+  // Who can read information about the canister (e.g. canister status),
+  // changes to this permission can be made by the `change` permission.
+  read : opt Allow;
+  // Who can make changes to the canister, includes:
+  // - changing the permissions
+  // - install operations
+  change : opt Allow;
+  // The permissions for the calling methods on the canister.
+  calls : opt vec ExternalCanisterCallPermission;
+};
 
 // The request policy rules for the external canister.
 type ExternalCanisterRequestPolicies = record {
@@ -2324,9 +2337,9 @@ type ExternalCanisterRequestPolicies = record {
 // The input type for setting the request policies for the external canister.
 type ExternalCanisterRequestPoliciesInput = record {
   // The request policy rules for the canister change operation.
-  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  change : opt vec ExternalCanisterChangeRequestPolicyRuleInput;
   // The request policy rules for the calling methods on the canister.
-  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+  calls : opt vec ExternalCanisterCallRequestPolicyRuleInput;
 };
 
 // An external canister that the station can interact with.

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2322,7 +2322,7 @@ type ExternalCanisterPermissionsUpdateInput = record {
   // - changing the permissions
   // - install operations
   change : opt Allow;
-  // The permissions for the calling methods on the canister.
+  // The permissions for calling methods on the canister.
   calls : opt vec ExternalCanisterCallPermission;
 };
 

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -655,7 +655,7 @@ type CreateExternalCanisterOperationInput = record {
   // What operations are allowed on the canister.
   permissions : ExternalCanisterPermissionsCreateInput;
   // The request policies for the canister.
-  request_policies : ExternalCanisterRequestPoliciesInput;
+  request_policies : ExternalCanisterRequestPoliciesCreateInput;
 };
 
 type ConfigureExternalCanisterSettingsInput = record {
@@ -667,7 +667,7 @@ type ConfigureExternalCanisterSettingsInput = record {
   // What operations are allowed on the canister.
   permissions : opt ExternalCanisterPermissionsUpdateInput;
   // The request policies for the canister.
-  request_policies : opt ExternalCanisterRequestPoliciesInput;
+  request_policies : opt ExternalCanisterRequestPoliciesUpdateInput;
   // The state of the external canister.
   state : opt ExternalCanisterState;
 };
@@ -2313,6 +2313,17 @@ type ExternalCanisterPermissions = record {
 // The create input type for setting the permissions for the external canister.
 type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
 
+// The input type for setting call permissions of an existing external canister.
+type ExternalCanisterChangeCallPermissionsInput = variant {
+  // Replaces all the call permissions with the provided list, if the list is empty
+  // all the call permissions will be removed.
+  ReplaceAllBy : vec ExternalCanisterCallPermission;
+  // Override the call permissions from the specified methods.
+  OverrideSpecifiedByMethods : vec ExternalCanisterCallPermission;
+  // Remove call permissions of the specified methods.
+  RemoveByMethods : vec text;
+};
+
 // The input type for setting the permissions for the external canister.
 type ExternalCanisterPermissionsUpdateInput = record {
   // Who can read information about the canister (e.g. canister status),
@@ -2323,7 +2334,7 @@ type ExternalCanisterPermissionsUpdateInput = record {
   // - install operations
   change : opt Allow;
   // The permissions for calling methods on the canister.
-  calls : opt vec ExternalCanisterCallPermission;
+  calls : opt ExternalCanisterChangeCallPermissionsInput;
 };
 
 // The request policy rules for the external canister.
@@ -2334,12 +2345,29 @@ type ExternalCanisterRequestPolicies = record {
   calls : vec ExternalCanisterCallRequestPolicyRule;
 };
 
-// The input type for setting the request policies for the external canister.
-type ExternalCanisterRequestPoliciesInput = record {
+// The input type for setting the request policies for a new external canister.
+type ExternalCanisterRequestPoliciesCreateInput = record {
+  // The request policy rules for the canister change operation.
+  change : vec ExternalCanisterChangeRequestPolicyRuleInput;
+  // The request policy rules for the calling methods on the canister.
+  calls : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
+
+type ExternalCanisterChangeCallRequestPoliciesInput = variant {
+  // Replaces all the call request policies with the provided list.
+  ReplaceAllBy : vec ExternalCanisterCallRequestPolicyRuleInput;
+  // Remove call request policies by the provided ids.
+  RemoveByPolicyIds : vec UUID;
+  // Override the request policies for the specified methods.
+  OverrideSpecifiedByMethods : vec ExternalCanisterCallRequestPolicyRuleInput;
+};
+
+// The input type for setting the request policies for an existing external canister.
+type ExternalCanisterRequestPoliciesUpdateInput = record {
   // The request policy rules for the canister change operation.
   change : opt vec ExternalCanisterChangeRequestPolicyRuleInput;
   // The request policy rules for the calling methods on the canister.
-  calls : opt vec ExternalCanisterCallRequestPolicyRuleInput;
+  calls : opt ExternalCanisterChangeCallRequestPoliciesInput;
 };
 
 // An external canister that the station can interact with.

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -44,12 +44,7 @@ pub struct CreateExternalCanisterOperationInput {
     pub request_policies: ExternalCanisterRequestPoliciesInput,
 }
 
-#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
-pub struct ExternalCanisterPermissionsCreateInput {
-    pub read: AllowDTO,
-    pub change: AllowDTO,
-    pub calls: Vec<ExternalCanisterCallPermissionDTO>,
-}
+pub type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissionsDTO;
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterPermissionsUpdateInput {

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -3,9 +3,6 @@ use crate::{
     SortDirection, TimestampRfc3339, UuidDTO, ValidationMethodResourceTargetDTO,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
-
-pub type ExternalCanisterPermissionsInput = ExternalCanisterPermissionsDTO;
-
 // Taken from https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct DefiniteCanisterSettingsInput {
@@ -43,8 +40,22 @@ pub struct CreateExternalCanisterOperationInput {
     pub name: String,
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
-    pub permissions: ExternalCanisterPermissionsInput,
+    pub permissions: ExternalCanisterPermissionsCreateInput,
     pub request_policies: ExternalCanisterRequestPoliciesInput,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterPermissionsCreateInput {
+    pub read: AllowDTO,
+    pub change: AllowDTO,
+    pub calls: Vec<ExternalCanisterCallPermissionDTO>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterPermissionsUpdateInput {
+    pub read: Option<AllowDTO>,
+    pub change: Option<AllowDTO>,
+    pub calls: Option<Vec<ExternalCanisterCallPermissionDTO>>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -85,7 +96,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
     pub state: Option<ExternalCanisterStateDTO>,
-    pub permissions: Option<ExternalCanisterPermissionsInput>,
+    pub permissions: Option<ExternalCanisterPermissionsUpdateInput>,
     pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
 }
 
@@ -172,8 +183,8 @@ pub struct ExternalCanisterRequestPoliciesDTO {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct ExternalCanisterRequestPoliciesInput {
-    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
-    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
+    pub change: Option<Vec<ExternalCanisterChangeRequestPolicyRuleInput>>,
+    pub calls: Option<Vec<ExternalCanisterCallRequestPolicyRuleInput>>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -41,7 +41,7 @@ pub struct CreateExternalCanisterOperationInput {
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
     pub permissions: ExternalCanisterPermissionsCreateInput,
-    pub request_policies: ExternalCanisterRequestPoliciesInput,
+    pub request_policies: ExternalCanisterRequestPoliciesCreateInput,
 }
 
 pub type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissionsDTO;
@@ -50,7 +50,14 @@ pub type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissionsDTO
 pub struct ExternalCanisterPermissionsUpdateInput {
     pub read: Option<AllowDTO>,
     pub change: Option<AllowDTO>,
-    pub calls: Option<Vec<ExternalCanisterCallPermissionDTO>>,
+    pub calls: Option<ExternalCanisterChangeCallPermissionsInput>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub enum ExternalCanisterChangeCallPermissionsInput {
+    ReplaceAllBy(Vec<ExternalCanisterCallPermissionDTO>),
+    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallPermissionDTO>),
+    RemoveByMethods(Vec<String>),
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -92,7 +99,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub labels: Option<Vec<String>>,
     pub state: Option<ExternalCanisterStateDTO>,
     pub permissions: Option<ExternalCanisterPermissionsUpdateInput>,
-    pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
+    pub request_policies: Option<ExternalCanisterRequestPoliciesUpdateInput>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -177,9 +184,22 @@ pub struct ExternalCanisterRequestPoliciesDTO {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
-pub struct ExternalCanisterRequestPoliciesInput {
+pub struct ExternalCanisterRequestPoliciesCreateInput {
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
+    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalCanisterRequestPoliciesUpdateInput {
     pub change: Option<Vec<ExternalCanisterChangeRequestPolicyRuleInput>>,
-    pub calls: Option<Vec<ExternalCanisterCallRequestPolicyRuleInput>>,
+    pub calls: Option<ExternalCanisterChangeCallRequestPoliciesInput>,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub enum ExternalCanisterChangeCallRequestPoliciesInput {
+    ReplaceAllBy(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
+    RemoveByPolicyIds(Vec<UuidDTO>),
+    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -56,8 +56,8 @@ pub struct ExternalCanisterPermissionsUpdateInput {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum ExternalCanisterChangeCallPermissionsInput {
     ReplaceAllBy(Vec<ExternalCanisterCallPermissionDTO>),
-    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallPermissionDTO>),
-    RemoveByMethods(Vec<String>),
+    OverrideSpecifiedByExecutionMethods(Vec<ExternalCanisterCallPermissionDTO>),
+    RemoveByExecutionMethods(Vec<String>),
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -199,7 +199,7 @@ pub struct ExternalCanisterRequestPoliciesUpdateInput {
 pub enum ExternalCanisterChangeCallRequestPoliciesInput {
     ReplaceAllBy(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
     RemoveByPolicyIds(Vec<UuidDTO>),
-    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
+    OverrideSpecifiedByExecutionMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/errors/external_canister.rs
+++ b/core/station/impl/src/errors/external_canister.rs
@@ -17,7 +17,7 @@ pub enum ExternalCanisterError {
     #[error(r#"The external canister operation failed due to {reason}"#)]
     Failed { reason: String },
     /// The external canister has failed validation.
-    #[error(r#"The external canister has failed validation."#)]
+    #[error(r#"The external canister has failed validation with reason `{info}`."#)]
     ValidationError { info: String },
 }
 
@@ -49,6 +49,9 @@ impl From<ExternalCanisterValidationError> for ExternalCanisterError {
         match err {
             ExternalCanisterValidationError::InvalidExternalCanister { principal } => {
                 ExternalCanisterError::InvalidExternalCanister { principal }
+            }
+            ExternalCanisterValidationError::ValidationError { info } => {
+                ExternalCanisterError::ValidationError { info }
             }
         }
     }

--- a/core/station/impl/src/errors/request.rs
+++ b/core/station/impl/src/errors/request.rs
@@ -92,6 +92,9 @@ impl From<ExternalCanisterValidationError> for RequestError {
                     info: format!("Invalid external canister {}", principal),
                 }
             }
+            ExternalCanisterValidationError::ValidationError { info } => {
+                RequestError::ValidationError { info }
+            }
         }
     }
 }

--- a/core/station/impl/src/errors/request_policy.rs
+++ b/core/station/impl/src/errors/request_policy.rs
@@ -43,6 +43,9 @@ impl From<ExternalCanisterValidationError> for RequestPolicyError {
                     info: format!("Invalid external canister {}", principal),
                 }
             }
+            ExternalCanisterValidationError::ValidationError { info } => {
+                RequestPolicyError::ValidationError { info }
+            }
         }
     }
 }

--- a/core/station/impl/src/errors/validation.rs
+++ b/core/station/impl/src/errors/validation.rs
@@ -59,10 +59,12 @@ impl DetailableError for RecordValidationError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum ExternalCanisterValidationError {
     #[error(r#"The principal {principal} is an invalid external canister."#)]
     InvalidExternalCanister { principal: Principal },
+    #[error(r#"The external canister has failed validation with reason `{info}`."#)]
+    ValidationError { info: String },
 }
 
 impl DetailableError for ExternalCanisterValidationError {
@@ -72,6 +74,10 @@ impl DetailableError for ExternalCanisterValidationError {
         match self {
             ExternalCanisterValidationError::InvalidExternalCanister { principal } => {
                 details.insert("principal".to_string(), principal.to_string());
+                Some(details)
+            }
+            ExternalCanisterValidationError::ValidationError { info } => {
+                details.insert("info".to_string(), info.to_string());
                 Some(details)
             }
         }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -620,8 +620,8 @@ impl From<station_api::ExternalCanisterChangeCallRequestPoliciesInput>
             station_api::ExternalCanisterChangeCallRequestPoliciesInput::ReplaceAllBy(input) => {
                 ExternalCanisterChangeCallRequestPoliciesInput::ReplaceAllBy(input.into_iter().map(Into::into).collect())
             }
-            station_api::ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByMethods(input) => {
-                ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByMethods(input.into_iter().map(Into::into).collect())
+            station_api::ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByExecutionMethods(input) => {
+                ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByExecutionMethods(input.into_iter().map(Into::into).collect())
             }
             station_api::ExternalCanisterChangeCallRequestPoliciesInput::RemoveByPolicyIds(ids) => {
                 ExternalCanisterChangeCallRequestPoliciesInput::RemoveByPolicyIds(ids.into_iter().map(|id| *HelperMapper::to_uuid(id).expect("Invalid policy id").as_bytes()).collect())
@@ -640,8 +640,8 @@ impl From<ExternalCanisterChangeCallRequestPoliciesInput>
             ExternalCanisterChangeCallRequestPoliciesInput::ReplaceAllBy(input) => {
                 station_api::ExternalCanisterChangeCallRequestPoliciesInput::ReplaceAllBy(input.into_iter().map(Into::into).collect())
             }
-            ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByMethods(input) => {
-                station_api::ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByMethods(input.into_iter().map(Into::into).collect())
+            ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByExecutionMethods(input) => {
+                station_api::ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByExecutionMethods(input.into_iter().map(Into::into).collect())
             }
             ExternalCanisterChangeCallRequestPoliciesInput::RemoveByPolicyIds(ids) => {
                 station_api::ExternalCanisterChangeCallRequestPoliciesInput::RemoveByPolicyIds(ids.into_iter().map(|id| Uuid::from_bytes(id).hyphenated().to_string()).collect())
@@ -742,13 +742,13 @@ impl From<station_api::ExternalCanisterChangeCallPermissionsInput>
                     input.into_iter().map(Into::into).collect(),
                 )
             }
-            station_api::ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByMethods(
+            station_api::ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
                 input,
-            ) => ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByMethods(
+            ) => ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
                 input.into_iter().map(Into::into).collect(),
             ),
-            station_api::ExternalCanisterChangeCallPermissionsInput::RemoveByMethods(methods) => {
-                ExternalCanisterChangeCallPermissionsInput::RemoveByMethods(
+            station_api::ExternalCanisterChangeCallPermissionsInput::RemoveByExecutionMethods(methods) => {
+                ExternalCanisterChangeCallPermissionsInput::RemoveByExecutionMethods(
                     methods.into_iter().map(Into::into).collect(),
                 )
             }
@@ -768,13 +768,13 @@ impl From<ExternalCanisterChangeCallPermissionsInput>
                     input.into_iter().map(Into::into).collect(),
                 )
             }
-            ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByMethods(input) => {
-                station_api::ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByMethods(
+            ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(input) => {
+                station_api::ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
                     input.into_iter().map(Into::into).collect(),
                 )
             }
-            ExternalCanisterChangeCallPermissionsInput::RemoveByMethods(methods) => {
-                station_api::ExternalCanisterChangeCallPermissionsInput::RemoveByMethods(
+            ExternalCanisterChangeCallPermissionsInput::RemoveByExecutionMethods(methods) => {
+                station_api::ExternalCanisterChangeCallPermissionsInput::RemoveByExecutionMethods(
                     methods.into_iter().map(Into::into).collect(),
                 )
             }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -23,13 +23,14 @@ use crate::{
         EditPermissionOperationInput, EditRequestPolicyOperation, EditRequestPolicyOperationInput,
         EditUserGroupOperation, EditUserOperation, EditUserOperationInput,
         ExternalCanisterCallPermission, ExternalCanisterCallRequestPolicyRuleInput,
-        ExternalCanisterChangeRequestPolicyRuleInput, ExternalCanisterPermissionsInput,
-        ExternalCanisterRequestPoliciesInput, FundExternalCanisterOperation,
-        ManageSystemInfoOperation, ManageSystemInfoOperationInput, RemoveAddressBookEntryOperation,
-        RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, RemoveUserGroupOperation,
-        RequestOperation, SetDisasterRecoveryOperation, SetDisasterRecoveryOperationInput,
-        SystemUpgradeOperation, SystemUpgradeOperationInput, SystemUpgradeTarget,
-        TransferOperation, User, WasmModuleExtraChunks,
+        ExternalCanisterChangeRequestPolicyRuleInput, ExternalCanisterPermissionsCreateInput,
+        ExternalCanisterPermissionsUpdateInput, ExternalCanisterRequestPoliciesInput,
+        FundExternalCanisterOperation, ManageSystemInfoOperation, ManageSystemInfoOperationInput,
+        RemoveAddressBookEntryOperation, RemoveRequestPolicyOperation,
+        RemoveRequestPolicyOperationInput, RemoveUserGroupOperation, RequestOperation,
+        SetDisasterRecoveryOperation, SetDisasterRecoveryOperationInput, SystemUpgradeOperation,
+        SystemUpgradeOperationInput, SystemUpgradeTarget, TransferOperation, User,
+        WasmModuleExtraChunks,
     },
     repositories::{
         AccountRepository, AddressBookRepository, UserRepository, ACCOUNT_REPOSITORY,
@@ -602,11 +603,13 @@ impl From<ExternalCanisterCallPermission> for station_api::ExternalCanisterCallP
     }
 }
 
-impl From<station_api::ExternalCanisterPermissionsInput> for ExternalCanisterPermissionsInput {
+impl From<station_api::ExternalCanisterPermissionsCreateInput>
+    for ExternalCanisterPermissionsCreateInput
+{
     fn from(
-        input: station_api::ExternalCanisterPermissionsInput,
-    ) -> ExternalCanisterPermissionsInput {
-        ExternalCanisterPermissionsInput {
+        input: station_api::ExternalCanisterPermissionsCreateInput,
+    ) -> ExternalCanisterPermissionsCreateInput {
+        ExternalCanisterPermissionsCreateInput {
             read: input.read.into(),
             change: input.change.into(),
             calls: input.calls.into_iter().map(Into::into).collect(),
@@ -614,14 +617,62 @@ impl From<station_api::ExternalCanisterPermissionsInput> for ExternalCanisterPer
     }
 }
 
-impl From<ExternalCanisterPermissionsInput> for station_api::ExternalCanisterPermissionsInput {
+impl From<ExternalCanisterPermissionsCreateInput>
+    for station_api::ExternalCanisterPermissionsCreateInput
+{
     fn from(
-        input: ExternalCanisterPermissionsInput,
-    ) -> station_api::ExternalCanisterPermissionsInput {
-        station_api::ExternalCanisterPermissionsInput {
+        input: ExternalCanisterPermissionsCreateInput,
+    ) -> station_api::ExternalCanisterPermissionsCreateInput {
+        station_api::ExternalCanisterPermissionsCreateInput {
             read: input.read.into(),
             change: input.change.into(),
             calls: input.calls.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ExternalCanisterPermissionsCreateInput> for ExternalCanisterPermissionsUpdateInput {
+    fn from(
+        input: ExternalCanisterPermissionsCreateInput,
+    ) -> ExternalCanisterPermissionsUpdateInput {
+        ExternalCanisterPermissionsUpdateInput {
+            read: Some(input.read),
+            change: Some(input.change),
+            calls: Some(input.calls.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+impl From<station_api::ExternalCanisterPermissionsUpdateInput>
+    for ExternalCanisterPermissionsUpdateInput
+{
+    fn from(
+        input: station_api::ExternalCanisterPermissionsUpdateInput,
+    ) -> ExternalCanisterPermissionsUpdateInput {
+        ExternalCanisterPermissionsUpdateInput {
+            read: input.read.map(|read| read.into()),
+            change: input.change.map(|change| change.into()),
+            calls: input.calls.map(
+                |calls: Vec<station_api::ExternalCanisterCallPermissionDTO>| {
+                    calls.into_iter().map(Into::into).collect()
+                },
+            ),
+        }
+    }
+}
+
+impl From<ExternalCanisterPermissionsUpdateInput>
+    for station_api::ExternalCanisterPermissionsUpdateInput
+{
+    fn from(
+        input: ExternalCanisterPermissionsUpdateInput,
+    ) -> station_api::ExternalCanisterPermissionsUpdateInput {
+        station_api::ExternalCanisterPermissionsUpdateInput {
+            read: input.read.map(|read| read.into()),
+            change: input.change.map(|change| change.into()),
+            calls: input
+                .calls
+                .map(|calls| calls.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -701,8 +752,12 @@ impl From<station_api::ExternalCanisterRequestPoliciesInput>
         input: station_api::ExternalCanisterRequestPoliciesInput,
     ) -> ExternalCanisterRequestPoliciesInput {
         ExternalCanisterRequestPoliciesInput {
-            change: input.change.into_iter().map(Into::into).collect(),
-            calls: input.calls.into_iter().map(Into::into).collect(),
+            change: input
+                .change
+                .map(|policies| policies.into_iter().map(Into::into).collect()),
+            calls: input
+                .calls
+                .map(|policies| policies.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -714,8 +769,12 @@ impl From<ExternalCanisterRequestPoliciesInput>
         input: ExternalCanisterRequestPoliciesInput,
     ) -> station_api::ExternalCanisterRequestPoliciesInput {
         station_api::ExternalCanisterRequestPoliciesInput {
-            change: input.change.into_iter().map(Into::into).collect(),
-            calls: input.calls.into_iter().map(Into::into).collect(),
+            change: input
+                .change
+                .map(|policies| policies.into_iter().map(Into::into).collect()),
+            calls: input
+                .calls
+                .map(|policies| policies.into_iter().map(Into::into).collect()),
         }
     }
 }

--- a/core/station/impl/src/migration.rs
+++ b/core/station/impl/src/migration.rs
@@ -46,6 +46,8 @@ impl MigrationHandler {
         let stored_version = system_info.get_stable_memory_version();
 
         if stored_version == STABLE_MEMORY_VERSION {
+            // Run the post-run checks that need to be run on every upgrade.
+            post_run();
             return;
         }
 
@@ -61,7 +63,21 @@ impl MigrationHandler {
         // Update the stable memory version to the latest version.
         system_info.set_stable_memory_version(STABLE_MEMORY_VERSION);
         write_system_info(system_info);
+
+        // Run the post-run checks that need to be run on every upgrade.
+        post_run();
     }
+}
+
+/// If there is a check that needs to be run on every upgrade, regardless if the memory version has changed,
+/// it should be added here.
+fn post_run() {
+    // Deserialization of the all requests to make sure an incompatible memory will panic and avoids
+    // putting the station in an inconsistent state.
+    //
+    // This is a temporary addition only for the next release since we've added a breaking change to
+    // the `ConfigureExternalCanisterSettingsInput` which was a new API not yet used in production.
+    REQUEST_REPOSITORY.rebuild();
 }
 
 /// The migration to apply to the station canister stable memory.

--- a/core/station/impl/src/migration.rs
+++ b/core/station/impl/src/migration.rs
@@ -76,13 +76,9 @@ fn post_run() {
     // putting the station in an inconsistent state.
     //
     // This is a temporary addition only for the next release since we've added a breaking change to
-    // the `ConfigureExternalCanisterSettingsInput` and `CreateExternalCanister` which had a new API
-    // not yet used in production.
+    // the `ConfigureExternalCanisterSettingsInput` which had a new API not yet used in production.
     let where_clause = RequestWhereClause {
-        operation_types: vec![
-            ListRequestsOperationType::CreateExternalCanister,
-            ListRequestsOperationType::ConfigureExternalCanister(None),
-        ],
+        operation_types: vec![ListRequestsOperationType::ConfigureExternalCanister(None)],
         ..Default::default()
     };
 

--- a/core/station/impl/src/models/request.rs
+++ b/core/station/impl/src/models/request.rs
@@ -1,7 +1,7 @@
 use super::request_policy_rule::{RequestEvaluationResult, RequestPolicyRuleInput};
 use super::{
-    DisplayUser, EvaluationStatus, RequestApproval, RequestApprovalStatus, RequestOperation,
-    RequestStatus, UserId, UserKey,
+    ConfigureExternalCanisterOperationKind, DisplayUser, EvaluationStatus, RequestApproval,
+    RequestApprovalStatus, RequestOperation, RequestStatus, UserId, UserKey,
 };
 use crate::core::evaluation::{
     Evaluate, REQUEST_APPROVE_RIGHTS_REQUEST_POLICY_RULE_EVALUATOR, REQUEST_POLICY_RULE_EVALUATOR,
@@ -20,7 +20,7 @@ use crate::errors::{EvaluateError, RequestError, ValidationError};
 use crate::models::resource::{ExecutionMethodResourceTarget, ValidationMethodResourceTarget};
 use crate::repositories::USER_REPOSITORY;
 use candid::{CandidType, Deserialize};
-use orbit_essentials::model::ModelKey;
+use orbit_essentials::model::{ContextualModel, ModelKey};
 use orbit_essentials::repository::Repository;
 use orbit_essentials::storable;
 use orbit_essentials::{
@@ -214,9 +214,19 @@ fn validate_request_operation_foreign_keys(
         }
         RequestOperation::SystemUpgrade(_) => (),
         RequestOperation::ChangeExternalCanister(_) => (),
-        RequestOperation::ConfigureExternalCanister(_) => (),
+        RequestOperation::ConfigureExternalCanister(op) => {
+            let canister_id = op.canister_id;
+            if let ConfigureExternalCanisterOperationKind::Settings(settings) = &op.kind {
+                if let Some(updated_request_policies) = &settings.request_policies {
+                    ContextualModel::new(updated_request_policies.clone(), canister_id)
+                        .validate()?;
+                }
+            }
+        }
         RequestOperation::FundExternalCanister(_) => (),
-        RequestOperation::CreateExternalCanister(_) => (),
+        RequestOperation::CreateExternalCanister(op) => {
+            op.input.validate()?;
+        }
         RequestOperation::CallExternalCanister(op) => {
             let validation_method_target: ValidationMethodResourceTarget =
                 op.input.validation_method.clone().into();

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -366,8 +366,8 @@ pub struct ExternalCanisterPermissionsUpdateInput {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ExternalCanisterChangeCallPermissionsInput {
     ReplaceAllBy(Vec<ExternalCanisterCallPermission>),
-    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallPermission>),
-    RemoveByMethods(Vec<String>),
+    OverrideSpecifiedByExecutionMethods(Vec<ExternalCanisterCallPermission>),
+    RemoveByExecutionMethods(Vec<String>),
 }
 
 #[storable]
@@ -405,7 +405,7 @@ pub struct ExternalCanisterRequestPoliciesUpdateInput {
 pub enum ExternalCanisterChangeCallRequestPoliciesInput {
     ReplaceAllBy(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
     RemoveByPolicyIds(Vec<UUID>),
-    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
+    OverrideSpecifiedByExecutionMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
 }
 
 #[storable]

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -348,10 +348,18 @@ pub struct ChangeExternalCanisterOperation {
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ExternalCanisterPermissionsInput {
+pub struct ExternalCanisterPermissionsCreateInput {
     pub read: Allow,
     pub change: Allow,
     pub calls: Vec<ExternalCanisterCallPermission>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterPermissionsUpdateInput {
+    pub read: Option<Allow>,
+    pub change: Option<Allow>,
+    pub calls: Option<Vec<ExternalCanisterCallPermission>>,
 }
 
 #[storable]
@@ -373,8 +381,8 @@ pub struct ExternalCanisterChangeRequestPolicyRuleInput {
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ExternalCanisterRequestPoliciesInput {
-    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
-    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
+    pub change: Option<Vec<ExternalCanisterChangeRequestPolicyRuleInput>>,
+    pub calls: Option<Vec<ExternalCanisterCallRequestPolicyRuleInput>>,
 }
 
 #[storable]
@@ -403,7 +411,7 @@ pub struct CreateExternalCanisterOperationInput {
     pub name: String,
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
-    pub permissions: ExternalCanisterPermissionsInput,
+    pub permissions: ExternalCanisterPermissionsCreateInput,
     pub request_policies: ExternalCanisterRequestPoliciesInput,
 }
 
@@ -470,7 +478,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
     pub state: Option<ExternalCanisterState>,
-    pub permissions: Option<ExternalCanisterPermissionsInput>,
+    pub permissions: Option<ExternalCanisterPermissionsUpdateInput>,
     pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
 }
 

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -359,7 +359,15 @@ pub struct ExternalCanisterPermissionsCreateInput {
 pub struct ExternalCanisterPermissionsUpdateInput {
     pub read: Option<Allow>,
     pub change: Option<Allow>,
-    pub calls: Option<Vec<ExternalCanisterCallPermission>>,
+    pub calls: Option<ExternalCanisterChangeCallPermissionsInput>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ExternalCanisterChangeCallPermissionsInput {
+    ReplaceAllBy(Vec<ExternalCanisterCallPermission>),
+    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallPermission>),
+    RemoveByMethods(Vec<String>),
 }
 
 #[storable]
@@ -380,9 +388,24 @@ pub struct ExternalCanisterChangeRequestPolicyRuleInput {
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ExternalCanisterRequestPoliciesInput {
+pub struct ExternalCanisterRequestPoliciesCreateInput {
+    pub change: Vec<ExternalCanisterChangeRequestPolicyRuleInput>,
+    pub calls: Vec<ExternalCanisterCallRequestPolicyRuleInput>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExternalCanisterRequestPoliciesUpdateInput {
     pub change: Option<Vec<ExternalCanisterChangeRequestPolicyRuleInput>>,
-    pub calls: Option<Vec<ExternalCanisterCallRequestPolicyRuleInput>>,
+    pub calls: Option<ExternalCanisterChangeCallRequestPoliciesInput>,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ExternalCanisterChangeCallRequestPoliciesInput {
+    ReplaceAllBy(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
+    RemoveByPolicyIds(Vec<UUID>),
+    OverrideSpecifiedByMethods(Vec<ExternalCanisterCallRequestPolicyRuleInput>),
 }
 
 #[storable]
@@ -412,7 +435,7 @@ pub struct CreateExternalCanisterOperationInput {
     pub description: Option<String>,
     pub labels: Option<Vec<String>>,
     pub permissions: ExternalCanisterPermissionsCreateInput,
-    pub request_policies: ExternalCanisterRequestPoliciesInput,
+    pub request_policies: ExternalCanisterRequestPoliciesCreateInput,
 }
 
 #[storable]
@@ -479,7 +502,7 @@ pub struct ConfigureExternalCanisterSettingsInput {
     pub labels: Option<Vec<String>>,
     pub state: Option<ExternalCanisterState>,
     pub permissions: Option<ExternalCanisterPermissionsUpdateInput>,
-    pub request_policies: Option<ExternalCanisterRequestPoliciesInput>,
+    pub request_policies: Option<ExternalCanisterRequestPoliciesUpdateInput>,
 }
 
 #[storable]

--- a/core/station/impl/src/repositories/request.rs
+++ b/core/station/impl/src/repositories/request.rs
@@ -418,7 +418,7 @@ impl RequestRepository {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RequestWhereClause {
     pub created_dt_from: Option<Timestamp>,
     pub created_dt_to: Option<Timestamp>,

--- a/core/station/impl/src/repositories/request_policy.rs
+++ b/core/station/impl/src/repositories/request_policy.rs
@@ -1,4 +1,6 @@
-use super::indexes::request_policy_resource_index::RequestPolicyResourceIndexRepository;
+use super::indexes::request_policy_resource_index::{
+    ExternalCanisterPoliciesList, RequestPolicyResourceIndexRepository,
+};
 use crate::{
     core::{
         metrics::REQUEST_POLICY_METRICS, with_memory_manager, Memory, REQUEST_POLICIES_MEMORY_ID,
@@ -116,7 +118,10 @@ impl RequestPolicyRepository {
     ///
     /// - `Change` related policies.
     /// - `Call` related policies.
-    pub fn find_external_canister_policies(&self, canister_id: &Principal) -> Vec<UUID> {
+    pub fn find_external_canister_policies(
+        &self,
+        canister_id: &Principal,
+    ) -> ExternalCanisterPoliciesList {
         self.resource_index
             .find_external_canister_policies(canister_id)
     }

--- a/core/station/impl/src/repositories/request_policy.rs
+++ b/core/station/impl/src/repositories/request_policy.rs
@@ -125,6 +125,16 @@ impl RequestPolicyRepository {
         self.resource_index
             .find_external_canister_policies(canister_id)
     }
+
+    /// Finds all external canister call policies related to the specified canister id and execution method.
+    pub fn find_external_canister_call_policies_by_execution_method(
+        &self,
+        canister_id: &Principal,
+        execution_method: &String,
+    ) -> Vec<UUID> {
+        self.resource_index
+            .find_external_canister_call_policies_by_execution_method(canister_id, execution_method)
+    }
 }
 
 #[cfg(test)]

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -843,10 +843,7 @@ impl ExternalCanisterService {
                 ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
                     calls,
                 ) => {
-                    let update_call_methods = calls.iter().fold(HashSet::new(), |mut acc, call| {
-                        acc.insert(call.execution_method.clone());
-                        acc
-                    });
+                    let update_call_methods: HashSet<_> = calls.iter().map(|call| call.execution_method).collect();
 
                     // removes all existing call permissions of the updated methods
                     self.permission_repository

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -640,7 +640,7 @@ impl ExternalCanisterService {
                         &current_policies.calls,
                         calls,
                     )?,
-                ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByMethods(
+                ExternalCanisterChangeCallRequestPoliciesInput::OverrideSpecifiedByExecutionMethods(
                     calls,
                 ) => {
                     // first aggregates the calls by the execution method
@@ -840,7 +840,9 @@ impl ExternalCanisterService {
                             })?;
                     }
                 }
-                ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByMethods(calls) => {
+                ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
+                    calls,
+                ) => {
                     let update_call_methods = calls.iter().fold(HashSet::new(), |mut acc, call| {
                         acc.insert(call.execution_method.clone());
                         acc
@@ -901,7 +903,7 @@ impl ExternalCanisterService {
                             })?;
                     }
                 }
-                ExternalCanisterChangeCallPermissionsInput::RemoveByMethods(methods) => {
+                ExternalCanisterChangeCallPermissionsInput::RemoveByExecutionMethods(methods) => {
                     // removes the all call permissions associated with the methods specified of the external canister
                     for method in &methods {
                         self.permission_repository

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -633,12 +633,6 @@ impl ExternalCanisterService {
             for updated_change_policy in updated_change_policies {
                 match updated_change_policy.policy_id {
                     Some(policy_id) => {
-                        if !current_policies.change.contains(&policy_id) {
-                            return Err(ExternalCanisterError::NotFound {
-                                id: Uuid::from_bytes(policy_id).hyphenated().to_string(),
-                            })?;
-                        }
-
                         self.request_policy_service.edit_request_policy(
                             EditRequestPolicyOperationInput {
                                 policy_id,
@@ -682,12 +676,6 @@ impl ExternalCanisterService {
             for updated_call_policy in updated_call_policies {
                 match updated_call_policy.policy_id {
                     Some(policy_id) => {
-                        if !current_policies.calls.contains(&policy_id) {
-                            return Err(ExternalCanisterError::NotFound {
-                                id: Uuid::from_bytes(policy_id).hyphenated().to_string(),
-                            })?;
-                        }
-
                         self.request_policy_service.edit_request_policy(
                             EditRequestPolicyOperationInput {
                                 policy_id,

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -843,32 +843,33 @@ impl ExternalCanisterService {
                 ExternalCanisterChangeCallPermissionsInput::OverrideSpecifiedByExecutionMethods(
                     calls,
                 ) => {
-                    let update_call_methods: HashSet<_> = calls.iter().map(|call| call.execution_method).collect();
+                    let update_call_methods: HashSet<_> = calls
+                        .iter()
+                        .map(|call| call.execution_method.clone())
+                        .collect();
 
                     // removes all existing call permissions of the updated methods
                     self.permission_repository
                         .find_external_canister_call_permissions(&external_canister.canister_id)
                         .iter()
                         .filter(|permission| {
-                            if let Resource::ExternalCanister(
-                                ExternalCanisterResourceAction::Call(
-                                    CallExternalCanisterResourceTarget {
-                                        execution_method:
-                                            ExecutionMethodResourceTarget::ExecutionMethod(
-                                                CanisterMethod {
-                                                    canister_id: _,
-                                                    method_name,
-                                                },
-                                            ),
-                                        validation_method: _,
-                                    },
-                                ),
-                            ) = &permission.resource
-                            {
-                                update_call_methods.contains(method_name)
-                            } else {
-                                false
-                            }
+                            matches!(
+                                &permission.resource,
+                                Resource::ExternalCanister(
+                                    ExternalCanisterResourceAction::Call(
+                                        CallExternalCanisterResourceTarget {
+                                            execution_method:
+                                                ExecutionMethodResourceTarget::ExecutionMethod(
+                                                    CanisterMethod {
+                                                        canister_id: _,
+                                                        method_name,
+                                                    },
+                                                ),
+                                            validation_method: _,
+                                        },
+                                    ),
+                                ) if update_call_methods.contains(method_name)
+                            )
                         })
                         .for_each(|permission| {
                             self.permission_service

--- a/libs/orbit-essentials/src/model.rs
+++ b/libs/orbit-essentials/src/model.rs
@@ -8,6 +8,18 @@ pub trait ModelValidator<Err = ApiError> {
     fn validate(&self) -> ModelValidatorResult<Err>;
 }
 
+#[derive(Debug, Clone)]
+pub struct ContextualModel<M, C = ()> {
+    pub model: M,
+    pub context: C,
+}
+
+impl<M, C> ContextualModel<M, C> {
+    pub fn new(model: M, context: C) -> Self {
+        Self { model, context }
+    }
+}
+
 /// A trait for models to expose their key.
 pub trait ModelKey<Key = UUID> {
     fn key(&self) -> Key;

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -17,7 +17,7 @@ use station_api::{
     ChangeExternalCanisterOperationInput, CreateExternalCanisterOperationInput,
     CreateExternalCanisterOperationKindCreateNewDTO, CreateExternalCanisterOperationKindDTO,
     EditPermissionOperationInput, ExecutionMethodResourceTargetDTO, ExternalCanisterIdDTO,
-    ExternalCanisterPermissionsInput, ExternalCanisterRequestPoliciesInput, HealthStatus,
+    ExternalCanisterPermissionsCreateInput, ExternalCanisterRequestPoliciesInput, HealthStatus,
     ListRequestsInput, ListRequestsOperationTypeDTO, ListRequestsResponse, QuorumDTO,
     RequestApprovalStatusDTO, RequestOperationDTO, RequestOperationInput, RequestPolicyRuleDTO,
     RequestSpecifierDTO, RequestStatusDTO, UserSpecifierDTO, ValidationMethodResourceTargetDTO,
@@ -379,7 +379,7 @@ fn create_external_canister_and_check_status() {
             name: "test".to_string(),
             description: None,
             labels: None,
-            permissions: ExternalCanisterPermissionsInput {
+            permissions: ExternalCanisterPermissionsCreateInput {
                 calls: vec![],
                 read: AllowDTO {
                     auth_scope: station_api::AuthScopeDTO::Restricted,
@@ -393,8 +393,8 @@ fn create_external_canister_and_check_status() {
                 },
             },
             request_policies: ExternalCanisterRequestPoliciesInput {
-                change: Vec::new(),
-                calls: vec![],
+                change: None,
+                calls: None,
             },
         });
     let trap_message = submit_request_with_expected_trap(
@@ -1152,7 +1152,7 @@ fn create_external_canister_with_too_many_cycles() {
             name: name.to_string(),
             description: None,
             labels: None,
-            permissions: ExternalCanisterPermissionsInput {
+            permissions: ExternalCanisterPermissionsCreateInput {
                 calls: vec![],
                 read: AllowDTO {
                     auth_scope: station_api::AuthScopeDTO::Restricted,
@@ -1166,8 +1166,8 @@ fn create_external_canister_with_too_many_cycles() {
                 },
             },
             request_policies: ExternalCanisterRequestPoliciesInput {
-                change: Vec::new(),
-                calls: vec![],
+                change: None,
+                calls: None,
             },
         })
     };

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -17,8 +17,8 @@ use station_api::{
     ChangeExternalCanisterOperationInput, CreateExternalCanisterOperationInput,
     CreateExternalCanisterOperationKindCreateNewDTO, CreateExternalCanisterOperationKindDTO,
     EditPermissionOperationInput, ExecutionMethodResourceTargetDTO, ExternalCanisterIdDTO,
-    ExternalCanisterPermissionsCreateInput, ExternalCanisterRequestPoliciesInput, HealthStatus,
-    ListRequestsInput, ListRequestsOperationTypeDTO, ListRequestsResponse, QuorumDTO,
+    ExternalCanisterPermissionsCreateInput, ExternalCanisterRequestPoliciesCreateInput,
+    HealthStatus, ListRequestsInput, ListRequestsOperationTypeDTO, ListRequestsResponse, QuorumDTO,
     RequestApprovalStatusDTO, RequestOperationDTO, RequestOperationInput, RequestPolicyRuleDTO,
     RequestSpecifierDTO, RequestStatusDTO, UserSpecifierDTO, ValidationMethodResourceTargetDTO,
 };
@@ -392,9 +392,9 @@ fn create_external_canister_and_check_status() {
                     users: vec![],
                 },
             },
-            request_policies: ExternalCanisterRequestPoliciesInput {
-                change: None,
-                calls: None,
+            request_policies: ExternalCanisterRequestPoliciesCreateInput {
+                change: vec![],
+                calls: vec![],
             },
         });
     let trap_message = submit_request_with_expected_trap(
@@ -1165,9 +1165,9 @@ fn create_external_canister_with_too_many_cycles() {
                     users: vec![],
                 },
             },
-            request_policies: ExternalCanisterRequestPoliciesInput {
-                change: None,
-                calls: None,
+            request_policies: ExternalCanisterRequestPoliciesCreateInput {
+                change: vec![],
+                calls: vec![],
             },
         })
     };

--- a/tests/integration/src/test_data/system_upgrade.rs
+++ b/tests/integration/src/test_data/system_upgrade.rs
@@ -54,7 +54,7 @@ pub fn perform_station_update(
     );
 
     // wait with extra ticks since the canister is stopped by the upgrade process
-    for _ in 0..10 {
+    for _ in 0..20 {
         env.tick();
         env.advance_time(Duration::from_secs(1));
     }


### PR DESCRIPTION
With the existing API it was not possible to optionally only update the ExternalCanister change or call request policies, we always had to provide both, same with the permissions for read, change, call. This PR updates that and marks the individual policy and permission types as optional.