### PR TITLE
feat(station): allow external canister creation on subnet of choice

### DIFF
--- a/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
@@ -216,6 +216,8 @@ const createNewExternalCanister = async (): Promise<Request> => {
         initial_cycles: wizard.value.configuration.maybe_with_initial_cycles
           ? [wizard.value.configuration.maybe_with_initial_cycles]
           : [],
+        // TODO: implement subnet selection
+        subnet_selection: [],
       },
     };
   }

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -625,12 +625,30 @@ type ChangeExternalCanisterOperation = record {
   arg_checksum : opt Sha256Hash;
 };
 
+type SubnetFilter = record {
+  subnet_type : opt text;
+};
+
+type SubnetSelection = variant {
+  // Choose a specific subnet
+  Subnet : record {
+    subnet : principal;
+  };
+  // Choose a random subnet that fulfills the specified properties
+  Filter : SubnetFilter;
+};
+
 type CreateExternalCanisterOperationKindCreateNew = record {
   // The initial cycles to allocate to the canister.
   //
   // If not set, only the minimal amount of cycles required to create the
   // canister will be allocated.
   initial_cycles : opt nat64;
+
+  // The subnet to which the station should be deployed.
+  //
+  // By default, the station is deployed to the same subnet as the station.
+  subnet_selection : opt SubnetSelection;
 };
 
 type CreateExternalCanisterOperationKindAddExisting = record {

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -645,9 +645,9 @@ type CreateExternalCanisterOperationKindCreateNew = record {
   // canister will be allocated.
   initial_cycles : opt nat64;
 
-  // The subnet to which the station should be deployed.
+  // The subnet on which the canister should be created.
   //
-  // By default, the station is deployed to the same subnet as the station.
+  // By default, the canister is created on the same subnet as the station.
   subnet_selection : opt SubnetSelection;
 };
 

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -238,6 +238,7 @@ export interface CreateExternalCanisterOperationKindAddExisting {
 }
 export interface CreateExternalCanisterOperationKindCreateNew {
   'initial_cycles' : [] | [bigint],
+  'subnet_selection' : [] | [SubnetSelection],
 }
 export interface CreateRequestInput {
   'title' : [] | [string],
@@ -1095,6 +1096,9 @@ export type SubmitRequestApprovalResult = {
     }
   } |
   { 'Err' : Error };
+export interface SubnetFilter { 'subnet_type' : [] | [string] }
+export type SubnetSelection = { 'Filter' : SubnetFilter } |
+  { 'Subnet' : { 'subnet' : Principal } };
 export interface SystemInfo {
   'disaster_recovery' : [] | [DisasterRecovery],
   'name' : string,

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -409,8 +409,14 @@ export const idlFactory = ({ IDL }) => {
   const CreateExternalCanisterOperationKindAddExisting = IDL.Record({
     'canister_id' : IDL.Principal,
   });
+  const SubnetFilter = IDL.Record({ 'subnet_type' : IDL.Opt(IDL.Text) });
+  const SubnetSelection = IDL.Variant({
+    'Filter' : SubnetFilter,
+    'Subnet' : IDL.Record({ 'subnet' : IDL.Principal }),
+  });
   const CreateExternalCanisterOperationKindCreateNew = IDL.Record({
     'initial_cycles' : IDL.Opt(IDL.Nat64),
+    'subnet_selection' : IDL.Opt(SubnetSelection),
   });
   const CreateExternalCanisterOperationKind = IDL.Variant({
     'AddExisting' : CreateExternalCanisterOperationKindAddExisting,

--- a/core/control-panel/api/src/user_station.rs
+++ b/core/control-panel/api/src/user_station.rs
@@ -1,5 +1,6 @@
 use crate::UserSubscriptionStatusDTO;
 use candid::{CandidType, Deserialize, Principal};
+use orbit_essentials::cmc::SubnetSelection;
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct DeployStationAdminUserInput {
@@ -10,20 +11,6 @@ pub struct DeployStationAdminUserInput {
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
 pub struct AssociateWithCallerInput {
     pub labels: Vec<String>,
-}
-
-#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
-pub struct SubnetFilter {
-    pub subnet_type: Option<String>,
-}
-
-/// Options to select subnets when creating a canister
-#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]
-pub enum SubnetSelection {
-    /// Choose a random subnet that satisfies the specified properties
-    Filter(SubnetFilter),
-    /// Choose a specific subnet
-    Subnet { subnet: Principal },
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug)]

--- a/core/control-panel/impl/src/core/constants.rs
+++ b/core/control-panel/impl/src/core/constants.rs
@@ -42,9 +42,6 @@ pub const ONE_MONTH_NS: u64 = 30 * ONE_DAY_NS;
 /// The NNS Root canister id added to station and upgrader canisters as a recovery method.
 pub const NNS_ROOT_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 3, 1, 1]);
 
-/// The CMC canister is used to deploy the station canister on a subnet of choice.
-pub const CMC_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 4, 1, 1]);
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/control-panel/impl/src/services/deploy.rs
+++ b/core/control-panel/impl/src/services/deploy.rs
@@ -1,41 +1,19 @@
 use super::{UserService, UserStationService};
 use crate::{
-    core::ic_cdk::api::{canister_balance, id},
-    core::{
-        canister_config, CallContext, CMC_CANISTER_ID, INITIAL_STATION_CYCLES, NNS_ROOT_CANISTER_ID,
-    },
+    core::{canister_config, CallContext, INITIAL_STATION_CYCLES, NNS_ROOT_CANISTER_ID},
     errors::{DeployError, UserError},
     models::{CanDeployStation, UserStation},
     services::{USER_SERVICE, USER_STATION_SERVICE},
 };
 use candid::{Encode, Principal};
-use control_panel_api::{DeployStationInput, SubnetSelection};
+use control_panel_api::DeployStationInput;
 use ic_cdk::api::id as self_canister_id;
 use ic_cdk::api::management_canister::main::{self as mgmt};
 use lazy_static::lazy_static;
 use orbit_essentials::api::ServiceResult;
-use orbit_essentials::cdk::api::call::call_with_payment128;
-use orbit_essentials::cdk::api::management_canister::main::{
-    canister_status, CanisterIdRecord, CanisterSettings,
-};
+use orbit_essentials::cmc::create_canister;
 use orbit_essentials::install_chunked_code::install_chunked_code;
 use std::sync::Arc;
-
-/// Argument taken by `create_canister` endpoint of the CMC.
-#[derive(candid::CandidType, serde::Serialize)]
-struct CreateCanister {
-    pub subnet_selection: Option<SubnetSelection>,
-    pub settings: Option<CanisterSettings>,
-}
-
-/// Error for create_canister endpoint
-#[derive(candid::CandidType, candid::Deserialize, serde::Serialize)]
-enum CreateCanisterError {
-    Refunded {
-        refund_amount: u128,
-        create_error: String,
-    },
-}
 
 lazy_static! {
     pub static ref DEPLOY_SERVICE: Arc<DeployService> = Arc::new(DeployService::new(
@@ -67,23 +45,6 @@ impl DeployService {
         input: DeployStationInput,
         ctx: &CallContext,
     ) -> ServiceResult<Principal> {
-        let station_status = canister_status(CanisterIdRecord { canister_id: id() })
-            .await
-            .map_err(|(_, err)| DeployError::Failed { reason: err })?
-            .0;
-        // enough cycles to keep the canister unfrozen for its freezing threshold duration
-        let min_balance_for_deploy_station = station_status.idle_cycles_burned_per_day
-            * station_status.settings.freezing_threshold
-            * 2_u64
-            / 86_400u64;
-        if canister_balance() < min_balance_for_deploy_station + INITIAL_STATION_CYCLES {
-            let err = DeployError::Failed {
-                reason: "Control panel has insufficient cycles balance to deploy a station"
-                    .to_string(),
-            };
-            return Err(err.into());
-        }
-
         let user = self.user_service.get_user_by_identity(&ctx.caller(), ctx)?;
         let config = canister_config().ok_or(DeployError::Failed {
             reason: "Canister config not initialized.".to_string(),
@@ -106,38 +67,9 @@ impl DeployService {
         }
 
         // Creates the station canister with some initial cycles
-        let station_canister = if let Some(subnet_selection) = input.subnet_selection {
-            let create_canister = CreateCanister {
-                subnet_selection: Some(subnet_selection),
-                settings: None,
-            };
-            call_with_payment128::<_, (Result<Principal, CreateCanisterError>,)>(
-                CMC_CANISTER_ID,
-                "create_canister",
-                (create_canister,),
-                INITIAL_STATION_CYCLES,
-            )
+        let station_canister = create_canister(input.subnet_selection, INITIAL_STATION_CYCLES)
             .await
-            .map(|res| res.0)
-            .map_err(|(_, err)| DeployError::Failed {
-                reason: err.to_string(),
-            })?
-            .map_err(
-                |CreateCanisterError::Refunded { create_error, .. }| DeployError::Failed {
-                    reason: create_error,
-                },
-            )?
-        } else {
-            mgmt::create_canister(
-                mgmt::CreateCanisterArgument { settings: None },
-                INITIAL_STATION_CYCLES,
-            )
-            .await
-            .map(|res| res.0.canister_id)
-            .map_err(|(_, err)| DeployError::Failed {
-                reason: err.to_string(),
-            })?
-        };
+            .map_err(|err| DeployError::Failed { reason: err })?;
 
         // Adds the station canister as a controller of itself so that it can change its own settings
         mgmt::update_settings(mgmt::UpdateSettingsArgument {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -625,12 +625,30 @@ type ChangeExternalCanisterOperation = record {
   arg_checksum : opt Sha256Hash;
 };
 
+type SubnetFilter = record {
+  subnet_type : opt text;
+};
+
+type SubnetSelection = variant {
+  // Choose a specific subnet
+  Subnet : record {
+    subnet : principal;
+  };
+  // Choose a random subnet that fulfills the specified properties
+  Filter : SubnetFilter;
+};
+
 type CreateExternalCanisterOperationKindCreateNew = record {
   // The initial cycles to allocate to the canister.
   //
   // If not set, only the minimal amount of cycles required to create the
   // canister will be allocated.
   initial_cycles : opt nat64;
+
+  // The subnet to which the station should be deployed.
+  //
+  // By default, the station is deployed to the same subnet as the station.
+  subnet_selection : opt SubnetSelection;
 };
 
 type CreateExternalCanisterOperationKindAddExisting = record {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -645,9 +645,9 @@ type CreateExternalCanisterOperationKindCreateNew = record {
   // canister will be allocated.
   initial_cycles : opt nat64;
 
-  // The subnet to which the station should be deployed.
+  // The subnet on which the canister should be created.
   //
-  // By default, the station is deployed to the same subnet as the station.
+  // By default, the canister is created on the same subnet as the station.
   subnet_selection : opt SubnetSelection;
 };
 

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -3,6 +3,7 @@ use crate::{
     SortDirection, TimestampRfc3339, UuidDTO, ValidationMethodResourceTargetDTO,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
+use orbit_essentials::cmc::SubnetSelection;
 use orbit_essentials::types::WasmModuleExtraChunks;
 
 // Taken from https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister
@@ -23,6 +24,7 @@ pub struct DefiniteCanisterSettingsInput {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct CreateExternalCanisterOperationKindCreateNewDTO {
     pub initial_cycles: Option<u64>,
+    pub subnet_selection: Option<SubnetSelection>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/results.yml
+++ b/core/station/impl/results.yml
@@ -1,55 +1,55 @@
 benches:
   batch_insert_100_requests:
     total:
-      instructions: 224484119
+      instructions: 224655635
       heap_increase: 0
       stable_memory_increase: 96
     scopes: {}
   find_100_users_from_50k_user_dataset:
     total:
-      instructions: 218535601
+      instructions: 218785648
       heap_increase: 97
       stable_memory_increase: 0
     scopes: {}
   find_500_external_canister_policies_from_50k_dataset:
     total:
-      instructions: 30920471
+      instructions: 30986085
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   heap_size_of_indexed_request_fields_cache_is_lt_300mib:
     total:
-      instructions: 128977905
-      heap_increase: 87
+      instructions: 129657475
+      heap_increase: 86
       stable_memory_increase: 0
     scopes: {}
   list_1k_requests:
     total:
-      instructions: 95868889
+      instructions: 98094106
       heap_increase: 7
       stable_memory_increase: 0
     scopes: {}
   list_external_canisters_with_all_statuses:
     total:
-      instructions: 201197808
+      instructions: 201751221
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   repository_find_1k_requests_from_10k_dataset_default_filters:
     total:
-      instructions: 94491311
+      instructions: 94624141
       heap_increase: 17
       stable_memory_increase: 0
     scopes: {}
   service_filter_5k_requests_from_100k_dataset:
     total:
-      instructions: 686870525
+      instructions: 687656691
       heap_increase: 106
       stable_memory_increase: 16
     scopes: {}
   service_find_all_requests_from_2k_dataset:
     total:
-      instructions: 278337883
+      instructions: 278671029
       heap_increase: 44
       stable_memory_increase: 16
     scopes: {}

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -1089,6 +1089,7 @@ impl From<station_api::CreateExternalCanisterOperationKindCreateNewDTO>
     ) -> CreateExternalCanisterOperationKindCreateNew {
         CreateExternalCanisterOperationKindCreateNew {
             initial_cycles: input.initial_cycles,
+            subnet_selection: input.subnet_selection,
         }
     }
 }
@@ -1101,6 +1102,7 @@ impl From<CreateExternalCanisterOperationKindCreateNew>
     ) -> station_api::CreateExternalCanisterOperationKindCreateNewDTO {
         station_api::CreateExternalCanisterOperationKindCreateNewDTO {
             initial_cycles: input.initial_cycles,
+            subnet_selection: input.subnet_selection,
         }
     }
 }

--- a/core/station/impl/src/models/external_canister.rs
+++ b/core/station/impl/src/models/external_canister.rs
@@ -711,6 +711,7 @@ mod tests {
             kind: CreateExternalCanisterOperationKind::CreateNew(
                 CreateExternalCanisterOperationKindCreateNew {
                     initial_cycles: None,
+                    subnet_selection: None,
                 },
             ),
             request_policies: ExternalCanisterRequestPoliciesCreateInput {

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -12,6 +12,7 @@ use crate::errors::ValidationError;
 use crate::models::Metadata;
 use candid::Principal;
 use orbit_essentials::cdk::api::management_canister::main::{self as mgmt};
+use orbit_essentials::cmc::SubnetSelection;
 use orbit_essentials::model::{ModelValidator, ModelValidatorResult};
 use orbit_essentials::{storable, types::UUID};
 use std::fmt::Display;
@@ -468,6 +469,7 @@ pub enum ExternalCanisterChangeCallRequestPoliciesInput {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CreateExternalCanisterOperationKindCreateNew {
     pub initial_cycles: Option<u64>,
+    pub subnet_selection: Option<SubnetSelection>,
 }
 
 #[storable]

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -63,7 +63,7 @@ lazy_static! {
         ));
 }
 
-const CREATE_CANISTER_CYCLES: u128 = 500_000_000_000; // fee sufficient to create canisters on any ICP mainnet subnet
+const CREATE_CANISTER_CYCLES: u128 = 325_000_000_000; // fee sufficient to create canisters on any ICP mainnet subnet
 
 #[derive(Default, Debug)]
 pub struct ExternalCanisterService {

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -35,7 +35,7 @@ use candid::{Encode, Principal};
 use ic_cdk::api::call::call_raw;
 use ic_cdk::api::management_canister::main::{
     self as mgmt, delete_canister, deposit_cycles, stop_canister, update_settings,
-    CanisterIdRecord, CanisterStatusResponse, CreateCanisterArgument, UpdateSettingsArgument,
+    CanisterIdRecord, CanisterStatusResponse, UpdateSettingsArgument,
 };
 use lazy_static::lazy_static;
 use orbit_essentials::api::ServiceResult;
@@ -63,7 +63,7 @@ lazy_static! {
         ));
 }
 
-const CREATE_CANISTER_CYCLES: u128 = 100_000_000_000; // the default fee of 100 B cycles
+const CREATE_CANISTER_CYCLES: u128 = 500_000_000_000; // fee sufficient to create canisters on any ICP mainnet subnet
 
 #[derive(Default, Debug)]
 pub struct ExternalCanisterService {
@@ -409,30 +409,6 @@ impl ExternalCanisterService {
         ExternalCanisterAvailableFilters { names, labels }
     }
 
-    /// Creates a new external canister.
-    ///
-    /// Optionally, the caller can provide the initial cycles to deposit into the canister, if not provided,
-    /// the default value will be used.
-    pub async fn create_canister(
-        &self,
-        cycles: Option<u128>,
-    ) -> ServiceResult<Principal, ExternalCanisterError> {
-        let create_canister_arg = CreateCanisterArgument { settings: None };
-
-        let canister_id = mgmt::create_canister(
-            create_canister_arg,
-            cycles.unwrap_or(CREATE_CANISTER_CYCLES),
-        )
-        .await
-        .map_err(|(_, err)| ExternalCanisterError::Failed {
-            reason: err.to_string(),
-        })?
-        .0
-        .canister_id;
-
-        Ok(canister_id)
-    }
-
     /// Calls the management canister to get the status of the canister with the given id.
     ///
     /// The station needs to be a controller of the target canister.
@@ -496,12 +472,14 @@ impl ExternalCanisterService {
                 external_canister.validate()?;
 
                 // Create the canister in the subnet and update the external canister with the correct id.
-                external_canister.canister_id = self
-                    .create_canister(opts.initial_cycles.map(|cycles| cycles as u128))
-                    .await
-                    .map_err(|err| ExternalCanisterError::Failed {
-                        reason: format!("failed to create external canister: {}", err),
-                    })?;
+                external_canister.canister_id = orbit_essentials::cmc::create_canister(
+                    opts.subnet_selection.clone(),
+                    opts.initial_cycles
+                        .map(|cycles| cycles as u128)
+                        .unwrap_or(CREATE_CANISTER_CYCLES),
+                )
+                .await
+                .map_err(|err| ExternalCanisterError::Failed { reason: err })?;
 
                 external_canister
             }

--- a/libs/orbit-essentials/src/cmc.rs
+++ b/libs/orbit-essentials/src/cmc.rs
@@ -1,0 +1,73 @@
+use crate::utils::check_balance_before_transfer;
+use candid::{CandidType, Deserialize, Principal};
+use ic_cdk::api::call::call_with_payment128;
+use ic_cdk::api::management_canister::main::{self as mgmt, CanisterSettings};
+use serde::Serialize;
+
+/// The CMC canister is used to deploy the station canister on a subnet of choice.
+const CMC_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 4, 1, 1]);
+
+#[derive(
+    CandidType, Deserialize, Serialize, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd,
+)]
+pub struct SubnetFilter {
+    pub subnet_type: Option<String>,
+}
+
+/// Options to select subnets when creating a canister
+#[derive(
+    CandidType, Deserialize, Serialize, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd,
+)]
+pub enum SubnetSelection {
+    /// Choose a random subnet that satisfies the specified properties
+    Filter(SubnetFilter),
+    /// Choose a specific subnet
+    Subnet { subnet: Principal },
+}
+
+/// Argument taken by `create_canister` endpoint of the CMC.
+#[derive(candid::CandidType, serde::Serialize)]
+struct CreateCanister {
+    pub subnet_selection: Option<SubnetSelection>,
+    pub settings: Option<CanisterSettings>,
+}
+
+/// Error for create_canister endpoint
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize)]
+enum CreateCanisterError {
+    Refunded {
+        refund_amount: u128,
+        create_error: String,
+    },
+}
+
+pub async fn create_canister(
+    subnet_selection: Option<SubnetSelection>,
+    initial_cycles: u128,
+) -> Result<Principal, String> {
+    check_balance_before_transfer(initial_cycles).await?;
+    if let Some(subnet_selection) = subnet_selection {
+        let create_canister = CreateCanister {
+            subnet_selection: Some(subnet_selection),
+            settings: None,
+        };
+        call_with_payment128::<_, (Result<Principal, CreateCanisterError>,)>(
+            CMC_CANISTER_ID,
+            "create_canister",
+            (create_canister,),
+            initial_cycles,
+        )
+        .await
+        .map(|res| res.0)
+        .map_err(|(_, err)| err.to_string())?
+        .map_err(|CreateCanisterError::Refunded { create_error, .. }| create_error)
+    } else {
+        mgmt::create_canister(
+            mgmt::CreateCanisterArgument { settings: None },
+            initial_cycles,
+        )
+        .await
+        .map(|res| res.0.canister_id)
+        .map_err(|(_, err)| err.to_string())
+    }
+}

--- a/libs/orbit-essentials/src/cmc.rs
+++ b/libs/orbit-essentials/src/cmc.rs
@@ -4,7 +4,7 @@ use ic_cdk::api::call::call_with_payment128;
 use ic_cdk::api::management_canister::main::{self as mgmt, CanisterSettings};
 use serde::Serialize;
 
-/// The CMC canister is used to deploy the station canister on a subnet of choice.
+/// The CMC canister is used to deploy a canister on a subnet of choice.
 const CMC_CANISTER_ID: Principal = Principal::from_slice(&[0, 0, 0, 0, 0, 0, 0, 4, 1, 1]);
 
 #[derive(
@@ -14,7 +14,7 @@ pub struct SubnetFilter {
     pub subnet_type: Option<String>,
 }
 
-/// Options to select subnets when creating a canister
+/// Options to select subnets when creating a canister.
 #[derive(
     CandidType, Deserialize, Serialize, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd,
 )]
@@ -32,7 +32,7 @@ struct CreateCanister {
     pub settings: Option<CanisterSettings>,
 }
 
-/// Error for create_canister endpoint
+/// Error type for `create_canister` endpoint of the CMC.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize)]
 enum CreateCanisterError {
     Refunded {

--- a/libs/orbit-essentials/src/lib.rs
+++ b/libs/orbit-essentials/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod api;
 pub mod cdk;
+pub mod cmc;
 pub mod deserialize;
 pub mod http;
 pub mod install_chunked_code;

--- a/libs/orbit-essentials/src/utils/cycles.rs
+++ b/libs/orbit-essentials/src/utils/cycles.rs
@@ -1,0 +1,24 @@
+use ic_cdk::api::canister_balance;
+use ic_cdk::api::management_canister::main::{canister_status, CanisterIdRecord};
+use ic_cdk::id;
+
+pub async fn check_balance_before_transfer(transfer_amount: u128) -> Result<(), String> {
+    let self_id = id();
+    let status = canister_status(CanisterIdRecord {
+        canister_id: self_id,
+    })
+    .await
+    .map_err(|(_, err)| err)?
+    .0;
+    // enough cycles to keep the canister unfrozen for its freezing threshold duration
+    let min_balance =
+        status.idle_cycles_burned_per_day * status.settings.freezing_threshold * 2_u64 / 86_400u64;
+    if canister_balance() < min_balance + transfer_amount {
+        let err = format!(
+            "Canister {} has insufficient cycles balance to transfer {} cycles.",
+            self_id, transfer_amount
+        );
+        return Err(err);
+    }
+    Ok(())
+}

--- a/libs/orbit-essentials/src/utils/mod.rs
+++ b/libs/orbit-essentials/src/utils/mod.rs
@@ -22,3 +22,7 @@ pub use number::*;
 /// Hash utils.
 mod hash;
 pub use hash::*;
+
+/// Cycles utils.
+mod cycles;
+pub use cycles::*;

--- a/tests/integration/src/control_panel_tests.rs
+++ b/tests/integration/src/control_panel_tests.rs
@@ -710,7 +710,6 @@ fn insufficient_control_panel_cycles() {
         )
         .unwrap();
         if let Err(e) = res.0 {
-            println!("err: {:?}", e);
             assert_eq!(
                 *e.details.unwrap().get("reason").unwrap(),
                 format!(

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -1261,7 +1261,6 @@ fn create_external_canister_with_too_many_cycles() {
     // the canister with too many cycles failed to be created because the station would be out of cycles
     match rich_canister_request_status {
         RequestStatusDTO::Failed { reason } => {
-            println!("reason: {:?}", reason);
             assert_eq!(reason.unwrap(), format!("Request execution failed due to `failed to add external canister: FAILED: The external canister operation failed due to Canister {} has insufficient cycles balance to transfer {} cycles.`.", canister_ids.station, 2 * station_cycles));
         }
         _ => panic!(

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -9,6 +9,7 @@ use crate::TestEnv;
 use candid::{Encode, Principal};
 use ic_cdk::api::management_canister::main::{CanisterIdRecord, CanisterStatusResponse};
 use orbit_essentials::api::ApiResult;
+use orbit_essentials::cmc::{SubnetFilter, SubnetSelection};
 use pocket_ic::update_candid_as;
 use sha2::{Digest, Sha256};
 use station_api::{
@@ -385,6 +386,7 @@ fn create_external_canister_and_check_status() {
             kind: CreateExternalCanisterOperationKindDTO::CreateNew(
                 CreateExternalCanisterOperationKindCreateNewDTO {
                     initial_cycles: None,
+                    subnet_selection: None,
                 },
             ),
             name: "test".to_string(),
@@ -557,10 +559,6 @@ fn create_external_canister_and_check_status() {
             executed_request.operation
         ),
     };
-
-    // top up canister
-    assert_eq!(env.cycle_balance(canister_id), 0);
-    env.add_cycles(canister_id, 100_000_000_000_000);
 
     // check canister status on behalf of the station and ensure that the canister is empty
     let status = canister_status(&env, Some(canister_ids.station), canister_id);
@@ -1158,7 +1156,10 @@ fn create_external_canister_with_too_many_cycles() {
     let create_canister_operation = |name: &str, initial_cycles| {
         RequestOperationInput::CreateExternalCanister(CreateExternalCanisterOperationInput {
             kind: CreateExternalCanisterOperationKindDTO::CreateNew(
-                CreateExternalCanisterOperationKindCreateNewDTO { initial_cycles },
+                CreateExternalCanisterOperationKindCreateNewDTO {
+                    initial_cycles,
+                    subnet_selection: None,
+                },
             ),
             name: name.to_string(),
             description: None,
@@ -1260,7 +1261,8 @@ fn create_external_canister_with_too_many_cycles() {
     // the canister with too many cycles failed to be created because the station would be out of cycles
     match rich_canister_request_status {
         RequestStatusDTO::Failed { reason } => {
-            assert_eq!(reason.unwrap(), format!("Request execution failed due to internal error: `IC0504: Error from Canister {}: Canister {} is out of cycles`.", canister_ids.station, canister_ids.station));
+            println!("reason: {:?}", reason);
+            assert_eq!(reason.unwrap(), format!("Request execution failed due to `failed to add external canister: FAILED: The external canister operation failed due to Canister {} has insufficient cycles balance to transfer {} cycles.`.", canister_ids.station, 2 * station_cycles));
         }
         _ => panic!(
             "Unexpected request status: {:?}",
@@ -1271,4 +1273,74 @@ fn create_external_canister_with_too_many_cycles() {
     let health_status =
         get_core_canister_health_status(&env, WALLET_ADMIN_USER, canister_ids.station);
     assert_eq!(health_status, HealthStatus::Healthy);
+}
+
+#[test]
+fn create_external_canister_on_different_subnet() {
+    let TestEnv {
+        env, canister_ids, ..
+    } = setup_new_env();
+
+    // create a canister on the fiduciary subnet
+    let subnet_selection = Some(SubnetSelection::Filter(SubnetFilter {
+        subnet_type: Some("fiduciary".to_string()),
+    }));
+    let create_canister_operation =
+        RequestOperationInput::CreateExternalCanister(CreateExternalCanisterOperationInput {
+            kind: CreateExternalCanisterOperationKindDTO::CreateNew(
+                CreateExternalCanisterOperationKindCreateNewDTO {
+                    initial_cycles: None,
+                    subnet_selection,
+                },
+            ),
+            name: "test".to_string(),
+            description: None,
+            labels: None,
+            permissions: ExternalCanisterPermissionsCreateInput {
+                calls: vec![],
+                read: AllowDTO {
+                    auth_scope: station_api::AuthScopeDTO::Restricted,
+                    user_groups: vec![],
+                    users: vec![],
+                },
+                change: AllowDTO {
+                    auth_scope: station_api::AuthScopeDTO::Restricted,
+                    user_groups: vec![],
+                    users: vec![],
+                },
+            },
+            request_policies: ExternalCanisterRequestPoliciesCreateInput {
+                change: vec![],
+                calls: vec![],
+            },
+        });
+    let create_canister_request = execute_request(
+        &env,
+        WALLET_ADMIN_USER,
+        canister_ids.station,
+        create_canister_operation,
+    )
+    .unwrap();
+    let canister_id = match create_canister_request.operation {
+        RequestOperationDTO::CreateExternalCanister(operation) => operation.canister_id.unwrap(),
+        _ => panic!(
+            "Unexpected request operation type: {:?}",
+            create_canister_request.operation
+        ),
+    };
+
+    // check canister status on behalf of the station and ensure that the canister is empty
+    let status = canister_status(&env, Some(canister_ids.station), canister_id);
+    assert_eq!(status.module_hash, None);
+
+    // check that the canister has been deployed to the fiduciary subnet
+    assert_eq!(
+        env.get_subnet(canister_id).unwrap(),
+        env.topology().get_fiduciary().unwrap()
+    );
+    // which is different from the subnet to which the station is deployed
+    assert_ne!(
+        env.get_subnet(canister_id).unwrap(),
+        env.get_subnet(canister_ids.control_panel).unwrap()
+    );
 }


### PR DESCRIPTION
This PR allows to create external canisters on a subnet of choice when using the station to create an external canister. To support fiduciary subnet which has higher cycles consumption, the initial number of cycles used when creating a canister using the station has been increased.