### PR TITLE
chore(ci): run integration tests with large station WASM

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -48,4 +48,8 @@ if [ $DOWNLOAD_ASSET_CANISTER == "true" ]; then
     ./scripts/download-asset-canister-wasm.sh
 fi
 
+# ungzip station wasm to make it a large WASM for integration tests
+gzip -d wasms/station.wasm.gz
+mv wasms/station.wasm wasms/station.wasm.gz
+
 cargo test --package integration-tests $TESTNAME -- --test-threads $TEST_THREADS --nocapture

--- a/tests/integration/src/disaster_recovery_tests.rs
+++ b/tests/integration/src/disaster_recovery_tests.rs
@@ -537,7 +537,7 @@ fn test_disaster_recovery_flow_recreates_same_accounts() {
         .collect();
 
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(&env, station_wasm_module, 200_000);
+        upload_canister_chunks_to_asset_canister(&env, station_wasm_module, 500_000);
     let res: (ApiResult<()>,) = update_candid_as(
         &env,
         upgrader_id,
@@ -715,7 +715,7 @@ fn test_disaster_recovery_flow_reuses_same_upgrader() {
 
     // 2. perform the disaster recovery request with the station wasm and using the same upgrader id
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(&env, station_wasm_module.clone(), 200_000);
+        upload_canister_chunks_to_asset_canister(&env, station_wasm_module.clone(), 500_000);
     let res: (ApiResult<()>,) = update_candid_as(
         &env,
         upgrader_id,
@@ -934,7 +934,7 @@ fn test_disaster_recovery_upgrade() {
     let station_init_arg = SystemInstall::Upgrade(SystemUpgrade { name: None });
     let new_wasm_module = get_canister_wasm("station");
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(&env, new_wasm_module, 200_000);
+        upload_canister_chunks_to_asset_canister(&env, new_wasm_module, 500_000);
     let good_request = upgrader_api::RequestDisasterRecoveryInput {
         module: base_chunk,
         module_extra_chunks: Some(module_extra_chunks),
@@ -977,7 +977,7 @@ fn test_disaster_recovery_failing() {
     // install with intentionally bad arg to fail
     let new_wasm_module = get_canister_wasm("station");
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(&env, new_wasm_module, 200_000);
+        upload_canister_chunks_to_asset_canister(&env, new_wasm_module, 500_000);
     let good_request = upgrader_api::RequestDisasterRecoveryInput {
         module: base_chunk,
         module_extra_chunks: Some(module_extra_chunks),

--- a/tests/integration/src/system_upgrade_tests.rs
+++ b/tests/integration/src/system_upgrade_tests.rs
@@ -13,7 +13,7 @@ use station_api::{
 };
 use upgrader_api::InitArg;
 
-const EXTRA_TICKS: u64 = 50;
+const EXTRA_TICKS: u64 = 100;
 
 fn do_successful_station_upgrade(
     env: &PocketIc,
@@ -127,29 +127,6 @@ fn do_failed_system_upgrade(
 }
 
 #[test]
-fn successful_station_upgrade() {
-    let TestEnv {
-        env, canister_ids, ..
-    } = setup_new_env();
-
-    // get station wasm
-    let station_wasm = get_canister_wasm("station").to_vec();
-
-    // create station upgrade request
-    let station_init_arg = SystemInstall::Upgrade(SystemUpgrade { name: None });
-    let station_init_arg_bytes = Encode!(&station_init_arg).unwrap();
-    let station_upgrade_operation =
-        RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
-            target: SystemUpgradeTargetDTO::UpgradeStation,
-            module: station_wasm,
-            module_extra_chunks: None,
-            arg: Some(station_init_arg_bytes),
-        });
-
-    do_successful_station_upgrade(&env, &canister_ids, station_upgrade_operation);
-}
-
-#[test]
 fn failed_station_upgrade() {
     let TestEnv {
         env, canister_ids, ..
@@ -189,7 +166,7 @@ fn system_upgrade_from_chunks() {
             SystemUpgradeTargetDTO::UpgradeStation,
             station_init_arg_bytes,
             "station",
-            200_000,
+            500_000,
         ),
         (
             SystemUpgradeTargetDTO::UpgradeUpgrader,

--- a/tests/integration/src/test_data/system_upgrade.rs
+++ b/tests/integration/src/test_data/system_upgrade.rs
@@ -42,7 +42,7 @@ pub fn perform_station_update(
 ) {
     // upload chunks to asset canister
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(&env, station_wasm, 500_000);
+        upload_canister_chunks_to_asset_canister(env, station_wasm, 500_000);
 
     // create system upgrade request from chunks
     let system_upgrade_operation =

--- a/tests/integration/src/test_data/system_upgrade.rs
+++ b/tests/integration/src/test_data/system_upgrade.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
-use crate::utils::{submit_request, wait_for_request};
+use crate::utils::{submit_request, upload_canister_chunks_to_asset_canister, wait_for_request};
 use candid::Principal;
 use pocket_ic::PocketIc;
+use station_api::{RequestOperationInput, SystemUpgradeOperationInput};
 
 pub fn perform_upgrader_update(
     env: &PocketIc,
@@ -39,22 +40,28 @@ pub fn perform_station_update(
     requester: Principal,
     station_wasm: Vec<u8>,
 ) {
+    // upload chunks to asset canister
+    let (base_chunk, module_extra_chunks) =
+        upload_canister_chunks_to_asset_canister(&env, station_wasm, 500_000);
+
+    // create system upgrade request from chunks
+    let system_upgrade_operation =
+        RequestOperationInput::SystemUpgrade(SystemUpgradeOperationInput {
+            target: station_api::SystemUpgradeTargetDTO::UpgradeStation,
+            module: base_chunk,
+            module_extra_chunks: Some(module_extra_chunks),
+            arg: None,
+        });
+
     let request_station_upgrade = submit_request(
         env,
         requester,
         station_canister_id,
-        station_api::RequestOperationInput::SystemUpgrade(
-            station_api::SystemUpgradeOperationInput {
-                target: station_api::SystemUpgradeTargetDTO::UpgradeStation,
-                module: station_wasm.clone(),
-                module_extra_chunks: None,
-                arg: None,
-            },
-        ),
+        system_upgrade_operation,
     );
 
     // wait with extra ticks since the canister is stopped by the upgrade process
-    for _ in 0..20 {
+    for _ in 0..100 {
         env.tick();
         env.advance_time(Duration::from_secs(1));
     }

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -736,7 +736,7 @@ pub fn upload_canister_modules(env: &PocketIc, control_panel_id: Principal, cont
     // upload station
     let station_wasm = get_canister_wasm("station");
     let (base_chunk, module_extra_chunks) =
-        upload_canister_chunks_to_asset_canister(env, station_wasm, 200_000);
+        upload_canister_chunks_to_asset_canister(env, station_wasm, 500_000);
     let upload_canister_modules_args = UploadCanisterModulesInput {
         upgrader_wasm_module: None,
         station_wasm_module: Some(base_chunk),


### PR DESCRIPTION
This PR makes the integration tests run with a large station WASM so that we make sure to be ready for having a large station WASM in production.