### PR TITLE
feat(dfx-orbit): support installing canisters with large WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ dependencies = [
  "ic-certified-assets",
  "ic-utils",
  "itertools 0.13.0",
+ "orbit-essentials",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/core/station/impl/src/factories/requests/change_external_canister.rs
+++ b/core/station/impl/src/factories/requests/change_external_canister.rs
@@ -32,9 +32,13 @@ impl Create<ChangeExternalCanisterOperationInput> for ChangeExternalCanisterRequ
                     hasher.finalize().to_vec()
                 }),
                 module_checksum: {
-                    let mut hasher = Sha256::new();
-                    hasher.update(&operation_input.module);
-                    hasher.finalize().to_vec()
+                    if let Some(ref module_extra_chunks) = operation_input.module_extra_chunks {
+                        module_extra_chunks.wasm_module_hash.clone()
+                    } else {
+                        let mut hasher = Sha256::new();
+                        hasher.update(&operation_input.module);
+                        hasher.finalize().to_vec()
+                    }
                 },
                 input: operation_input.into(),
             }),

--- a/tests/integration/src/dfx_orbit.rs
+++ b/tests/integration/src/dfx_orbit.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, sync::Mutex};
 
 mod assets;
 mod canister_call;
+mod install;
 mod me;
 mod review;
 mod setup;

--- a/tests/integration/src/dfx_orbit/install.rs
+++ b/tests/integration/src/dfx_orbit/install.rs
@@ -1,0 +1,154 @@
+use crate::{
+    dfx_orbit::{
+        setup::{dfx_orbit_test, setup_dfx_orbit, setup_dfx_user, DfxOrbitTestConfig},
+        util::{permit_change_operation, set_four_eyes_on_change},
+    },
+    setup::{create_canister, get_canister_wasm, setup_new_env},
+    utils::{add_user, canister_status, submit_request_approval, user_test_id, wait_for_request},
+    TestEnv,
+};
+use candid::Encode;
+use dfx_orbit::canister::{CanisterInstallModeArgs, RequestCanisterInstallArgs};
+use dfx_orbit::{
+    args::{RequestArgs, RequestArgsActions, VerifyArgs, VerifyArgsAction},
+    canister::{
+        RequestCanisterActionArgs, RequestCanisterArgs, VerifyCanisterActionArgs,
+        VerifyCanisterArgs,
+    },
+};
+use sha2::{Digest, Sha256};
+use station_api::{GetRequestInput, RequestApprovalStatusDTO};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn hash(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
+}
+
+/// Test installing a canister through orbit using the station agent
+#[test]
+fn canister_install_no_chunks() {
+    canister_install(false);
+}
+
+/// Test installing a canister using chunks through orbit using the station agent
+#[test]
+fn canister_install_chunks() {
+    canister_install(true);
+}
+
+fn canister_install(use_chunks: bool) {
+    let TestEnv {
+        mut env,
+        canister_ids,
+        ..
+    } = setup_new_env();
+
+    let (dfx_user, _) = setup_dfx_user(&env, &canister_ids);
+    let other_user = user_test_id(1);
+    add_user(&env, other_user, vec![], canister_ids.station);
+
+    // create the test canister
+    let test_canister = create_canister(&env, canister_ids.station);
+
+    // create and install the asset canister to hold module chunks
+    let asset_canister = if use_chunks {
+        let asset_canister_id = create_canister(&env, dfx_user);
+        env.install_canister(
+            asset_canister_id,
+            get_canister_wasm("assetstorage"),
+            Encode!(&()).unwrap(),
+            Some(dfx_user),
+        );
+        Some(asset_canister_id)
+    } else {
+        None
+    };
+
+    permit_change_operation(&env, &canister_ids);
+    set_four_eyes_on_change(&env, &canister_ids);
+
+    let config = DfxOrbitTestConfig {
+        canister_ids: vec![(String::from("test"), test_canister)],
+        ..Default::default()
+    };
+
+    let mut wasm = NamedTempFile::new().unwrap();
+    let module_bytes = get_canister_wasm("test_canister");
+    let max_chunk_len = module_bytes.len() / 2;
+    assert!(max_chunk_len > 0);
+    let module_hash = hash(&module_bytes);
+    wasm.write_all(&module_bytes).unwrap();
+
+    let inner_args = RequestCanisterInstallArgs {
+        canister: String::from("test"),
+        mode: CanisterInstallModeArgs::Install,
+        wasm: wasm.path().as_os_str().to_str().unwrap().to_string(),
+        argument: None,
+        arg_file: None,
+        asset_canister: asset_canister.map(|p| p.to_text()),
+        max_chunk_len: asset_canister.map(|_| max_chunk_len),
+    };
+
+    let request = dfx_orbit_test(&mut env, config, async {
+        // Setup the station agent
+        let dfx_orbit = setup_dfx_orbit(canister_ids.station).await;
+
+        // Call the test canister
+        let request = RequestArgs {
+            title: None,
+            summary: None,
+            action: RequestArgsActions::Canister(RequestCanisterArgs {
+                action: RequestCanisterActionArgs::Install(inner_args.clone()),
+            }),
+        }
+        .into_request(&dfx_orbit)
+        .await
+        .unwrap();
+
+        let request = dfx_orbit.station.request(request.clone()).await.unwrap();
+
+        // Check that the request verifies
+        let req_response = dfx_orbit
+            .station
+            .review_id(GetRequestInput {
+                request_id: request.request.id.clone(),
+            })
+            .await
+            .unwrap();
+
+        VerifyArgs {
+            request_id: request.request.id.clone(),
+            and_approve: false,
+            or_reject: false,
+            action: VerifyArgsAction::Canister(VerifyCanisterArgs {
+                action: VerifyCanisterActionArgs::Install(inner_args),
+            }),
+        }
+        .verify(&dfx_orbit, &req_response)
+        .await
+        .unwrap();
+
+        request.request
+    });
+
+    // Check that the canister is still empty.
+    let status = canister_status(&env, Some(canister_ids.station), test_canister);
+    assert_eq!(status.module_hash, None);
+
+    // The other user approves the request
+    submit_request_approval(
+        &env,
+        other_user,
+        canister_ids.station,
+        request.clone(),
+        RequestApprovalStatusDTO::Approved,
+    );
+    wait_for_request(&env, other_user, canister_ids.station, request).unwrap();
+
+    // Check that the canister is installed now.
+    let status = canister_status(&env, Some(canister_ids.station), test_canister);
+    assert_eq!(status.module_hash, Some(module_hash));
+}

--- a/tools/dfx-orbit/Cargo.toml
+++ b/tools/dfx-orbit/Cargo.toml
@@ -27,6 +27,7 @@ ic-asset.workspace = true
 ic-certified-assets.workspace = true
 ic-utils.workspace = true
 itertools.workspace = true
+orbit-essentials = { path = '../../libs/orbit-essentials', version = '0.0.2-alpha.5' }
 sha2.workspace = true
 slog.workspace = true
 slog-term.workspace = true

--- a/tools/dfx-orbit/src/canister.rs
+++ b/tools/dfx-orbit/src/canister.rs
@@ -7,7 +7,10 @@ mod install;
 mod settings;
 mod util;
 
-pub use self::{call::RequestCanisterCallArgs, install::RequestCanisterInstallArgs};
+pub use self::{
+    call::RequestCanisterCallArgs, install::CanisterInstallModeArgs,
+    install::RequestCanisterInstallArgs,
+};
 
 // TODO: Support Canister create + integration test
 // TODO: Canister get response functionality
@@ -48,7 +51,7 @@ impl RequestCanisterActionArgs {
         dfx_orbit: &DfxOrbit,
     ) -> anyhow::Result<RequestOperationInput> {
         match self {
-            RequestCanisterActionArgs::Install(args) => args.into_request(dfx_orbit),
+            RequestCanisterActionArgs::Install(args) => args.into_request(dfx_orbit).await,
             RequestCanisterActionArgs::Call(args) => args.into_request(dfx_orbit),
             //RequestCanisterActionArgs::UpdateSettings(args) => args.into_request(dfx_orbit).await,
         }

--- a/tools/dfx-orbit/src/canister/install.rs
+++ b/tools/dfx-orbit/src/canister/install.rs
@@ -1,35 +1,62 @@
 use super::util::parse_arguments;
 use crate::{canister::util::log_hashes, DfxOrbit};
 use anyhow::{bail, Context};
+use candid::CandidType;
 use clap::{Parser, ValueEnum};
+use orbit_essentials::types::WasmModuleExtraChunks;
 use sha2::{Digest, Sha256};
 use station_api::{
     CanisterInstallMode, ChangeExternalCanisterOperationDTO, ChangeExternalCanisterOperationInput,
     GetRequestResponse, RequestOperationDTO, RequestOperationInput,
 };
 use std::fmt::Write;
+
+/// The default maximum length in bytes of module chunks (the IC does not allow chunks larger than 1MiB).
+const DEFAULT_MAX_CHUNK_LEN: usize = 1 << 20;
+
 /// Requests that a canister be installed or updated.  Equivalent to `orbit_station_api::CanisterInstallMode`.
 #[derive(Debug, Clone, Parser)]
 pub struct RequestCanisterInstallArgs {
     /// The canister name or ID.
-    canister: String,
+    pub canister: String,
     /// The installation mode.
     #[clap(long, value_enum, rename_all = "kebab-case")]
-    mode: CanisterInstallModeArgs,
+    pub mode: CanisterInstallModeArgs,
     /// The path to the wasm file to install (can also be a wasm.gz).
     #[clap(short, long)]
-    wasm: String,
+    pub wasm: String,
     /// The argument to pass to the canister.
     #[clap(short, long, conflicts_with = "arg_file")]
-    argument: Option<String>,
+    pub argument: Option<String>,
     /// The path to a file containing the argument to pass to the canister.
     #[clap(short = 'f', long, conflicts_with = "arg")]
-    arg_file: Option<String>,
+    pub arg_file: Option<String>,
+    /// The asset canister name or ID to upload module chunks to.
+    #[clap(long)]
+    pub asset_canister: Option<String>,
+    /// The maximum length in bytes of module chunks.
+    #[clap(long)]
+    pub max_chunk_len: Option<usize>,
+}
+
+#[derive(CandidType)]
+struct StoreArg {
+    pub key: String,
+    pub content: Vec<u8>,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub sha256: Option<Vec<u8>>,
+}
+
+fn hash(data: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
 }
 
 impl RequestCanisterInstallArgs {
     /// Converts the CLI arg type into the equivalent Orbit API type.
-    pub(crate) fn into_request(
+    pub(crate) async fn into_request(
         self,
         dfx_orbit: &DfxOrbit,
     ) -> anyhow::Result<RequestOperationInput> {
@@ -37,11 +64,53 @@ impl RequestCanisterInstallArgs {
 
         let (module, arg) = self.load_module_and_args()?;
         let mode = self.mode.into();
+
+        let (module, module_extra_chunks) = if let Some(ref asset_canister) = self.asset_canister {
+            let asset_canister_id = dfx_orbit.canister_id(asset_canister)?;
+            let asset_agent = dfx_orbit.canister_agent(asset_canister_id)?;
+
+            // compute module hash
+            let canister_wasm_hash = hash(&module);
+
+            // chunk module
+            let chunks: Vec<&[u8]> = module
+                .chunks(self.max_chunk_len.unwrap_or(DEFAULT_MAX_CHUNK_LEN))
+                .collect();
+
+            // upload chunks to asset canister
+            for chunk in &chunks {
+                let chunk_hash = hash(chunk);
+                let store_arg = StoreArg {
+                    key: hex::encode(chunk_hash.clone()),
+                    content: chunk.to_vec(),
+                    content_type: "application/octet-stream".to_string(),
+                    content_encoding: "identity".to_string(),
+                    sha256: Some(chunk_hash),
+                };
+                asset_agent
+                    .update("store")
+                    .with_arg(store_arg)
+                    .build()
+                    .call_and_wait()
+                    .await?;
+            }
+
+            (
+                vec![],
+                Some(WasmModuleExtraChunks {
+                    store_canister: asset_canister_id,
+                    chunk_hashes_list: chunks.iter().map(|c| hash(c)).collect(),
+                    wasm_module_hash: canister_wasm_hash,
+                }),
+            )
+        } else {
+            (module, None)
+        };
         let operation = ChangeExternalCanisterOperationInput {
             canister_id,
             mode,
             module,
-            module_extra_chunks: None,
+            module_extra_chunks,
             arg,
         };
         Ok(RequestOperationInput::ChangeExternalCanister(operation))


### PR DESCRIPTION
This PR fixes the computation of `module_checksum` for external canisters with large WASM in the station and adds support for large WASM in the dfx-orbit tool.