### PR TITLE
chore(orbit-essentials): use asset canister native chunking for large WASM

### DIFF
--- a/apps/wallet/src/generated/control-panel/control_panel.did
+++ b/apps/wallet/src/generated/control-panel/control_panel.did
@@ -265,8 +265,8 @@ type CanDeployStationResult = variant {
 type WasmModuleExtraChunks = record {
   // The asset canister from which the chunks are to be retrieved.
   store_canister : principal;
-  // The list of chunk hashes in the order they should be appended to the wasm module.
-  chunk_hashes_list : vec blob;
+  // The name of the asset containing extra chunks in the asset canister.
+  extra_chunks_key : text;
   // The hash of the assembled wasm module.
   wasm_module_hash : blob;
 };

--- a/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
@@ -206,8 +206,8 @@ export type UserSubscriptionStatus = { 'Unsubscribed' : null } |
   { 'Pending' : null };
 export interface WasmModuleExtraChunks {
   'wasm_module_hash' : Uint8Array | number[],
-  'chunk_hashes_list' : Array<Uint8Array | number[]>,
   'store_canister' : Principal,
+  'extra_chunks_key' : string,
 }
 export interface WasmModuleRegistryEntryDependency {
   'name' : string,

--- a/apps/wallet/src/generated/control-panel/control_panel.did.js
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.js
@@ -1,8 +1,8 @@
 export const idlFactory = ({ IDL }) => {
   const WasmModuleExtraChunks = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
-    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister' : IDL.Principal,
+    'extra_chunks_key' : IDL.Text,
   });
   const WasmModuleRegistryEntryDependency = IDL.Record({
     'name' : IDL.Text,

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -558,8 +558,8 @@ type SystemUpgradeTarget = variant {
 type WasmModuleExtraChunks = record {
   // The asset canister from which the chunks are to be retrieved.
   store_canister : principal;
-  // The list of chunk hashes in the order they should be appended to the wasm module.
-  chunk_hashes_list : vec blob;
+  // The name of the asset containing extra chunks in the asset canister.
+  extra_chunks_key : text;
   // The hash of the assembled wasm module.
   wasm_module_hash : blob;
 };

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -1239,8 +1239,8 @@ export type ValidationMethodResourceTarget = { 'No' : null } |
   { 'ValidationMethod' : CanisterMethod };
 export interface WasmModuleExtraChunks {
   'wasm_module_hash' : Uint8Array | number[],
-  'chunk_hashes_list' : Array<Uint8Array | number[]>,
   'store_canister' : Principal,
+  'extra_chunks_key' : string,
 }
 export interface _SERVICE {
   'canister_status' : ActorMethod<[CanisterStatusInput], CanisterStatusResult>,

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -316,8 +316,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const WasmModuleExtraChunks = IDL.Record({
     'wasm_module_hash' : IDL.Vec(IDL.Nat8),
-    'chunk_hashes_list' : IDL.Vec(IDL.Vec(IDL.Nat8)),
     'store_canister' : IDL.Principal,
+    'extra_chunks_key' : IDL.Text,
   });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -265,8 +265,8 @@ type CanDeployStationResult = variant {
 type WasmModuleExtraChunks = record {
   // The asset canister from which the chunks are to be retrieved.
   store_canister : principal;
-  // The list of chunk hashes in the order they should be appended to the wasm module.
-  chunk_hashes_list : vec blob;
+  // The name of the asset containing extra chunks in the asset canister.
+  extra_chunks_key : text;
   // The hash of the assembled wasm module.
   wasm_module_hash : blob;
 };

--- a/core/control-panel/impl/src/services/registry.rs
+++ b/core/control-panel/impl/src/services/registry.rs
@@ -542,7 +542,7 @@ mod tests {
 
         let module_extra_chunks = WasmModuleExtraChunks {
             store_canister: Principal::management_canister(),
-            chunk_hashes_list: vec![],
+            extra_chunks_key: "".to_string(),
             wasm_module_hash: vec![],
         };
         let input = RegistryEntryUpdateInput {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -558,8 +558,8 @@ type SystemUpgradeTarget = variant {
 type WasmModuleExtraChunks = record {
   // The asset canister from which the chunks are to be retrieved.
   store_canister : principal;
-  // The list of chunk hashes in the order they should be appended to the wasm module.
-  chunk_hashes_list : vec blob;
+  // The name of the asset containing extra chunks in the asset canister.
+  extra_chunks_key : text;
   // The hash of the assembled wasm module.
   wasm_module_hash : blob;
 };

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -358,7 +358,7 @@ impl From<orbit_essentials::types::WasmModuleExtraChunks> for WasmModuleExtraChu
     fn from(input: orbit_essentials::types::WasmModuleExtraChunks) -> WasmModuleExtraChunks {
         WasmModuleExtraChunks {
             store_canister: input.store_canister,
-            chunk_hashes_list: input.chunk_hashes_list,
+            extra_chunks_key: input.extra_chunks_key,
             wasm_module_hash: input.wasm_module_hash,
         }
     }
@@ -368,7 +368,7 @@ impl From<WasmModuleExtraChunks> for orbit_essentials::types::WasmModuleExtraChu
     fn from(input: WasmModuleExtraChunks) -> orbit_essentials::types::WasmModuleExtraChunks {
         orbit_essentials::types::WasmModuleExtraChunks {
             store_canister: input.store_canister,
-            chunk_hashes_list: input.chunk_hashes_list,
+            extra_chunks_key: input.extra_chunks_key,
             wasm_module_hash: input.wasm_module_hash,
         }
     }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -266,7 +266,7 @@ pub enum SystemUpgradeTarget {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct WasmModuleExtraChunks {
     pub store_canister: Principal,
-    pub chunk_hashes_list: Vec<Vec<u8>>,
+    pub extra_chunks_key: String,
     pub wasm_module_hash: Vec<u8>,
 }
 

--- a/core/upgrader/api/spec.did
+++ b/core/upgrader/api/spec.did
@@ -15,8 +15,8 @@ type InitArg = record {
 type WasmModuleExtraChunks = record {
   // The asset canister from which the chunks are to be retrieved.
   store_canister : principal;
-  // The list of chunk hashes in the order they should be appended to the wasm module.
-  chunk_hashes_list : vec blob;
+  // The name of the asset containing extra chunks in the asset canister.
+  extra_chunks_key : text;
   // The hash of the assembled wasm module.
   wasm_module_hash : blob;
 };

--- a/libs/orbit-essentials/src/install_chunked_code.rs
+++ b/libs/orbit-essentials/src/install_chunked_code.rs
@@ -7,12 +7,22 @@ use ic_cdk::api::management_canister::main::{
 use ic_cdk::call;
 use sha2::{Digest, Sha256};
 
-// asset canister argument types
+const MAX_ICP_CHUNK_LEN: usize = 1 << 20;
+
+// asset canister types
 
 #[derive(CandidType)]
 struct GetArg {
     pub key: String,
     pub accept_encodings: Vec<String>,
+}
+
+#[derive(CandidType)]
+struct GetChunkArg {
+    pub key: String,
+    pub content_encoding: String,
+    pub index: candid::Nat,
+    pub sha256: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -26,12 +36,62 @@ struct EncodedAsset {
     pub sha256: Option<Vec<u8>>,
 }
 
+#[derive(Clone, Debug, CandidType, Deserialize)]
+struct GetChunkResponse {
+    #[serde(with = "serde_bytes")]
+    pub content: Vec<u8>,
+}
+
+// fetches extra chunks from an asset canister
+async fn fetch_extra_chunks(
+    store_canister: Principal,
+    extra_chunks_key: String,
+) -> Result<Vec<u8>, String> {
+    let asset = call::<_, (EncodedAsset,)>(
+        store_canister,
+        "get",
+        (GetArg {
+            key: extra_chunks_key.clone(),
+            accept_encodings: vec!["identity".to_string()],
+        },),
+    )
+    .await
+    .map_err(|(_, err)| format!("failed to fetch asset: {err}"))?
+    .0;
+    let mut res = asset.content;
+    let mut idx = 1_u64;
+    while res.len() < asset.total_length {
+        let mut chunk = call::<_, (GetChunkResponse,)>(
+            store_canister,
+            "get_chunk",
+            (GetChunkArg {
+                key: extra_chunks_key.clone(),
+                content_encoding: "identity".to_string(),
+                index: idx.into(),
+                sha256: asset.sha256.clone(),
+            },),
+        )
+        .await
+        .map_err(|(_, err)| format!("failed to fetch chunk: {err}"))?
+        .0;
+        res.append(&mut chunk.content);
+        idx += 1;
+    }
+    if res.len() != asset.total_length {
+        return Err(format!(
+            "total chunk length ({}) exceeds the total length claimed by the asset canister ({})",
+            res.len(),
+            asset.total_length
+        ));
+    }
+    Ok(res)
+}
+
 // uploads a wasm chunk to the ICP chunk store
-async fn upload_chunk(
-    target_canister: Principal,
-    chunk: Vec<u8>,
-    expected_hash: &[u8],
-) -> Result<(), String> {
+async fn upload_chunk(target_canister: Principal, chunk: Vec<u8>) -> Result<Vec<u8>, String> {
+    let mut hasher = Sha256::new();
+    hasher.update(chunk.clone());
+    let chunk_hash = hasher.finalize().to_vec();
     let actual_hash = mgmt::upload_chunk(UploadChunkArgument {
         canister_id: target_canister,
         chunk,
@@ -39,14 +99,14 @@ async fn upload_chunk(
     .await
     .map_err(|(_, err)| format!("failed to upload chunk: {err}"))?
     .0;
-    if actual_hash.hash != *expected_hash {
+    if actual_hash.hash != chunk_hash {
         return Err(format!(
             "chunk hash mismatch (expected hash: {}, actual hash: {})",
-            hex::encode(expected_hash),
+            hex::encode(chunk_hash),
             hex::encode(&actual_hash.hash)
         ));
     }
-    Ok(())
+    Ok(chunk_hash)
 }
 
 pub async fn install_chunked_code(
@@ -56,7 +116,7 @@ pub async fn install_chunked_code(
     module_extra_chunks: Option<WasmModuleExtraChunks>,
     arg: Vec<u8>,
 ) -> Result<(), String> {
-    if let Some(mut module_extra_chunks) = module_extra_chunks {
+    if let Some(module_extra_chunks) = module_extra_chunks {
         // clear the ICP chunk store of the target canister
         mgmt::clear_chunk_store(ClearChunkStoreArgument {
             canister_id: target_canister,
@@ -65,36 +125,21 @@ pub async fn install_chunked_code(
         .map_err(|(_, err)| format!("failed to clear chunk store: {err}"))?;
         // upload the provided module as the first chunk
         // to the ICP chunk store of the target canister
-        let mut hasher = Sha256::new();
-        hasher.update(module.clone());
-        let module_hash = hasher.finalize().to_vec();
-        upload_chunk(target_canister, module, &module_hash).await?;
-        // fetch all extra chunks from the asset store canister
-        // and upload them to the ICP chunk store of the target canister
-        for hash in &module_extra_chunks.chunk_hashes_list {
-            let asset = call::<_, (EncodedAsset,)>(
-                module_extra_chunks.store_canister,
-                "get",
-                (GetArg {
-                    key: hex::encode(hash),
-                    accept_encodings: vec!["identity".to_string()],
-                },),
-            )
-            .await
-            .map_err(|(_, err)| format!("failed to fetch chunk: {err}"))?
-            .0;
-            if asset.content.len() != asset.total_length {
-                return Err(format!(
-                    "failed to fetch chunk (expected length: {}, actual length: {})",
-                    asset.total_length,
-                    asset.content.len()
-                ));
-            }
-            upload_chunk(target_canister, asset.content, hash).await?;
+        let module_hash = upload_chunk(target_canister, module).await?;
+        // fetch extra chunks from the asset canister
+        let extra_chunks = fetch_extra_chunks(
+            module_extra_chunks.store_canister,
+            module_extra_chunks.extra_chunks_key,
+        )
+        .await?;
+        // upload extra chunks to the ICP chunk store of the target canister
+        let mut chunk_hashes_list = vec![module_hash];
+        let chunks = extra_chunks.chunks(MAX_ICP_CHUNK_LEN);
+        for chunk in chunks {
+            let chunk_hash = upload_chunk(target_canister, chunk.to_vec()).await?;
+            chunk_hashes_list.push(chunk_hash);
         }
         // install target canister from chunks stored in the ICP chunk store of the target canister
-        let mut chunk_hashes_list = vec![module_hash];
-        chunk_hashes_list.append(&mut module_extra_chunks.chunk_hashes_list);
         mgmt::install_chunked_code(InstallChunkedCodeArgument {
             mode: install_mode,
             target_canister,

--- a/libs/orbit-essentials/src/types.rs
+++ b/libs/orbit-essentials/src/types.rs
@@ -4,8 +4,7 @@ use serde::Serialize;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct WasmModuleExtraChunks {
     pub store_canister: Principal,
-    #[serde(deserialize_with = "crate::deserialize::deserialize_vec_blob")]
-    pub chunk_hashes_list: Vec<Vec<u8>>,
+    pub extra_chunks_key: String,
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,
 }

--- a/tests/integration/src/dfx_orbit/install.rs
+++ b/tests/integration/src/dfx_orbit/install.rs
@@ -89,7 +89,6 @@ fn canister_install(use_chunks: bool) {
         argument: None,
         arg_file: None,
         asset_canister: asset_canister.map(|p| p.to_text()),
-        max_chunk_len: asset_canister.map(|_| max_chunk_len),
     };
 
     let request = dfx_orbit_test(&mut env, config, async {

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -3,6 +3,10 @@ use candid::{CandidType, Encode, Principal};
 use control_panel_api::UploadCanisterModulesInput;
 use flate2::{write::GzEncoder, Compression};
 use ic_cdk::api::management_canister::main::CanisterStatusResponse;
+use ic_certified_assets::types::{
+    BatchOperation, CommitBatchArguments, CreateAssetArguments, CreateBatchResponse,
+    CreateChunkArg, CreateChunkResponse, SetAssetContentArguments,
+};
 use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::api::management_canister::main::CanisterId;
 use orbit_essentials::types::WasmModuleExtraChunks;
@@ -767,7 +771,7 @@ struct StoreArg {
     pub sha256: Option<Vec<u8>>,
 }
 
-fn hash(data: Vec<u8>) -> Vec<u8> {
+fn hash(data: &Vec<u8>) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(data);
     hasher.finalize().to_vec()
@@ -788,9 +792,7 @@ pub fn upload_canister_chunks_to_asset_canister(
     );
 
     // get canister wasm hash
-    let mut hasher = Sha256::new();
-    hasher.update(&canister_wasm);
-    let canister_wasm_hash = hasher.finalize().to_vec();
+    let canister_wasm_hash = hash(&canister_wasm);
 
     // chunk canister
     let mut chunks = canister_wasm.chunks(chunk_len);
@@ -800,28 +802,68 @@ pub fn upload_canister_chunks_to_asset_canister(
     assert!(chunks.len() >= 2);
 
     // upload chunks to asset canister
-    for chunk in &chunks {
-        let chunk_hash = hash(chunk.to_vec());
-        let store_arg = StoreArg {
-            key: hex::encode(chunk_hash.clone()),
-            content: chunk.to_vec(),
-            content_type: "application/octet-stream".to_string(),
-            content_encoding: "identity".to_string(),
-            sha256: Some(chunk_hash),
+    let batch_id = update_candid_as::<_, (CreateBatchResponse,)>(
+        env,
+        asset_canister_id,
+        Principal::anonymous(),
+        "create_batch",
+        ((),),
+    )
+    .unwrap()
+    .0
+    .batch_id;
+    let extra_chunks_key = "/extra_chunks".to_string();
+    let create_asset = CreateAssetArguments {
+        key: extra_chunks_key.clone(),
+        content_type: "application/octet-stream".to_string(),
+        max_age: None,
+        headers: None,
+        enable_aliasing: None,
+        allow_raw_access: None,
+    };
+    let mut chunk_ids = vec![];
+    for chunk in chunks {
+        let create_chunk_arg = CreateChunkArg {
+            batch_id: batch_id.clone(),
+            content: chunk.to_vec().into(),
         };
-        update_candid_as::<_, ((),)>(
+        let create_chunk_response = update_candid_as::<_, (CreateChunkResponse,)>(
             env,
             asset_canister_id,
             Principal::anonymous(),
-            "store",
-            (store_arg,),
+            "create_chunk",
+            (create_chunk_arg,),
         )
-        .unwrap();
+        .unwrap()
+        .0;
+        chunk_ids.push(create_chunk_response.chunk_id);
     }
+    let set_asset_content = SetAssetContentArguments {
+        key: extra_chunks_key.clone(),
+        content_encoding: "identity".to_string(),
+        chunk_ids,
+        sha256: None,
+    };
+    let operations = vec![
+        BatchOperation::CreateAsset(create_asset),
+        BatchOperation::SetAssetContent(set_asset_content),
+    ];
+    let commit_batch_args: CommitBatchArguments = CommitBatchArguments {
+        batch_id,
+        operations,
+    };
+    update_candid_as::<_, ((),)>(
+        env,
+        asset_canister_id,
+        Principal::anonymous(),
+        "commit_batch",
+        (commit_batch_args,),
+    )
+    .unwrap();
 
     let module_extra_chunks = WasmModuleExtraChunks {
         store_canister: asset_canister_id,
-        chunk_hashes_list: chunks.iter().map(|c| hash(c.to_vec())).collect(),
+        extra_chunks_key,
         wasm_module_hash: canister_wasm_hash,
     };
 

--- a/tools/dfx-orbit/src/canister/install.rs
+++ b/tools/dfx-orbit/src/canister/install.rs
@@ -1,6 +1,6 @@
 use super::util::parse_arguments;
 use crate::{canister::util::log_hashes, DfxOrbit};
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use candid::CandidType;
 use clap::{Parser, ValueEnum};
 use orbit_essentials::types::WasmModuleExtraChunks;
@@ -10,9 +10,7 @@ use station_api::{
     GetRequestResponse, RequestOperationDTO, RequestOperationInput,
 };
 use std::fmt::Write;
-
-/// The default maximum length in bytes of module chunks (the IC does not allow chunks larger than 1MiB).
-const DEFAULT_MAX_CHUNK_LEN: usize = 1 << 20;
+use std::path::PathBuf;
 
 /// Requests that a canister be installed or updated.  Equivalent to `orbit_station_api::CanisterInstallMode`.
 #[derive(Debug, Clone, Parser)]
@@ -34,9 +32,6 @@ pub struct RequestCanisterInstallArgs {
     /// The asset canister name or ID to upload module chunks to.
     #[clap(long)]
     pub asset_canister: Option<String>,
-    /// The maximum length in bytes of module chunks.
-    #[clap(long)]
-    pub max_chunk_len: Option<usize>,
 }
 
 #[derive(CandidType)]
@@ -67,39 +62,31 @@ impl RequestCanisterInstallArgs {
 
         let (module, module_extra_chunks) = if let Some(ref asset_canister) = self.asset_canister {
             let asset_canister_id = dfx_orbit.canister_id(asset_canister)?;
-            let asset_agent = dfx_orbit.canister_agent(asset_canister_id)?;
 
             // compute module hash
             let canister_wasm_hash = hash(&module);
 
-            // chunk module
-            let chunks: Vec<&[u8]> = module
-                .chunks(self.max_chunk_len.unwrap_or(DEFAULT_MAX_CHUNK_LEN))
-                .collect();
-
-            // upload chunks to asset canister
-            for chunk in &chunks {
-                let chunk_hash = hash(chunk);
-                let store_arg = StoreArg {
-                    key: hex::encode(chunk_hash.clone()),
-                    content: chunk.to_vec(),
-                    content_type: "application/octet-stream".to_string(),
-                    content_encoding: "identity".to_string(),
-                    sha256: Some(chunk_hash),
-                };
-                asset_agent
-                    .update("store")
-                    .with_arg(store_arg)
-                    .build()
-                    .call_and_wait()
-                    .await?;
-            }
+            // upload module as extra chunks to asset canister
+            let path: PathBuf = self.wasm.into();
+            let extra_chunks_key = path
+                .file_name()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Could not derive the WASM file name from {}",
+                        path.display()
+                    )
+                })?
+                .to_str()
+                .ok_or_else(|| anyhow!("The WASM file name cannot be converted to a String"))?
+                .to_string();
+            let paths = vec![path.as_path()];
+            dfx_orbit.upload(asset_canister_id, &paths, false).await?;
 
             (
                 vec![],
                 Some(WasmModuleExtraChunks {
                     store_canister: asset_canister_id,
-                    chunk_hashes_list: chunks.iter().map(|c| hash(c)).collect(),
+                    extra_chunks_key,
                     wasm_module_hash: canister_wasm_hash,
                 }),
             )


### PR DESCRIPTION
This PR uses the asset canister native chunking for large WASM: the extra chunks are uploaded as a single (chunked) asset as opposed to uploading each chunk as a separate asset.