### PR TITLE
fix(dfx-orbit): Check that there is a matching asset upload proposal

### DIFF
--- a/tools/dfx-orbit/src/asset/util.rs
+++ b/tools/dfx-orbit/src/asset/util.rs
@@ -84,7 +84,7 @@ impl AssetAgent<'_> {
         let result: Result<String, String> = method
             .call_and_wait_one()
             .await
-            .with_context(|| "Failed to check if the batch is valid")?;
+            .with_context(|| "Failed to fetch current upload proposal from asset canister")?;
         result.map_err(|str| anyhow!(str))?;
 
         Ok(())


### PR DESCRIPTION
This PR adds check to `verify asset upload`, that not only the argument matches, but in fact the asset canister has the proposed upload, i.e. a matching `batch_id` and `evidence` pair.

This fixes FOLLOW-1702