### PR TITLE
fix(orbit-essentials): prefix wasm chunk hashes with slash in asset canister

### DIFF
--- a/libs/orbit-essentials/src/install_chunked_code.rs
+++ b/libs/orbit-essentials/src/install_chunked_code.rs
@@ -76,7 +76,7 @@ pub async fn install_chunked_code(
                 module_extra_chunks.store_canister,
                 "get",
                 (GetArg {
-                    key: hex::encode(hash),
+                    key: format!("/{}", hex::encode(hash)),
                     accept_encodings: vec!["identity".to_string()],
                 },),
             )

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -803,7 +803,7 @@ pub fn upload_canister_chunks_to_asset_canister(
     for chunk in &chunks {
         let chunk_hash = hash(chunk.to_vec());
         let store_arg = StoreArg {
-            key: hex::encode(chunk_hash.clone()),
+            key: format!("/{}", hex::encode(chunk_hash.clone())),
             content: chunk.to_vec(),
             content_type: "application/octet-stream".to_string(),
             content_encoding: "identity".to_string(),

--- a/tools/dfx-orbit/src/canister/install.rs
+++ b/tools/dfx-orbit/src/canister/install.rs
@@ -81,7 +81,7 @@ impl RequestCanisterInstallArgs {
             for chunk in &chunks {
                 let chunk_hash = hash(chunk);
                 let store_arg = StoreArg {
-                    key: hex::encode(chunk_hash.clone()),
+                    key: format!("/{}", hex::encode(chunk_hash.clone())),
                     content: chunk.to_vec(),
                     content_type: "application/octet-stream".to_string(),
                     content_encoding: "identity".to_string(),


### PR DESCRIPTION
This PR prefixes wasm chunk hashes with a slash when storing/retrieving wasm chunks to/from an asset canister. The motivation for this change is that icx-asset [prefixes](https://github.com/dfinity/sdk/blob/064e4ff3e47006ec13b99b012a5e69f1a56577c4/src/canisters/frontend/icx-asset/src/commands/upload.rs#L31) file names with slashes and thus this PR ensures that wasm chunks can be uploaded using icx-asset.