### PR TITLE
feat(station): add ICRC-1 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,6 +96,8 @@ jobs:
             name: 'ic-icp-index-canister'
           - canister: 'cmc'
             name: 'cycles-minting-canister'
+          - canister: 'icrc1_ledger'
+            name: 'ic-icrc1-ledger'
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2404,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "icrc-ledger-types"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f7f6b54df25295dd0ce2722d583c15e2ee7eec9cef58c10b424feb54561b2"
+dependencies = [
+ "base32",
+ "candid",
+ "crc32fast",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+ "strum 0.26.3",
+ "time",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2479,7 @@ dependencies = [
  "hex",
  "ic-cdk 0.13.5",
  "ic-ledger-types",
+ "icrc-ledger-types",
  "itertools 0.13.0",
  "lazy_static",
  "num-bigint 0.4.6",
@@ -2535,6 +2562,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2680,6 +2716,12 @@ dependencies = [
  "cc",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -3015,6 +3057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4459,6 +4502,7 @@ dependencies = [
  "ic-cdk-macros 0.9.0",
  "ic-ledger-types",
  "ic-stable-structures",
+ "icrc-ledger-types",
  "lazy_static",
  "num-bigint 0.4.6",
  "orbit-essentials",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ic-cdk-macros = "0.9"
 ic-cdk-timers = "0.7.0"
 ic-ledger-types = "0.10.0"
 ic-stable-structures = "0.6.4"
+icrc-ledger-types = "0.1.6"
 ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 itertools = "0.13.0"
 lazy_static = "1.4.0"

--- a/core/station/impl/Cargo.toml
+++ b/core/station/impl/Cargo.toml
@@ -31,6 +31,7 @@ ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-ledger-types = { workspace = true }
 ic-stable-structures = { workspace = true }
+icrc-ledger-types = { workspace = true }
 lazy_static = { workspace = true }
 num-bigint = { workspace = true }
 serde = { workspace = true, features = ['derive'] }

--- a/core/station/impl/src/core/validation.rs
+++ b/core/station/impl/src/core/validation.rs
@@ -5,7 +5,6 @@ use std::cell::RefCell;
 
 use crate::{
     errors::{ExternalCanisterValidationError, RecordValidationError},
-    factories::blockchains::InternetComputer,
     models::{
         resource::{Resource, ResourceId, ResourceIds},
         AccountKey, AddressBookEntryKey, NotificationKey, RequestKey, UserKey,
@@ -18,6 +17,7 @@ use crate::{
     services::SYSTEM_SERVICE,
 };
 use candid::Principal;
+use ic_ledger_types::MAINNET_LEDGER_CANISTER_ID;
 use ic_stable_structures::{Memory, Storable};
 #[cfg(not(test))]
 pub use orbit_essentials::cdk as ic_cdk;
@@ -199,9 +199,10 @@ impl EnsureExternalCanister {
     pub fn is_external_canister(
         principal: Principal,
     ) -> Result<(), ExternalCanisterValidationError> {
+        // todo: look into Asset repository and exclude the ledger_canister_id's
         if principal == Principal::management_canister()
             || principal == ic_cdk::api::id()
-            || principal == InternetComputer::ledger_canister_id()
+            || principal == MAINNET_LEDGER_CANISTER_ID
             || principal == SYSTEM_SERVICE.get_upgrader_canister_id()
         {
             return Err(ExternalCanisterValidationError::InvalidExternalCanister { principal });

--- a/core/station/impl/src/errors/blockchain_api.rs
+++ b/core/station/impl/src/errors/blockchain_api.rs
@@ -8,6 +8,12 @@ pub enum BlockchainApiError {
     /// Failed to fetch latest asset balance.
     #[error(r#"Failed to fetch latest asset balance."#)]
     FetchBalanceFailed { asset_id: String },
+    /// Missing metadata key.
+    #[error(r#"Metadata '{key}' not found."#)]
+    MissingMetadata { key: String },
+    /// Invalid metadata value.
+    #[error(r#"Metadata data value for key '{key}'"#)]
+    InvalidMetadata { key: String, value: String },
     /// Invalid address format.
     #[error(r#"Invalid address format. Found {found}, expected {expected}"#)]
     InvalidAddressFormat { found: String, expected: String },
@@ -20,6 +26,9 @@ pub enum BlockchainApiError {
     /// The to address is invalid.
     #[error("The to address '{address}' is invalid: {error}")]
     InvalidToAddress { address: String, error: String },
+    /// Missing metadata key.
+    #[error(r#"Asset id '{asset_id}' not found."#)]
+    MissingAsset { asset_id: String },
 }
 
 impl DetailableError for BlockchainApiError {
@@ -48,6 +57,19 @@ impl DetailableError for BlockchainApiError {
             BlockchainApiError::InvalidAddressFormat { found, expected } => {
                 details.insert("found".to_string(), found.to_string());
                 details.insert("expected".to_string(), expected.to_string());
+                Some(details)
+            }
+            BlockchainApiError::MissingMetadata { key } => {
+                details.insert("key".to_string(), key.to_string());
+                Some(details)
+            }
+            BlockchainApiError::InvalidMetadata { key, value } => {
+                details.insert("key".to_string(), key.to_string());
+                details.insert("value".to_string(), value.to_string());
+                Some(details)
+            }
+            BlockchainApiError::MissingAsset { asset_id } => {
+                details.insert("asset_id".to_string(), asset_id.to_string());
                 Some(details)
             }
         }

--- a/core/station/impl/src/errors/blockchain_api.rs
+++ b/core/station/impl/src/errors/blockchain_api.rs
@@ -26,7 +26,7 @@ pub enum BlockchainApiError {
     /// The to address is invalid.
     #[error("The to address '{address}' is invalid: {error}")]
     InvalidToAddress { address: String, error: String },
-    /// Missing metadata key.
+    /// Missing asset.
     #[error(r#"Asset id '{asset_id}' not found."#)]
     MissingAsset { asset_id: String },
 }

--- a/core/station/impl/src/errors/factory.rs
+++ b/core/station/impl/src/errors/factory.rs
@@ -6,22 +6,15 @@ use thiserror::Error;
 #[derive(Error, Debug, Eq, PartialEq, Clone)]
 pub enum FactoryError {
     /// The selected account is not yet supported by the system.
-    #[error(r#"The selected account is not yet supported by the system."#)]
-    UnsupportedBlockchainAccount {
-        blockchain: String,
-        standard: String,
-    },
+    #[error(r#"The selected blockchain is not yet supported by the system."#)]
+    UnsupportedBlockchain { blockchain: String },
 }
 
 impl DetailableError for FactoryError {
     fn details(&self) -> Option<HashMap<String, String>> {
         let mut details = HashMap::new();
-        let FactoryError::UnsupportedBlockchainAccount {
-            blockchain,
-            standard,
-        } = self;
+        let FactoryError::UnsupportedBlockchain { blockchain } = self;
         details.insert("blockchain".to_string(), blockchain.to_string());
-        details.insert("standard".to_string(), standard.to_string());
 
         Some(details)
     }

--- a/core/station/impl/src/factories/blockchains/core.rs
+++ b/core/station/impl/src/factories/blockchains/core.rs
@@ -59,7 +59,11 @@ pub trait BlockchainApi: Send + Sync {
     ) -> Result<AccountAddress, ApiError>;
 
     /// Returns the latest balance of the given account.
-    async fn balance(&self, asset: &Asset, address: &AccountAddress) -> Result<BigUint, ApiError>;
+    async fn balance(
+        &self,
+        asset: &Asset,
+        addresses: &[AccountAddress],
+    ) -> Result<BigUint, ApiError>;
 
     /// Returns the decimals of the given account.
     async fn decimals(&self, account: &Account) -> Result<u32, ApiError>;
@@ -86,18 +90,12 @@ pub trait BlockchainApi: Send + Sync {
 pub struct BlockchainApiFactory {}
 
 impl BlockchainApiFactory {
-    pub fn build(
-        blockchain: &Blockchain,
-        standard: &TokenStandard,
-    ) -> Result<Box<dyn BlockchainApi>, FactoryError> {
-        match (blockchain, standard) {
-            (Blockchain::InternetComputer, TokenStandard::InternetComputerNative)
-            | (Blockchain::InternetComputer, TokenStandard::ICRC1) => {
-                Ok(Box::new(InternetComputer::create()))
-            }
-            (blockchain, standard) => Err(FactoryError::UnsupportedBlockchainAccount {
+    pub fn build(blockchain: &Blockchain) -> Result<Box<dyn BlockchainApi>, FactoryError> {
+        match blockchain {
+            Blockchain::InternetComputer => Ok(Box::new(InternetComputer::create())),
+
+            blockchain => Err(FactoryError::UnsupportedBlockchain {
                 blockchain: blockchain.to_string(),
-                standard: standard.to_string(),
             }),
         }
     }

--- a/core/station/impl/src/factories/blockchains/core.rs
+++ b/core/station/impl/src/factories/blockchains/core.rs
@@ -65,9 +65,6 @@ pub trait BlockchainApi: Send + Sync {
         addresses: &[AccountAddress],
     ) -> Result<BigUint, ApiError>;
 
-    /// Returns the decimals of the given account.
-    async fn decimals(&self, account: &Account) -> Result<u32, ApiError>;
-
     /// Returns the latest average transaction fee.
     async fn transaction_fee(
         &self,

--- a/core/station/impl/src/factories/blockchains/internet_computer.rs
+++ b/core/station/impl/src/factories/blockchains/internet_computer.rs
@@ -491,6 +491,19 @@ impl BlockchainApi for InternetComputer {
         Ok(BigUint::from(0u64))
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn transaction_fee(
+        &self,
+        _asset: &Asset,
+        _standard: TokenStandard,
+    ) -> BlockchainApiResult<BlockchainTransactionFee> {
+        Ok(BlockchainTransactionFee {
+            fee: 10_000u64.into(),
+            metadata: Metadata::default(),
+        })
+    }
+
+    #[cfg(target_arch = "wasm32")]
     async fn transaction_fee(
         &self,
         asset: &Asset,

--- a/core/station/impl/src/factories/requests/transfer.rs
+++ b/core/station/impl/src/factories/requests/transfer.rs
@@ -109,11 +109,11 @@ impl Execute for TransferRequestExecute<'_, '_> {
                 ),
             })?;
 
-        let blockchain_api =
-            BlockchainApiFactory::build(&asset.blockchain, &self.operation.input.with_standard)
-                .map_err(|e| RequestExecuteError::Failed {
-                    reason: format!("Failed to build blockchain api: {}", e),
-                })?;
+        let blockchain_api = BlockchainApiFactory::build(&asset.blockchain).map_err(|e| {
+            RequestExecuteError::Failed {
+                reason: format!("Failed to build blockchain api: {}", e),
+            }
+        })?;
         let fee = match &self.operation.input.fee {
             Some(fee) => fee.clone(),
             None => {

--- a/core/station/impl/src/jobs/execute_created_transfers.rs
+++ b/core/station/impl/src/jobs/execute_created_transfers.rs
@@ -205,12 +205,11 @@ impl Job {
             },
         )?;
 
-        let blockchain_api =
-            BlockchainApiFactory::build(&asset.blockchain, &transfer.with_standard).map_err(
-                |e| TransferError::ExecutionError {
-                    reason: format!("Failed to build blockchain api: {}", e),
-                },
-            )?;
+        let blockchain_api = BlockchainApiFactory::build(&asset.blockchain).map_err(|e| {
+            TransferError::ExecutionError {
+                reason: format!("Failed to build blockchain api: {}", e),
+            }
+        })?;
 
         match blockchain_api.submit_transaction(&account, &transfer).await {
             Ok(details) => Ok((transfer, details)),

--- a/core/station/impl/src/models/account.rs
+++ b/core/station/impl/src/models/account.rs
@@ -130,7 +130,14 @@ impl AddressFormat {
                     address_format: self.to_string(),
                 })
                 .map(|_| ()),
-            AddressFormat::ICRC1Account => todo!(),
+            AddressFormat::ICRC1Account => {
+                icrc_ledger_types::icrc1::account::Account::from_str(address)
+                    .map_err(|_| AccountError::InvalidAddress {
+                        address: address.to_string(),
+                        address_format: self.to_string(),
+                    })
+                    .map(|_| ())
+            }
             AddressFormat::EthereumAddress => todo!(),
             AddressFormat::BitcoinAddressP2WPKH => todo!(),
             AddressFormat::BitcoinAddressP2TR => todo!(),

--- a/core/station/impl/src/models/asset.rs
+++ b/core/station/impl/src/models/asset.rs
@@ -144,7 +144,7 @@ impl ModelValidator<AssetError> for Asset {
 #[cfg(any(test, feature = "canbench"))]
 pub mod asset_test_utils {
 
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use crate::models::{Blockchain, Metadata, TokenStandard};
 
@@ -157,8 +157,17 @@ pub mod asset_test_utils {
             standards: BTreeSet::from([TokenStandard::InternetComputerNative]),
             symbol: "ICP".to_string(),
             name: "Internet Computer".to_string(),
+            metadata: Metadata::new(BTreeMap::from([
+                (
+                    "ledger_canister_id".to_string(),
+                    "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string(),
+                ),
+                (
+                    "index_canister_id".to_string(),
+                    "qhbym-qaaaa-aaaaa-aaafq-cai".to_string(),
+                ),
+            ])),
             decimals: 8,
-            metadata: Metadata::default(),
         }
     }
 

--- a/core/station/impl/src/models/blockchain_standard.rs
+++ b/core/station/impl/src/models/blockchain_standard.rs
@@ -67,12 +67,11 @@ impl TokenStandard {
 
     pub fn get_supported_operations(&self) -> Vec<StandardOperation> {
         match self {
-            TokenStandard::InternetComputerNative => vec![
+            TokenStandard::InternetComputerNative | TokenStandard::ICRC1 => vec![
                 StandardOperation::Balance,
                 StandardOperation::Transfer,
                 StandardOperation::ListTransfers,
             ],
-            TokenStandard::ICRC1 => vec![],
         }
     }
 }

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -541,7 +541,10 @@ mod init_canister_sync_handlers {
     pub fn add_initial_assets() {
         let initial_assets: Vec<Asset> = vec![Asset {
             blockchain: Blockchain::InternetComputer,
-            standards: BTreeSet::from([TokenStandard::InternetComputerNative]),
+            standards: BTreeSet::from([
+                TokenStandard::InternetComputerNative,
+                TokenStandard::ICRC1,
+            ]),
             symbol: "ICP".to_string(),
             name: "Internet Computer".to_string(),
             metadata: Metadata::new(BTreeMap::from([

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -41,6 +41,7 @@ if [ $DOWNLOAD_NNS_CANISTERS == "true" ]; then
     ./scripts/download-nns-canister-wasm.sh icp_ledger ledger-canister
     ./scripts/download-nns-canister-wasm.sh icp_index ic-icp-index-canister
     ./scripts/download-nns-canister-wasm.sh cmc cycles-minting-canister
+    ./scripts/download-nns-canister-wasm.sh icrc1_ledger ic-icrc1-ledger
 fi
 
 if [ $DOWNLOAD_ASSET_CANISTER == "true" ]; then

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -13,6 +13,7 @@ hex = { workspace = true }
 orbit-essentials = { path = '../../libs/orbit-essentials', version = '0.0.2-alpha.4' }
 ic-cdk = { workspace = true }
 ic-ledger-types = { workspace = true }
+icrc-ledger-types = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 num-bigint = { workspace = true }

--- a/tests/integration/src/address_book_tests.rs
+++ b/tests/integration/src/address_book_tests.rs
@@ -311,6 +311,7 @@ fn check_address_book_for_transfer() {
         ICP + ICP_FEE,
         0,
         None,
+        None,
     )
     .unwrap();
 

--- a/tests/integration/src/cycles_monitor_tests.rs
+++ b/tests/integration/src/cycles_monitor_tests.rs
@@ -237,7 +237,7 @@ fn can_mint_cycles_to_top_up_self() {
     )
     .unwrap();
 
-    send_icp_to_account(&env, controller, account_id, 100 * ICP, 0, None).unwrap();
+    send_icp_to_account(&env, controller, account_id, 100 * ICP, 0, None, None).unwrap();
     let pre_account_balance = get_icp_account_balance(&env, account_id);
     let pre_cycle_balance = env.cycle_balance(canister_ids.station);
     assert_eq!(pre_account_balance, 100 * ICP);

--- a/tests/integration/src/interfaces.rs
+++ b/tests/integration/src/interfaces.rs
@@ -1,10 +1,12 @@
-use candid::{CandidType, Principal};
+use candid::{CandidType, Encode, Principal};
 use ic_ledger_types::{
     AccountBalanceArgs, AccountIdentifier, Memo, Subaccount, Tokens, TransferArgs, TransferError,
     DEFAULT_SUBACCOUNT,
 };
-use pocket_ic::{update_candid_as, PocketIc};
+use pocket_ic::{query_candid_as, update_candid_as, PocketIc};
 use std::collections::{HashMap, HashSet};
+
+use crate::setup::{create_canister_with_cycles, get_canister_wasm};
 
 #[derive(CandidType)]
 pub enum NnsLedgerCanisterPayload {
@@ -71,12 +73,13 @@ pub fn send_icp_to_account(
     e8s: u64,
     memo: u64,
     from_subaccount: Option<Subaccount>,
+    fee: Option<u64>,
 ) -> Result<u64, TransferError> {
     let ledger_canister_id = Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap();
     let transfer_args = TransferArgs {
         memo: Memo(memo),
         amount: Tokens::from_e8s(e8s),
-        fee: Tokens::from_e8s(10_000),
+        fee: Tokens::from_e8s(fee.unwrap_or(10_000)),
         from_subaccount,
         to: beneficiary_account,
         created_at_time: None,
@@ -100,5 +103,126 @@ pub fn send_icp(
     memo: u64,
 ) -> Result<u64, TransferError> {
     let to = AccountIdentifier::new(&beneficiary_id, &DEFAULT_SUBACCOUNT);
-    send_icp_to_account(env, sender_id, to, e8s, memo, None)
+    send_icp_to_account(env, sender_id, to, e8s, memo, None, None)
+}
+
+pub fn mint_icp(
+    env: &PocketIc,
+    minter_id: Principal,
+    to: &AccountIdentifier,
+    e8s: u64,
+) -> Result<u64, TransferError> {
+    send_icp_to_account(env, minter_id, *to, e8s, 0, None, Some(0))
+}
+
+#[derive(CandidType)]
+pub struct Icrc1LedgerInitArgs {
+    pub minting_account: icrc_ledger_types::icrc1::account::Account,
+    pub fee_collector_account: Option<icrc_ledger_types::icrc1::account::Account>,
+    pub initial_balances: Vec<(icrc_ledger_types::icrc1::account::Account, candid::Nat)>,
+    pub transfer_fee: candid::Nat,
+    pub decimals: Option<u8>,
+    pub token_name: String,
+    pub token_symbol: String,
+    pub metadata: Vec<(
+        String,
+        icrc_ledger_types::icrc::generic_metadata_value::MetadataValue,
+    )>,
+    pub archive_options: ArchiveOptions,
+    pub max_memo_length: Option<u16>,
+    pub feature_flags: Option<FeatureFlags>,
+    pub maximum_number_of_accounts: Option<u64>,
+    pub accounts_overflow_trim_quantity: Option<u64>,
+}
+
+#[derive(CandidType)]
+pub struct ArchiveOptions {
+    pub trigger_threshold: usize,
+    pub num_blocks_to_archive: usize,
+    pub node_max_memory_size_bytes: Option<u64>,
+    pub max_message_size_bytes: Option<u64>,
+    pub controller_id: Principal,
+    pub more_controller_ids: Option<Vec<Principal>>,
+    pub cycles_for_archive_creation: Option<u64>,
+    pub max_transactions_per_response: Option<u64>,
+}
+
+#[derive(CandidType)]
+pub struct FeatureFlags {
+    pub icrc2: bool,
+}
+
+#[derive(CandidType)]
+pub enum Icrc1LedgerArgument {
+    Init(Icrc1LedgerInitArgs),
+}
+
+pub fn deploy_icrc1_token(
+    env: &mut PocketIc,
+    controller: Principal,
+    init: Icrc1LedgerInitArgs,
+) -> Principal {
+    let wasm_module = get_canister_wasm("icrc1_ledger").to_vec();
+
+    let canister_id = create_canister_with_cycles(env, controller, 1_000_000_000_000);
+
+    env.install_canister(
+        canister_id,
+        wasm_module,
+        Encode!(&Icrc1LedgerArgument::Init(init)).unwrap(),
+        Some(controller),
+    );
+
+    canister_id
+}
+
+pub fn mint_icrc1_tokens(
+    env: &PocketIc,
+    ledger_id: Principal,
+    minter: Principal,
+    to: icrc_ledger_types::icrc1::account::Account,
+    amount: u64,
+) -> Result<
+    icrc_ledger_types::icrc1::transfer::BlockIndex,
+    icrc_ledger_types::icrc1::transfer::TransferError,
+> {
+    let res: (
+        Result<
+            icrc_ledger_types::icrc1::transfer::BlockIndex,
+            icrc_ledger_types::icrc1::transfer::TransferError,
+        >,
+    ) = update_candid_as(
+        env,
+        ledger_id,
+        minter,
+        "icrc1_transfer",
+        (icrc_ledger_types::icrc1::transfer::TransferArg {
+            from_subaccount: None,
+            to,
+            fee: None,
+            created_at_time: None,
+            memo: None,
+            amount: amount.into(),
+        },),
+    )
+    .expect("Failed to make update call");
+
+    res.0
+}
+
+pub fn get_icrc1_balance_of(
+    env: &PocketIc,
+    ledger_id: Principal,
+    account: icrc_ledger_types::icrc1::account::Account,
+) -> candid::Nat {
+    let res: (candid::Nat,) = query_candid_as(
+        env,
+        ledger_id,
+        Principal::anonymous(),
+        "icrc1_balance_of",
+        (account,),
+    )
+    .expect("Failed to make query call");
+
+    res.0
 }

--- a/tests/integration/src/transfer_tests.rs
+++ b/tests/integration/src/transfer_tests.rs
@@ -1,19 +1,28 @@
 use crate::interfaces::{
-    default_account, get_icp_balance, send_icp, send_icp_to_account, ICP, ICP_FEE,
+    default_account, deploy_icrc1_token, get_icp_balance, get_icrc1_balance_of, mint_icp,
+    mint_icrc1_tokens, send_icp, send_icp_to_account, ArchiveOptions, Icrc1LedgerInitArgs, ICP,
+    ICP_FEE,
 };
 use crate::setup::{setup_new_env, WALLET_ADMIN_USER};
-use crate::utils::{get_icp_account_identifier, get_icp_asset, user_test_id};
+use crate::test_data::asset::add_asset_with_input;
+use crate::utils::{
+    create_account, create_transfer, fetch_account_balances, get_icp_account_identifier,
+    get_icp_asset, user_test_id,
+};
 use crate::TestEnv;
+use candid::Principal;
 use ic_ledger_types::AccountIdentifier;
 use orbit_essentials::api::ApiResult;
 use pocket_ic::{query_candid_as, update_candid_as};
 use station_api::{
-    AddAccountOperationInput, AllowDTO, ApiErrorDTO, CreateRequestInput, CreateRequestResponse,
-    GetRequestInput, GetRequestResponse, GetTransfersInput, GetTransfersResponse,
-    ListAccountTransfersInput, ListAccountTransfersResponse, MeResponse, QuorumPercentageDTO,
-    RequestExecutionScheduleDTO, RequestOperationDTO, RequestOperationInput, RequestPolicyRuleDTO,
-    RequestStatusDTO, TransferOperationInput, UserSpecifierDTO,
+    AddAccountOperationInput, AddAssetOperationInput, AllowDTO, ApiErrorDTO, CreateRequestInput,
+    CreateRequestResponse, GetRequestInput, GetRequestResponse, GetTransfersInput,
+    GetTransfersResponse, ListAccountTransfersInput, ListAccountTransfersResponse, MeResponse,
+    MetadataDTO, QuorumPercentageDTO, RequestExecutionScheduleDTO, RequestOperationDTO,
+    RequestOperationInput, RequestPolicyRuleDTO, RequestStatusDTO, TransferOperationInput,
+    UserSpecifierDTO,
 };
+use std::str::FromStr;
 use std::time::Duration;
 
 #[test]
@@ -144,6 +153,7 @@ fn make_transfer_successful() {
         account_address,
         ICP + ICP_FEE,
         0,
+        None,
         None,
     )
     .unwrap();
@@ -276,4 +286,302 @@ fn make_transfer_successful() {
     });
 
     assert!(all_have_transaction_hash);
+}
+
+#[test]
+fn make_icrc1_transfer() {
+    let TestEnv {
+        mut env,
+        canister_ids,
+        // controller,
+        ..
+    } = setup_new_env();
+
+    let beneficiary_id = user_test_id(1);
+
+    // register user
+    let res: (ApiResult<MeResponse>,) =
+        update_candid_as(&env, canister_ids.station, WALLET_ADMIN_USER, "me", ()).unwrap();
+    let user_dto = res.0.unwrap().me;
+
+    let ledger_controller = Principal::from_slice(&[99; 29]);
+
+    let token_ledger_canister_id = deploy_icrc1_token(
+        &mut env,
+        ledger_controller,
+        Icrc1LedgerInitArgs {
+            minting_account: icrc_ledger_types::icrc1::account::Account {
+                owner: ledger_controller,
+                subaccount: None,
+            },
+            fee_collector_account: None,
+            initial_balances: vec![],
+            transfer_fee: 50u64.into(),
+            decimals: Some(12),
+            token_name: "TEST_ICRC1".to_owned(),
+            token_symbol: "TST".to_owned(),
+            metadata: vec![],
+            archive_options: ArchiveOptions {
+                trigger_threshold: 1000,
+                num_blocks_to_archive: 1000,
+                node_max_memory_size_bytes: None,
+                max_message_size_bytes: None,
+                controller_id: ledger_controller,
+                more_controller_ids: None,
+                cycles_for_archive_creation: None,
+                max_transactions_per_response: None,
+            },
+            max_memo_length: None,
+            feature_flags: None,
+            maximum_number_of_accounts: None,
+            accounts_overflow_trim_quantity: None,
+        },
+    );
+
+    let asset = add_asset_with_input(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        AddAssetOperationInput {
+            name: "Test ICRC1 Token".to_owned(),
+            blockchain: "icp".to_owned(),
+            standards: vec!["icrc1".to_owned()],
+            symbol: "TEST".to_owned(),
+            decimals: 4,
+            metadata: vec![
+                MetadataDTO {
+                    key: "ledger_canister_id".to_owned(),
+                    value: Principal::to_text(&token_ledger_canister_id),
+                },
+                MetadataDTO {
+                    key: "index_canister_id".to_owned(),
+                    value: Principal::to_text(&token_ledger_canister_id),
+                },
+            ],
+        },
+    );
+
+    let permission = AllowDTO {
+        auth_scope: station_api::AuthScopeDTO::Restricted,
+        user_groups: vec![],
+        users: vec![user_dto.id.clone()],
+    };
+
+    let account = create_account(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        AddAccountOperationInput {
+            name: "test account".to_owned(),
+            assets: vec![asset.id.clone()],
+            metadata: vec![],
+            read_permission: permission.clone(),
+            configs_permission: permission.clone(),
+            transfer_permission: permission.clone(),
+            configs_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+            transfer_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+        },
+    );
+
+    let station_account_icrc1_account =
+        icrc_ledger_types::icrc1::account::Account::from_str(&account.addresses[0].address)
+            .expect("invalid account address");
+
+    mint_icrc1_tokens(
+        &env,
+        token_ledger_canister_id,
+        ledger_controller,
+        station_account_icrc1_account,
+        1_000_000,
+    )
+    .expect("failed to mint icrc1 tokens");
+
+    let to_address = icrc_ledger_types::icrc1::account::Account {
+        owner: beneficiary_id,
+        subaccount: None,
+    }
+    .to_string();
+
+    create_transfer(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::TransferOperationInput {
+            from_account_id: account.id.clone(),
+            from_asset_id: asset.id.clone(),
+            with_standard: "icrc1".to_owned(),
+            to: to_address.clone(),
+            amount: candid::Nat::from(100u128),
+            fee: Some(50u64.into()),
+            metadata: vec![],
+            network: None,
+        },
+    );
+
+    let balance = get_icrc1_balance_of(
+        &env,
+        token_ledger_canister_id,
+        icrc_ledger_types::icrc1::account::Account {
+            owner: beneficiary_id,
+            subaccount: None,
+        },
+    );
+
+    assert_eq!(balance, candid::Nat::from(100u128));
+
+    let account_balances = fetch_account_balances(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::FetchAccountBalancesInput {
+            account_ids: vec![account.id.clone()],
+        },
+    );
+
+    assert_eq!(
+        account_balances.balances[0].balance,
+        candid::Nat::from(999_850u128)
+    );
+
+    // test transfering without specifying fee
+    let transfer_without_fee = create_transfer(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::TransferOperationInput {
+            from_account_id: account.id.clone(),
+            from_asset_id: asset.id.clone(),
+            with_standard: "icrc1".to_owned(),
+            to: to_address,
+            amount: candid::Nat::from(500u128),
+            fee: None,
+            metadata: vec![],
+            network: None,
+        },
+    );
+
+    // the station queries the ledger canister to get the fee
+    assert_eq!(transfer_without_fee.fee, candid::Nat::from(50u64));
+}
+
+#[test]
+fn make_icrc1_icp_transfer() {
+    let TestEnv {
+        env,
+        canister_ids,
+        // controller,
+        minter,
+        ..
+    } = setup_new_env();
+
+    // register user
+    let res: (ApiResult<MeResponse>,) =
+        update_candid_as(&env, canister_ids.station, WALLET_ADMIN_USER, "me", ()).unwrap();
+    let user_dto = res.0.unwrap().me;
+
+    let icp_asset = get_icp_asset(&env, canister_ids.station, WALLET_ADMIN_USER);
+
+    let permission = AllowDTO {
+        auth_scope: station_api::AuthScopeDTO::Restricted,
+        user_groups: vec![],
+        users: vec![user_dto.id.clone()],
+    };
+
+    let account = create_account(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        AddAccountOperationInput {
+            name: "test account".to_owned(),
+            assets: vec![icp_asset.id.clone()],
+            metadata: vec![],
+            read_permission: permission.clone(),
+            configs_permission: permission.clone(),
+            transfer_permission: permission.clone(),
+            configs_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+            transfer_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+        },
+    );
+
+    assert_eq!(account.addresses.len(), 2);
+
+    let icp_account_identifier = AccountIdentifier::from_hex(
+        &account
+            .addresses
+            .iter()
+            .find(|a| a.format == "icp_account_identifier")
+            .expect("cannot get ICP account identifier")
+            .address,
+    )
+    .expect("cannot parse ICP account identifier");
+
+    let icp_icrc1_account = icrc_ledger_types::icrc1::account::Account::from_str(
+        &account
+            .addresses
+            .iter()
+            .find(|a| a.format == "icrc1_account")
+            .expect("cannot get ICRC1 account")
+            .address,
+    )
+    .expect("invalid account address");
+
+    mint_icp(&env, minter, &icp_account_identifier, 10 * 100_000_000)
+        .expect("failed to mint ICP to account");
+
+    mint_icrc1_tokens(
+        &env,
+        Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap(),
+        minter,
+        icp_icrc1_account,
+        20 * 100_000_000,
+    )
+    .expect("failed to mint ICP to ICRC1 account");
+
+    let account_balances = fetch_account_balances(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::FetchAccountBalancesInput {
+            account_ids: vec![account.id.clone()],
+        },
+    );
+    assert_eq!(account_balances.balances.len(), 1);
+    assert_eq!(
+        account_balances.balances[0].balance,
+        candid::Nat::from(30 * 100_000_000u64)
+    );
+
+    create_transfer(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::TransferOperationInput {
+            from_account_id: account.id.clone(),
+            from_asset_id: icp_asset.id.clone(),
+            with_standard: "icrc1".to_owned(),
+            to: icrc_ledger_types::icrc1::account::Account {
+                owner: user_dto.identities[0],
+                subaccount: None,
+            }
+            .to_string(),
+            amount: candid::Nat::from(25 * 100_000_000u64),
+            fee: None,
+            metadata: vec![],
+            network: None,
+        },
+    );
+
+    let account_balances = fetch_account_balances(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        station_api::FetchAccountBalancesInput {
+            account_ids: vec![account.id.clone()],
+        },
+    );
+    assert_eq!(account_balances.balances.len(), 1);
+    assert_eq!(
+        account_balances.balances[0].balance,
+        candid::Nat::from(5 * 100_000_000u64 - 10_000)
+    );
 }

--- a/tests/integration/src/transfer_tests.rs
+++ b/tests/integration/src/transfer_tests.rs
@@ -201,6 +201,10 @@ fn make_transfer_successful() {
     env.tick();
     env.tick();
     env.tick();
+    env.advance_time(Duration::from_secs(5));
+    env.tick();
+    env.tick();
+    env.tick();
 
     // check transfer request status
     let get_request_args = GetRequestInput {

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -225,6 +225,10 @@ pub fn wait_for_request_with_extra_ticks(
     // wait for the request to be processing
     env.advance_time(Duration::from_secs(2));
     env.tick();
+    // wait in case the request calls out to other canisters
+    env.advance_time(Duration::from_secs(2));
+    env.tick();
+
     for _ in 0..extra_ticks {
         env.tick();
     }

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -10,12 +10,14 @@ use pocket_ic::{query_candid_as, update_candid_as, CallError, PocketIc, UserErro
 use sha2::Digest;
 use station_api::{
     AccountDTO, AddAccountOperationInput, AddUserOperationInput, AllowDTO, ApiErrorDTO,
-    CreateRequestInput, CreateRequestResponse, GetPermissionResponse, GetRequestInput,
-    GetRequestResponse, HealthStatus, MeResponse, QuorumPercentageDTO, RequestApprovalStatusDTO,
-    RequestDTO, RequestExecutionScheduleDTO, RequestOperationDTO, RequestOperationInput,
-    RequestPolicyRuleDTO, RequestStatusDTO, ResourceIdDTO, SetDisasterRecoveryOperationDTO,
-    SetDisasterRecoveryOperationInput, SubmitRequestApprovalInput, SubmitRequestApprovalResponse,
-    SystemInfoDTO, SystemInfoResponse, UserDTO, UserSpecifierDTO, UserStatusDTO, UuidDTO,
+    CreateRequestInput, CreateRequestResponse, FetchAccountBalancesInput,
+    FetchAccountBalancesResponse, GetPermissionResponse, GetRequestInput, GetRequestResponse,
+    GetTransfersInput, GetTransfersResponse, HealthStatus, MeResponse, QuorumPercentageDTO,
+    RequestApprovalStatusDTO, RequestDTO, RequestExecutionScheduleDTO, RequestOperationDTO,
+    RequestOperationInput, RequestPolicyRuleDTO, RequestStatusDTO, ResourceIdDTO,
+    SetDisasterRecoveryOperationDTO, SetDisasterRecoveryOperationInput, SubmitRequestApprovalInput,
+    SubmitRequestApprovalResponse, SystemInfoDTO, SystemInfoResponse, UserDTO, UserSpecifierDTO,
+    UserStatusDTO, UuidDTO,
 };
 use std::io::Write;
 use std::time::Duration;
@@ -602,8 +604,18 @@ pub fn create_icp_account(env: &PocketIc, station_id: Principal, user_id: UuidDT
         )),
         metadata: vec![],
     };
+
+    create_account(env, station_id, WALLET_ADMIN_USER, create_account_args)
+}
+
+pub fn create_account(
+    env: &PocketIc,
+    station_id: Principal,
+    requester: Principal,
+    input: AddAccountOperationInput,
+) -> AccountDTO {
     let add_account_request = CreateRequestInput {
-        operation: RequestOperationInput::AddAccount(create_account_args),
+        operation: RequestOperationInput::AddAccount(input),
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
@@ -611,7 +623,7 @@ pub fn create_icp_account(env: &PocketIc, station_id: Principal, user_id: UuidDT
     let res: (ApiResult<CreateRequestResponse>,) = update_candid_as(
         env,
         station_id,
-        WALLET_ADMIN_USER,
+        requester,
         "create_request",
         (add_account_request,),
     )
@@ -640,7 +652,7 @@ pub fn create_icp_account(env: &PocketIc, station_id: Principal, user_id: UuidDT
     let res: (ApiResult<CreateRequestResponse>,) = update_candid_as(
         env,
         station_id,
-        WALLET_ADMIN_USER,
+        requester,
         "get_request",
         (get_request_args,),
     )
@@ -664,6 +676,114 @@ pub fn create_icp_account(env: &PocketIc, station_id: Principal, user_id: UuidDT
             panic!("request must be AddAccount");
         }
     }
+}
+
+pub fn create_transfer(
+    env: &PocketIc,
+    station_id: Principal,
+    requester: Principal,
+    input: station_api::TransferOperationInput,
+) -> station_api::TransferDTO {
+    // make transfer request to beneficiary
+
+    let transfer_request = CreateRequestInput {
+        operation: RequestOperationInput::Transfer(input),
+        title: None,
+        summary: None,
+        execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+    };
+    let res: (Result<CreateRequestResponse, ApiErrorDTO>,) = update_candid_as(
+        env,
+        station_id,
+        requester,
+        "create_request",
+        (transfer_request,),
+    )
+    .unwrap();
+    let request_dto = res.0.unwrap().request;
+
+    // wait for the request to be approved (timer's period is 5 seconds)
+    env.advance_time(Duration::from_secs(5));
+    env.tick();
+    // wait for the request to be processing (timer's period is 5 seconds) and first is set to processing
+    env.advance_time(Duration::from_secs(5));
+    env.tick();
+    env.tick();
+    env.tick();
+    env.advance_time(Duration::from_secs(5));
+    env.tick();
+    env.tick();
+    env.tick();
+
+    // check transfer request status
+    let get_request_args = GetRequestInput {
+        request_id: request_dto.id.clone(),
+    };
+    let res: (Result<GetRequestResponse, ApiErrorDTO>,) = update_candid_as(
+        env,
+        station_id,
+        requester,
+        "get_request",
+        (get_request_args,),
+    )
+    .unwrap();
+    let new_request_dto = res.0.unwrap().request;
+    match new_request_dto.status {
+        RequestStatusDTO::Completed { .. } => {}
+        _ => {
+            panic!(
+                "request must be completed by now but instead is {:?}",
+                new_request_dto.status
+            );
+        }
+    };
+
+    // request has the transfer id filled out
+    let transfer_id = match new_request_dto.operation {
+        RequestOperationDTO::Transfer(transfer) => transfer
+            .transfer_id
+            .expect("transfer id must be set for completed transfer"),
+        _ => {
+            panic!("request must be Transfer");
+        }
+    };
+
+    // fetch the transfer and check if its request id matches the request id that created it
+    let res: (Result<GetTransfersResponse, ApiErrorDTO>,) = query_candid_as(
+        env,
+        station_id,
+        requester,
+        "get_transfers",
+        (GetTransfersInput {
+            transfer_ids: vec![transfer_id],
+        },),
+    )
+    .expect("Failed to send query call");
+
+    res.0
+        .expect("Failed to get transfers")
+        .transfers
+        .first()
+        .expect("no transfer in result")
+        .clone()
+}
+
+pub fn fetch_account_balances(
+    env: &PocketIc,
+    station_canister_id: Principal,
+    requester: Principal,
+    input: FetchAccountBalancesInput,
+) -> station_api::FetchAccountBalancesResponse {
+    update_candid_as::<(FetchAccountBalancesInput,), (ApiResult<FetchAccountBalancesResponse>,)>(
+        env,
+        station_canister_id,
+        requester,
+        "fetch_account_balances",
+        (input,),
+    )
+    .expect("Failed to send query call")
+    .0
+    .expect("Failed to get account balances")
 }
 
 pub fn get_icp_asset(


### PR DESCRIPTION
This PR adds ICRC-1 support for the station.

Adding the default ICP asset to an account now generates 2 addresses for the account: AccountIdentifier and ICRC-1 Account. They reference the same account in the ICP ledger.