### PR TITLE
chore(control-panel,station,upgrader): bump ic-cdk to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,8 +892,8 @@ dependencies = [
  "control-panel-api",
  "email_address",
  "hex",
- "ic-cdk 0.13.5",
- "ic-cdk-macros 0.9.0",
+ "ic-cdk 0.16.0",
+ "ic-cdk-macros 0.16.0",
  "ic-cdk-timers",
  "ic-stable-structures",
  "lazy_static",
@@ -2183,24 +2183,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-cdk-macros"
-version = "0.8.4"
+name = "ic-cdk"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
+checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
 dependencies = [
  "candid",
- "proc-macro2",
- "quote",
+ "ic-cdk-macros 0.16.0",
+ "ic0 0.23.0",
  "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
+ "serde_bytes",
 ]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.9.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde5ca6ef1e69825c68916ff1bf7256b8f7ed69ac5ea3f1756f6e57f1503e27"
+checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -2229,6 +2228,20 @@ name = "ic-cdk-macros"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af44fb4ec3a4b18831c9d3303ca8fa2ace846c4022d50cb8df4122635d3782e"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.2.2",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4d857135deef20cc7ea8f3869a30cd9cfeb1392b3a81043790b2cd82adc3e0"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -3149,7 +3162,7 @@ dependencies = [
  "convert_case",
  "getrandom",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-timers",
  "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
  "ic-http-certification 2.6.0 (git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816)",
@@ -4602,8 +4615,8 @@ dependencies = [
  "deunicode",
  "futures",
  "hex",
- "ic-cdk 0.13.5",
- "ic-cdk-macros 0.9.0",
+ "ic-cdk 0.16.0",
+ "ic-cdk-macros 0.16.0",
  "ic-ledger-types",
  "ic-stable-structures",
  "lazy_static",
@@ -4827,8 +4840,8 @@ dependencies = [
  "candid",
  "candid_parser",
  "futures",
- "ic-cdk 0.13.5",
- "ic-cdk-macros 0.9.0",
+ "ic-cdk 0.16.0",
+ "ic-cdk-macros 0.16.0",
  "orbit-essentials",
  "serde",
 ]
@@ -5244,7 +5257,7 @@ dependencies = [
  "candid",
  "candid_parser",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-timers",
  "ic-stable-structures",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ ic-certification = { git = "https://github.com/dfinity/response-verification", r
 ic-certified-assets = { git = "https://github.com/dfinity/sdk.git", rev = "bb5f8b58afa94b1950f5e1a750e0491457ad88d1" }
 ic-http-certification = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
 ic-representation-independent-hash = { git = "https://github.com/dfinity/response-verification", rev = "da70db93832f88ecc556ae082612aedec47d3816" }
-ic-cdk = "0.13.2"
-ic-cdk-macros = "0.9"
+ic-cdk = "0.16.0"
+ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.9.0"
 ic-ledger-types = "0.12.0"
 ic-stable-structures = "0.6.4"

--- a/apps/wallet/src/components/external-canisters/CanisterIcSettingsDialog.spec.ts
+++ b/apps/wallet/src/components/external-canisters/CanisterIcSettingsDialog.spec.ts
@@ -53,6 +53,8 @@ describe('CanisterIcSettingsDialog', () => {
           freezing_threshold: BigInt(0),
           memory_allocation: BigInt(0),
           reserved_cycles_limit: BigInt(0),
+          log_visibility: { controllers: null },
+          wasm_memory_limit: BigInt(0),
         },
         attach: true, // disables teleport in VDialog
       },

--- a/apps/wallet/src/components/external-canisters/CanisterIcSettingsDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterIcSettingsDialog.vue
@@ -112,6 +112,8 @@ const initialModel = (): CanisterIcSettingsModel => {
   model.reserved_cycles_limit = parseToNumberOrUndefined(
     props.canisterSettings?.reserved_cycles_limit,
   );
+  model.log_visibility = props.canisterSettings?.log_visibility;
+  model.wasm_memory_limit = parseToNumberOrUndefined(props.canisterSettings?.wasm_memory_limit);
 
   return model;
 };
@@ -166,6 +168,17 @@ const submit = async (input: CanisterIcSettingsModel) => {
           input.reserved_cycles_limit !== undefined &&
           BigInt(input.reserved_cycles_limit) !== props.canisterSettings?.reserved_cycles_limit
             ? [BigInt(input.reserved_cycles_limit)]
+            : [],
+        wasm_memory_limit:
+          input.wasm_memory_limit !== undefined &&
+          BigInt(input.wasm_memory_limit) !== props.canisterSettings?.wasm_memory_limit
+            ? [BigInt(input.wasm_memory_limit)]
+            : [],
+        log_visibility:
+          input.log_visibility &&
+          JSON.stringify(input.log_visibility) !==
+            JSON.stringify(props.canisterSettings?.log_visibility)
+            ? [input.log_visibility]
             : [],
         controllers: input.controllers && hasUpdatedControllers ? [input.controllers] : [],
       },

--- a/apps/wallet/src/components/external-canisters/external-canisters.types.ts
+++ b/apps/wallet/src/components/external-canisters/external-canisters.types.ts
@@ -4,6 +4,7 @@ import {
   CanisterInstallMode,
   CanisterMethod,
   ExternalCanisterChangeRequestPolicyRuleInput,
+  LogVisibility,
   ValidationMethodResourceTarget,
 } from '~/generated/station/station.did';
 
@@ -19,6 +20,8 @@ export interface CanisterIcSettingsModel {
   memory_allocation?: number;
   compute_allocation?: number;
   reserved_cycles_limit?: number;
+  log_visibility?: LogVisibility;
+  wasm_memory_limit?: number;
 }
 
 export interface CanisterInstallModel {

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -2235,12 +2235,19 @@ type CanisterStatusInput = record {
   canister_id : principal;
 };
 
+type LogVisibility = variant {
+  public;
+  controllers;
+};
+
 type DefiniteCanisterSettings = record {
   controllers : vec principal;
   compute_allocation : nat;
   memory_allocation : nat;
   freezing_threshold : nat;
   reserved_cycles_limit : nat;
+  log_visibility : LogVisibility;
+  wasm_memory_limit : nat;
 };
 
 type DefiniteCanisterSettingsInput = record {
@@ -2249,6 +2256,8 @@ type DefiniteCanisterSettingsInput = record {
   memory_allocation : opt nat;
   freezing_threshold : opt nat;
   reserved_cycles_limit : opt nat;
+  log_visibility : opt LogVisibility;
+  wasm_memory_limit : opt nat;
 };
 
 type CanisterStatusResponse = record {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -267,6 +267,8 @@ export interface DefiniteCanisterSettings {
   'freezing_threshold' : bigint,
   'controllers' : Array<Principal>,
   'reserved_cycles_limit' : bigint,
+  'log_visibility' : LogVisibility,
+  'wasm_memory_limit' : bigint,
   'memory_allocation' : bigint,
   'compute_allocation' : bigint,
 }
@@ -274,6 +276,8 @@ export interface DefiniteCanisterSettingsInput {
   'freezing_threshold' : [] | [bigint],
   'controllers' : [] | [Array<Principal>],
   'reserved_cycles_limit' : [] | [bigint],
+  'log_visibility' : [] | [LogVisibility],
+  'wasm_memory_limit' : [] | [bigint],
   'memory_allocation' : [] | [bigint],
   'compute_allocation' : [] | [bigint],
 }
@@ -790,6 +794,8 @@ export type ListUsersResult = {
     }
   } |
   { 'Err' : Error };
+export type LogVisibility = { 'controllers' : null } |
+  { 'public' : null };
 export interface ManageSystemInfoOperation {
   'input' : ManageSystemInfoOperationInput,
 }

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -32,10 +32,16 @@ export const idlFactory = ({ IDL }) => {
     'Init' : SystemInit,
   });
   const CanisterStatusInput = IDL.Record({ 'canister_id' : IDL.Principal });
+  const LogVisibility = IDL.Variant({
+    'controllers' : IDL.Null,
+    'public' : IDL.Null,
+  });
   const DefiniteCanisterSettings = IDL.Record({
     'freezing_threshold' : IDL.Nat,
     'controllers' : IDL.Vec(IDL.Principal),
     'reserved_cycles_limit' : IDL.Nat,
+    'log_visibility' : LogVisibility,
+    'wasm_memory_limit' : IDL.Nat,
     'memory_allocation' : IDL.Nat,
     'compute_allocation' : IDL.Nat,
   });
@@ -301,6 +307,8 @@ export const idlFactory = ({ IDL }) => {
     'freezing_threshold' : IDL.Opt(IDL.Nat),
     'controllers' : IDL.Opt(IDL.Vec(IDL.Principal)),
     'reserved_cycles_limit' : IDL.Opt(IDL.Nat),
+    'log_visibility' : IDL.Opt(LogVisibility),
+    'wasm_memory_limit' : IDL.Opt(IDL.Nat),
     'memory_allocation' : IDL.Opt(IDL.Nat),
     'compute_allocation' : IDL.Opt(IDL.Nat),
   });

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -529,6 +529,10 @@ export default {
       reserved_cycles_limit: 'Reserved Cycles Limit',
       reserved_cycles_limit_hint:
         'Number of cycles the canister can allocate, operations that allocate memory or compute will fail if the limit is reached.',
+      wasm_memory_limit: 'Wasm Memory Limit',
+      wasm_memory_limit_hint: 'The maximum amount of memory the canister can use for Wasm heap.',
+      log_visibility: 'Log Visibility',
+      log_visibility_hint: 'The visibility of the canister logs.',
     },
     wasm_module: 'WASM Module',
     wasm_args: 'Arguments',
@@ -545,6 +549,8 @@ export default {
     },
   },
   terms: {
+    controllers: 'Controllers',
+    public: 'Public',
     execute: 'Execute',
     error: 'Error',
     self: 'Self',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -537,6 +537,11 @@ export default {
       reserved_cycles_limit: 'Limite de cycles réservés',
       reserved_cycles_limit_hint:
         'Nombre de cycles que le canister peut allouer, les opérations qui allouent de la mémoire ou du calcul échoueront si la limite est atteinte.',
+      wasm_memory_limit: 'Limite de mémoire Wasm',
+      wasm_memory_limit_hint:
+        'La quantité maximale de mémoire que le canister peut utiliser pour le tas Wasm.',
+      log_visibility: 'Visibilité des logs',
+      log_visibility_hint: 'La visibilité des logs du canister.',
     },
     wasm_module: 'Module WASM',
     wasm_args: 'Arguments',
@@ -553,6 +558,8 @@ export default {
     },
   },
   terms: {
+    controllers: 'Contrôleurs',
+    public: 'Public',
     execute: 'Exécuter',
     error: 'Erreur',
     self: 'Soi',

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -532,6 +532,11 @@ export default {
       reserved_cycles_limit: 'Limite de ciclos reservados',
       reserved_cycles_limit_hint:
         'Número de ciclos que o canister pode alocar, operações que alocam memória ou computação falharão se o limite for atingido.',
+      wasm_memory_limit: 'Limite de memória WASM',
+      wasm_memory_limit_hint:
+        'A quantidade máxima de memória que o canister pode usar para o heap WASM.',
+      log_visibility: 'Visibilidade de log',
+      log_visibility_hint: 'A visibilidade dos logs do canister.',
     },
     wasm_module: 'Módulo WASM',
     wasm_args: 'Argumentos',
@@ -548,6 +553,8 @@ export default {
     },
   },
   terms: {
+    controllers: 'Controladores',
+    public: 'Público',
     execute: 'Executar',
     error: 'Erro',
     self: 'Próprio',

--- a/apps/wallet/src/pages/ExternalCanisterDetailPage.vue
+++ b/apps/wallet/src/pages/ExternalCanisterDetailPage.vue
@@ -58,6 +58,8 @@
                   memory_allocation: canisterDetails.status.value.settings.memory_allocation,
                   reserved_cycles_limit:
                     canisterDetails.status.value.settings.reserved_cycles_limit,
+                  wasm_memory_limit: canisterDetails.status.value.settings.wasm_memory_limit,
+                  log_visibility: canisterDetails.status.value.settings.log_visibility,
                 }"
               />
             </template>

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -2235,12 +2235,19 @@ type CanisterStatusInput = record {
   canister_id : principal;
 };
 
+type LogVisibility = variant {
+  public;
+  controllers;
+};
+
 type DefiniteCanisterSettings = record {
   controllers : vec principal;
   compute_allocation : nat;
   memory_allocation : nat;
   freezing_threshold : nat;
   reserved_cycles_limit : nat;
+  log_visibility : LogVisibility;
+  wasm_memory_limit : nat;
 };
 
 type DefiniteCanisterSettingsInput = record {
@@ -2249,6 +2256,8 @@ type DefiniteCanisterSettingsInput = record {
   memory_allocation : opt nat;
   freezing_threshold : opt nat;
   reserved_cycles_limit : opt nat;
+  log_visibility : opt LogVisibility;
+  wasm_memory_limit : opt nat;
 };
 
 type CanisterStatusResponse = record {

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -7,7 +7,15 @@ use orbit_essentials::cmc::SubnetSelection;
 use orbit_essentials::types::WasmModuleExtraChunks;
 
 // Taken from https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister
-#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Default)]
+pub enum LogVisibility {
+    #[serde(rename = "public")]
+    Public,
+    #[default]
+    #[serde(rename = "controllers")]
+    Controllers,
+}
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DefiniteCanisterSettingsInput {
     /// Controllers of the canister.
     pub controllers: Option<Vec<Principal>>,
@@ -19,6 +27,10 @@ pub struct DefiniteCanisterSettingsInput {
     pub freezing_threshold: Option<Nat>,
     /// Reserved cycles limit.
     pub reserved_cycles_limit: Option<Nat>,
+    /// Log visibility.
+    pub log_visibility: Option<LogVisibility>,
+    /// Wasm memory limit.
+    pub wasm_memory_limit: Option<Nat>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/factories/requests/configure_external_canister.rs
+++ b/core/station/impl/src/factories/requests/configure_external_canister.rs
@@ -202,10 +202,7 @@ pub mod configure_external_canister_test_utils {
             kind: station_api::ConfigureExternalCanisterOperationKindDTO::NativeSettings(
                 station_api::DefiniteCanisterSettingsInput {
                     controllers: Some(vec![Principal::from_slice(&[1; 29])]),
-                    compute_allocation: None,
-                    memory_allocation: None,
-                    freezing_threshold: None,
-                    reserved_cycles_limit: None,
+                    ..Default::default()
                 },
             ),
         }

--- a/core/station/impl/src/mappers/external_canister.rs
+++ b/core/station/impl/src/mappers/external_canister.rs
@@ -8,12 +8,12 @@ use crate::{
         ExternalCanisterChangeRequestPolicyRule, ExternalCanisterPermissions,
         ExternalCanisterRequestPolicies, ExternalCanisterState, FundExternalCanisterOperation,
         FundExternalCanisterOperationInput, FundExternalCanisterOperationKind,
-        FundExternalCanisterSendCyclesInput,
+        FundExternalCanisterSendCyclesInput, LogVisibility,
     },
     repositories::ExternalCanisterWhereClauseSort,
 };
 use candid::Principal;
-use ic_cdk::api::management_canister::main::CanisterSettings;
+use ic_cdk::api::management_canister::main::{self as mgmt};
 use orbit_essentials::{repository::SortDirection, utils::timestamp_to_rfc3339};
 use station_api::ExternalCanisterDTO;
 use uuid::Uuid;
@@ -141,14 +141,27 @@ impl From<ExternalCanisterCallerMethodsPrivileges>
     }
 }
 
-impl From<DefiniteCanisterSettingsInput> for CanisterSettings {
+impl From<LogVisibility> for mgmt::LogVisibility {
+    fn from(input: LogVisibility) -> Self {
+        match input {
+            LogVisibility::Public => mgmt::LogVisibility::Public,
+            LogVisibility::Controllers => mgmt::LogVisibility::Controllers,
+        }
+    }
+}
+
+impl From<DefiniteCanisterSettingsInput> for mgmt::CanisterSettings {
     fn from(input: DefiniteCanisterSettingsInput) -> Self {
-        CanisterSettings {
+        mgmt::CanisterSettings {
             controllers: input.controllers,
             compute_allocation: input.compute_allocation,
             freezing_threshold: input.freezing_threshold,
             memory_allocation: input.memory_allocation,
             reserved_cycles_limit: input.reserved_cycles_limit,
+            log_visibility: input
+                .log_visibility
+                .map(|log_visibility| log_visibility.into()),
+            wasm_memory_limit: input.wasm_memory_limit,
         }
     }
 }
@@ -185,6 +198,15 @@ impl From<station_api::ConfigureExternalCanisterOperationKindDTO>
     }
 }
 
+impl From<station_api::LogVisibility> for LogVisibility {
+    fn from(input: station_api::LogVisibility) -> Self {
+        match input {
+            station_api::LogVisibility::Public => LogVisibility::Public,
+            station_api::LogVisibility::Controllers => LogVisibility::Controllers,
+        }
+    }
+}
+
 impl From<station_api::DefiniteCanisterSettingsInput> for DefiniteCanisterSettingsInput {
     fn from(input: station_api::DefiniteCanisterSettingsInput) -> Self {
         DefiniteCanisterSettingsInput {
@@ -193,6 +215,10 @@ impl From<station_api::DefiniteCanisterSettingsInput> for DefiniteCanisterSettin
             freezing_threshold: input.freezing_threshold,
             memory_allocation: input.memory_allocation,
             reserved_cycles_limit: input.reserved_cycles_limit,
+            log_visibility: input
+                .log_visibility
+                .map(|log_visibility| log_visibility.into()),
+            wasm_memory_limit: input.wasm_memory_limit,
         }
     }
 }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -33,7 +33,7 @@ use crate::{
         ExternalCanisterChangeCallPermissionsInput, ExternalCanisterChangeCallRequestPoliciesInput,
         ExternalCanisterChangeRequestPolicyRuleInput, ExternalCanisterPermissionsCreateInput,
         ExternalCanisterPermissionsUpdateInput, ExternalCanisterRequestPoliciesCreateInput,
-        ExternalCanisterRequestPoliciesUpdateInput, FundExternalCanisterOperation,
+        ExternalCanisterRequestPoliciesUpdateInput, FundExternalCanisterOperation, LogVisibility,
         ManageSystemInfoOperation, ManageSystemInfoOperationInput, RemoveAddressBookEntryOperation,
         RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, RemoveUserGroupOperation,
         RequestOperation, SetDisasterRecoveryOperation, SetDisasterRecoveryOperationInput,
@@ -577,6 +577,15 @@ impl From<ConfigureExternalCanisterSettingsInput>
     }
 }
 
+impl From<LogVisibility> for station_api::LogVisibility {
+    fn from(input: LogVisibility) -> station_api::LogVisibility {
+        match input {
+            LogVisibility::Public => station_api::LogVisibility::Public,
+            LogVisibility::Controllers => station_api::LogVisibility::Controllers,
+        }
+    }
+}
+
 impl From<DefiniteCanisterSettingsInput> for station_api::DefiniteCanisterSettingsInput {
     fn from(input: DefiniteCanisterSettingsInput) -> station_api::DefiniteCanisterSettingsInput {
         station_api::DefiniteCanisterSettingsInput {
@@ -585,6 +594,10 @@ impl From<DefiniteCanisterSettingsInput> for station_api::DefiniteCanisterSettin
             freezing_threshold: input.freezing_threshold,
             memory_allocation: input.memory_allocation,
             reserved_cycles_limit: input.reserved_cycles_limit,
+            log_visibility: input
+                .log_visibility
+                .map(|log_visibility| log_visibility.into()),
+            wasm_memory_limit: input.wasm_memory_limit,
         }
     }
 }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -544,12 +544,23 @@ pub enum ConfigureExternalCanisterOperationKind {
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum LogVisibility {
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "controllers")]
+    Controllers,
+}
+
+#[storable]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DefiniteCanisterSettingsInput {
     pub controllers: Option<Vec<Principal>>,
     pub compute_allocation: Option<candid::Nat>,
     pub memory_allocation: Option<candid::Nat>,
     pub freezing_threshold: Option<candid::Nat>,
     pub reserved_cycles_limit: Option<candid::Nat>,
+    pub log_visibility: Option<LogVisibility>,
+    pub wasm_memory_limit: Option<candid::Nat>,
 }
 
 #[storable]

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -545,9 +545,7 @@ pub enum ConfigureExternalCanisterOperationKind {
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum LogVisibility {
-    #[serde(rename = "public")]
     Public,
-    #[serde(rename = "controllers")]
     Controllers,
 }
 

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -11,7 +11,7 @@ dfx-orbit = { path = '../../tools/dfx-orbit', version = '0.5.0' }
 flate2 = { workspace = true }
 hex = { workspace = true }
 orbit-essentials = { path = '../../libs/orbit-essentials', version = '0.0.2-alpha.5' }
-ic-cdk = { workspace = true }
+ic-cdk = "0.13.2"
 ic-certified-assets = { workspace = true }
 ic-ledger-types = { workspace = true }
 itertools = { workspace = true }

--- a/tests/integration/src/rate_limiter.rs
+++ b/tests/integration/src/rate_limiter.rs
@@ -43,7 +43,7 @@ fn test_request_size_rate_limiter() {
     test_rate_limit(&env, canister_ids, request_count, |_| {
         // the rate limiter uses the binary size of the (candid-encoded) argument
         // and thus we need to subtract the (estimated) overhead here
-        let arg_length = request_size - 2150;
+        let arg_length = request_size - 10_000;
         let call_external_canister_operation_input = CallExternalCanisterOperationInput {
             validation_method: None,
             execution_method: CanisterMethodDTO {

--- a/tools/dfx-orbit/src/canister/settings.rs
+++ b/tools/dfx-orbit/src/canister/settings.rs
@@ -45,10 +45,7 @@ impl RequestCanisterUpdateSettingsArgs {
             kind: ConfigureExternalCanisterOperationKindDTO::NativeSettings(
                 DefiniteCanisterSettingsInput {
                     controllers: Some(controllers),
-                    compute_allocation: None,
-                    memory_allocation: None,
-                    freezing_threshold: None,
-                    reserved_cycles_limit: None,
+                    ..Default::default()
                 },
             ),
         };


### PR DESCRIPTION
This PR bumps ic-cdk to 0.16.0 (so that canister snapshots are supported), but keeps ic-cdk at 0.13.2 for integration tests (requirement of PocketIC library).