### PR TITLE
feat(station): large WASM support for external canisters

### DIFF
--- a/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
@@ -161,6 +161,7 @@ const submit = async (input: CanisterInstallModel) => {
         mode: assertAndReturn(input.mode, 'install mode required'),
         module: assertAndReturn(input.wasmModule, 'wasm module required'),
         arg: input.wasmInstallArg !== undefined ? [input.wasmInstallArg] : [],
+        module_extra_chunks: [],
       },
       {
         comment:

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -608,6 +608,8 @@ type ChangeExternalCanisterOperationInput = record {
   mode : CanisterInstallMode;
   // The wasm module to install.
   module : blob;
+  // Additional wasm module chunks to append to the wasm module.
+  module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
 };

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -190,6 +190,7 @@ export interface ChangeExternalCanisterOperation {
 }
 export interface ChangeExternalCanisterOperationInput {
   'arg' : [] | [Uint8Array | number[]],
+  'module_extra_chunks' : [] | [WasmModuleExtraChunks],
   'mode' : CanisterInstallMode,
   'canister_id' : Principal,
   'module' : Uint8Array | number[],

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -269,6 +269,11 @@ export const idlFactory = ({ IDL }) => {
     'kind' : ConfigureExternalCanisterOperationKind,
     'canister_id' : IDL.Principal,
   });
+  const WasmModuleExtraChunks = IDL.Record({
+    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
+    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
+    'store_canister' : IDL.Principal,
+  });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,
     'upgrade' : IDL.Null,
@@ -276,6 +281,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ChangeExternalCanisterOperationInput = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'module_extra_chunks' : IDL.Opt(WasmModuleExtraChunks),
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'module' : IDL.Vec(IDL.Nat8),
@@ -336,11 +342,6 @@ export const idlFactory = ({ IDL }) => {
     'policy_id' : UUID,
   });
   const RemoveRequestPolicyOperationInput = IDL.Record({ 'policy_id' : UUID });
-  const WasmModuleExtraChunks = IDL.Record({
-    'wasm_module_hash' : IDL.Vec(IDL.Nat8),
-    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
-    'store_canister' : IDL.Principal,
-  });
   const SystemUpgradeTarget = IDL.Variant({
     'UpgradeUpgrader' : IDL.Null,
     'UpgradeStation' : IDL.Null,

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -608,6 +608,8 @@ type ChangeExternalCanisterOperationInput = record {
   mode : CanisterInstallMode;
   // The wasm module to install.
   module : blob;
+  // Additional wasm module chunks to append to the wasm module.
+  module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
 };

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -3,6 +3,7 @@ use crate::{
     SortDirection, TimestampRfc3339, UuidDTO, ValidationMethodResourceTargetDTO,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
+use orbit_essentials::types::WasmModuleExtraChunks;
 
 pub type ExternalCanisterPermissionsInput = ExternalCanisterPermissionsDTO;
 
@@ -59,6 +60,7 @@ pub struct ChangeExternalCanisterOperationInput {
     pub mode: CanisterInstallMode,
     #[serde(with = "serde_bytes")]
     pub module: Vec<u8>,
+    pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
     pub arg: Option<Vec<u8>>,
 }

--- a/core/station/impl/src/factories/requests/change_external_canister.rs
+++ b/core/station/impl/src/factories/requests/change_external_canister.rs
@@ -80,7 +80,7 @@ impl Execute for ChangeExternalCanisterRequestExecute<'_, '_> {
                 self.operation.input.canister_id,
                 self.operation.input.mode.clone(),
                 &self.operation.input.module,
-                &None,
+                &self.operation.input.module_extra_chunks,
                 self.operation.input.arg.clone(),
             )
             .await

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -482,6 +482,7 @@ impl From<ChangeExternalCanisterOperationInput>
             canister_id: input.canister_id,
             mode: input.mode.into(),
             module: input.module,
+            module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
         }
     }
@@ -497,6 +498,7 @@ impl From<station_api::ChangeExternalCanisterOperationInput>
             canister_id: input.canister_id,
             mode: input.mode.into(),
             module: input.module,
+            module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
         }
     }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -335,6 +335,7 @@ pub struct ChangeExternalCanisterOperationInput {
     pub canister_id: Principal,
     pub mode: CanisterInstallMode,
     pub module: Vec<u8>,
+    pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     pub arg: Option<Vec<u8>>,
 }
 

--- a/tests/integration/src/system_upgrade_tests.rs
+++ b/tests/integration/src/system_upgrade_tests.rs
@@ -1,14 +1,12 @@
-use crate::setup::{create_canister, get_canister_wasm, setup_new_env, WALLET_ADMIN_USER};
+use crate::setup::{get_canister_wasm, setup_new_env, WALLET_ADMIN_USER};
 use crate::utils::{
     execute_request, execute_request_with_extra_ticks, get_core_canister_health_status,
-    get_system_info,
+    get_system_info, upload_canister_chunks_to_asset_canister,
 };
 use crate::{CanisterIds, TestEnv};
-use candid::{CandidType, Encode, Principal};
+use candid::{Encode, Principal};
 use orbit_essentials::api::ApiResult;
-use orbit_essentials::types::WasmModuleExtraChunks;
 use pocket_ic::{update_candid_as, PocketIc};
-use sha2::{Digest, Sha256};
 use station_api::{
     HealthStatus, NotifyFailedStationUpgradeInput, RequestOperationInput, RequestStatusDTO,
     SystemInstall, SystemUpgrade, SystemUpgradeOperationInput, SystemUpgradeTargetDTO,
@@ -16,77 +14,6 @@ use station_api::{
 use upgrader_api::InitArg;
 
 const EXTRA_TICKS: u64 = 50;
-
-#[derive(CandidType)]
-struct StoreArg {
-    pub key: String,
-    pub content: Vec<u8>,
-    pub content_type: String,
-    pub content_encoding: String,
-    pub sha256: Option<Vec<u8>>,
-}
-
-fn hash(data: Vec<u8>) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hasher.finalize().to_vec()
-}
-
-fn upload_canister_chunks_to_asset_canister(
-    env: &PocketIc,
-    canister_name: &str,
-    chunk_len: usize,
-) -> (Vec<u8>, WasmModuleExtraChunks) {
-    // create and install the asset canister
-    let asset_canister_id = create_canister(env, Principal::anonymous());
-    env.install_canister(
-        asset_canister_id,
-        get_canister_wasm("assetstorage"),
-        Encode!(&()).unwrap(),
-        None,
-    );
-
-    // get canister wasm
-    let canister_wasm = get_canister_wasm(canister_name).to_vec();
-    let mut hasher = Sha256::new();
-    hasher.update(&canister_wasm);
-    let canister_wasm_hash = hasher.finalize().to_vec();
-
-    // chunk canister
-    let mut chunks = canister_wasm.chunks(chunk_len);
-    let base_chunk: &[u8] = chunks.next().unwrap();
-    assert!(!base_chunk.is_empty());
-    let chunks: Vec<&[u8]> = chunks.collect();
-    assert!(chunks.len() >= 2);
-
-    // upload chunks to asset canister
-    for chunk in &chunks {
-        let chunk_hash = hash(chunk.to_vec());
-        let store_arg = StoreArg {
-            key: hex::encode(chunk_hash.clone()),
-            content: chunk.to_vec(),
-            content_type: "application/octet-stream".to_string(),
-            content_encoding: "identity".to_string(),
-            sha256: Some(chunk_hash),
-        };
-        update_candid_as::<_, ((),)>(
-            env,
-            asset_canister_id,
-            Principal::anonymous(),
-            "store",
-            (store_arg,),
-        )
-        .unwrap();
-    }
-
-    let module_extra_chunks = WasmModuleExtraChunks {
-        store_canister: asset_canister_id,
-        chunk_hashes_list: chunks.iter().map(|c| hash(c.to_vec())).collect(),
-        wasm_module_hash: canister_wasm_hash,
-    };
-
-    (base_chunk.to_vec(), module_extra_chunks)
-}
 
 fn do_successful_station_upgrade(
     env: &PocketIc,
@@ -272,8 +199,9 @@ fn system_upgrade_from_chunks() {
         ),
     ] {
         // upload chunks to asset canister
+        let canister_wasm = get_canister_wasm(canister_name).to_vec();
         let (base_chunk, mut module_extra_chunks) =
-            upload_canister_chunks_to_asset_canister(&env, canister_name, chunk_len);
+            upload_canister_chunks_to_asset_canister(&env, canister_wasm, chunk_len);
 
         // create system upgrade request from chunks
         let system_upgrade_operation =

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -1,12 +1,14 @@
-use crate::setup::{get_canister_wasm, WALLET_ADMIN_USER};
-use candid::Principal;
+use crate::setup::{create_canister, get_canister_wasm, WALLET_ADMIN_USER};
+use candid::{CandidType, Encode, Principal};
 use control_panel_api::UploadCanisterModulesInput;
 use flate2::{write::GzEncoder, Compression};
 use ic_cdk::api::management_canister::main::CanisterStatusResponse;
 use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::api::management_canister::main::CanisterId;
+use orbit_essentials::types::WasmModuleExtraChunks;
 use pocket_ic::{query_candid_as, update_candid_as, CallError, PocketIc, UserError, WasmResult};
 use sha2::Digest;
+use sha2::Sha256;
 use station_api::{
     AccountDTO, AddAccountOperationInput, AddUserOperationInput, AllowDTO, ApiErrorDTO,
     CreateRequestInput, CreateRequestResponse, GetPermissionResponse, GetRequestInput,
@@ -711,8 +713,8 @@ pub fn upload_canister_modules(env: &PocketIc, control_panel_id: Principal, cont
     // upload upgrader
     let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
     let upload_canister_modules_args = UploadCanisterModulesInput {
-        station_wasm_module: None,
         upgrader_wasm_module: Some(upgrader_wasm.to_owned()),
+        station_wasm_module: None,
     };
     let res: (ApiResult<()>,) = update_candid_as(
         env,
@@ -727,8 +729,8 @@ pub fn upload_canister_modules(env: &PocketIc, control_panel_id: Principal, cont
     // upload station
     let station_wasm = get_canister_wasm("station").to_vec();
     let upload_canister_modules_args = UploadCanisterModulesInput {
-        station_wasm_module: Some(station_wasm.to_owned()),
         upgrader_wasm_module: None,
+        station_wasm_module: Some(station_wasm),
     };
     let res: (ApiResult<()>,) = update_candid_as(
         env,
@@ -744,4 +746,74 @@ pub fn upload_canister_modules(env: &PocketIc, control_panel_id: Principal, cont
 pub fn bump_time_to_avoid_ratelimit(env: &PocketIc) {
     // the rate limiter aggregation window is 300s and resolution is 10s
     env.advance_time(Duration::from_secs(300 + 10));
+}
+
+#[derive(CandidType)]
+struct StoreArg {
+    pub key: String,
+    pub content: Vec<u8>,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub sha256: Option<Vec<u8>>,
+}
+
+fn hash(data: Vec<u8>) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+pub fn upload_canister_chunks_to_asset_canister(
+    env: &PocketIc,
+    canister_wasm: Vec<u8>,
+    chunk_len: usize,
+) -> (Vec<u8>, WasmModuleExtraChunks) {
+    // create and install the asset canister
+    let asset_canister_id = create_canister(env, Principal::anonymous());
+    env.install_canister(
+        asset_canister_id,
+        get_canister_wasm("assetstorage"),
+        Encode!(&()).unwrap(),
+        None,
+    );
+
+    // get canister wasm hash
+    let mut hasher = Sha256::new();
+    hasher.update(&canister_wasm);
+    let canister_wasm_hash = hasher.finalize().to_vec();
+
+    // chunk canister
+    let mut chunks = canister_wasm.chunks(chunk_len);
+    let base_chunk: &[u8] = chunks.next().unwrap();
+    assert!(!base_chunk.is_empty());
+    let chunks: Vec<&[u8]> = chunks.collect();
+    assert!(chunks.len() >= 2);
+
+    // upload chunks to asset canister
+    for chunk in &chunks {
+        let chunk_hash = hash(chunk.to_vec());
+        let store_arg = StoreArg {
+            key: hex::encode(chunk_hash.clone()),
+            content: chunk.to_vec(),
+            content_type: "application/octet-stream".to_string(),
+            content_encoding: "identity".to_string(),
+            sha256: Some(chunk_hash),
+        };
+        update_candid_as::<_, ((),)>(
+            env,
+            asset_canister_id,
+            Principal::anonymous(),
+            "store",
+            (store_arg,),
+        )
+        .unwrap();
+    }
+
+    let module_extra_chunks = WasmModuleExtraChunks {
+        store_canister: asset_canister_id,
+        chunk_hashes_list: chunks.iter().map(|c| hash(c.to_vec())).collect(),
+        wasm_module_hash: canister_wasm_hash,
+    };
+
+    (base_chunk.to_vec(), module_extra_chunks)
 }

--- a/tools/dfx-orbit/src/args/request/canister.rs
+++ b/tools/dfx-orbit/src/args/request/canister.rs
@@ -179,6 +179,7 @@ impl RequestCanisterInstallArgs {
             canister_id,
             mode,
             module,
+            module_extra_chunks: None,
             arg,
         };
         Ok(RequestOperationInput::ChangeExternalCanister(operation))


### PR DESCRIPTION
This PR adds support for deploying external canisters with large WASM assembled from chunks stored in a dedicated asset canister.