### PR TITLE
feat(station): add expiration dt during request creation

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1088,6 +1088,8 @@ type CreateRequestInput = record {
   summary : opt text;
   // The time at which the request will execute if approved.
   execution_plan : opt RequestExecutionSchedule;
+  // The time at which the request will expire if still pending.
+  expiration_dt : opt TimestampRFC3339;
 };
 
 // The result type for creating a request.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -250,6 +250,7 @@ export interface CreateExternalCanisterOperationKindCreateNew {
 export interface CreateRequestInput {
   'title' : [] | [string],
   'execution_plan' : [] | [RequestExecutionSchedule],
+  'expiration_dt' : [] | [TimestampRFC3339],
   'summary' : [] | [string],
   'operation' : RequestOperationInput,
 }

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -571,6 +571,7 @@ export const idlFactory = ({ IDL }) => {
   const CreateRequestInput = IDL.Record({
     'title' : IDL.Opt(IDL.Text),
     'execution_plan' : IDL.Opt(RequestExecutionSchedule),
+    'expiration_dt' : IDL.Opt(TimestampRFC3339),
     'summary' : IDL.Opt(IDL.Text),
     'operation' : RequestOperationInput,
   });

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -253,6 +253,7 @@ export class StationService {
   async removeUserGroup(input: RemoveUserGroupOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { RemoveUserGroup: input },
@@ -268,6 +269,7 @@ export class StationService {
   async addUserGroup(input: AddUserGroupOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { AddUserGroup: input },
@@ -283,6 +285,7 @@ export class StationService {
   async editUserGroup(input: EditUserGroupOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditUserGroup: input },
@@ -298,6 +301,7 @@ export class StationService {
   async addUser(input: AddUserOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { AddUser: input },
@@ -313,6 +317,7 @@ export class StationService {
   async editUser(input: EditUserOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditUser: input },
@@ -571,6 +576,7 @@ export class StationService {
   async fundExternalCanister(input: FundExternalCanisterOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: {
@@ -591,6 +597,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: {
@@ -614,6 +621,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: opts.comment ? [opts.comment] : [],
       operation: {
@@ -639,6 +647,7 @@ export class StationService {
 
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: {
@@ -735,6 +744,7 @@ export class StationService {
   async addCanister(input: CreateExternalCanisterOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { CreateExternalCanister: input },
@@ -778,6 +788,7 @@ export class StationService {
   async addAddressBookEntry(input: AddAddressBookEntryOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { AddAddressBookEntry: input },
@@ -793,6 +804,7 @@ export class StationService {
   async editAddressBookEntry(input: EditAddressBookEntryOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditAddressBookEntry: input },
@@ -875,6 +887,7 @@ export class StationService {
   async addExternalCanister(input: CreateExternalCanisterOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { CreateExternalCanister: input },
@@ -899,6 +912,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: opts.comment ? [opts.comment] : [],
       operation: {
@@ -927,6 +941,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: {
@@ -963,6 +978,7 @@ export class StationService {
   async editPermission(input: EditPermissionOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditPermission: input },
@@ -978,6 +994,7 @@ export class StationService {
   async editRequestPolicy(input: EditRequestPolicyOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditRequestPolicy: input },
@@ -993,6 +1010,7 @@ export class StationService {
   async addRequestPolicy(input: AddRequestPolicyOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { AddRequestPolicy: input },
@@ -1008,6 +1026,7 @@ export class StationService {
   async createManageSystemInfoRequest(input: ManageSystemInfoOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { ManageSystemInfo: input },
@@ -1025,6 +1044,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: {
@@ -1044,6 +1064,7 @@ export class StationService {
   async editAccount(input: EditAccountOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { EditAccount: input },
@@ -1059,6 +1080,7 @@ export class StationService {
   async addAccount(input: AddAccountOperationInput): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { AddAccount: input },
@@ -1074,6 +1096,7 @@ export class StationService {
   async transfer(input: TransferOperationInput, summary?: string): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: summary ? [summary] : [],
       operation: { Transfer: input },
@@ -1092,6 +1115,7 @@ export class StationService {
   ): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: opts.comment ? [opts.comment] : [],
       operation: { SystemUpgrade: input },
@@ -1138,6 +1162,7 @@ export class StationService {
   async removeRequestPolicy(id: UUID): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { RemoveRequestPolicy: { policy_id: id } },
@@ -1153,6 +1178,7 @@ export class StationService {
   async removeAddressBookEntry(id: UUID): Promise<Request> {
     const result = await this.actor.create_request({
       execution_plan: [{ Immediate: null }],
+      expiration_dt: [],
       title: [],
       summary: [],
       operation: { RemoveAddressBookEntry: { address_book_entry_id: id } },

--- a/apps/wallet/src/stores/station.store.ts
+++ b/apps/wallet/src/stores/station.store.ts
@@ -77,6 +77,7 @@ export const createUserInitialAccount = async (
     title: [],
     summary: [],
     execution_plan: [{ Immediate: null }],
+    expiration_dt: [],
     operation: {
       AddAccount: {
         name: i18n.global.t('app.initial_account_name'),

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1088,6 +1088,8 @@ type CreateRequestInput = record {
   summary : opt text;
   // The time at which the request will execute if approved.
   execution_plan : opt RequestExecutionSchedule;
+  // The time at which the request will expire if still pending.
+  expiration_dt : opt TimestampRFC3339;
 };
 
 // The result type for creating a request.

--- a/core/station/api/src/request.rs
+++ b/core/station/api/src/request.rs
@@ -208,6 +208,7 @@ pub struct CreateRequestInput {
     pub title: Option<String>,
     pub summary: Option<String>,
     pub execution_plan: Option<RequestExecutionScheduleDTO>,
+    pub expiration_dt: Option<TimestampRfc3339>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/factories/requests/add_account.rs
+++ b/core/station/impl/src/factories/requests/add_account.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{AddAccountOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{AddAccountOperation, Request, RequestOperation},
     services::AccountService,
 };
 use async_trait::async_trait;
@@ -18,22 +18,15 @@ impl Create<station_api::AddAccountOperationInput> for AddAccountRequestCreate {
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddAccountOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddAccount(AddAccountOperation {
                 account_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Account creation".to_string()),
-            input.summary,
+            "Create account".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_account.rs
+++ b/core/station/impl/src/factories/requests/add_account.rs
@@ -26,7 +26,7 @@ impl Create<station_api::AddAccountOperationInput> for AddAccountRequestCreate {
                 account_id: None,
                 input: operation_input.into(),
             }),
-            "Create account".to_string(),
+            "Add account".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/add_address_book_entry.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{AddAddressBookEntryOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{AddAddressBookEntryOperation, Request, RequestOperation},
     services::ADDRESS_BOOK_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,22 +18,15 @@ impl Create<station_api::AddAddressBookEntryOperationInput> for AddAddressBookEn
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddAddressBookEntryOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddAddressBookEntry(AddAddressBookEntryOperation {
                 address_book_entry_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Address book entry creation".to_string()),
-            input.summary,
+            "Add address book entry".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_request_policy.rs
+++ b/core/station/impl/src/factories/requests/add_request_policy.rs
@@ -1,13 +1,12 @@
-use std::sync::Arc;
-
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{AddRequestPolicyOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{AddRequestPolicyOperation, Request, RequestOperation},
     services::RequestPolicyService,
 };
 use async_trait::async_trait;
 use orbit_essentials::types::UUID;
+use std::sync::Arc;
 
 pub struct AddRequestPolicyRequestCreate {}
 
@@ -20,22 +19,15 @@ impl Create<station_api::AddRequestPolicyOperationInput> for AddRequestPolicyReq
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddRequestPolicyOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddRequestPolicy(AddRequestPolicyOperation {
                 policy_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Request policy creation".to_string()),
-            input.summary,
+            "Add approval policy".to_string(),
         );
 
         Ok(request)
@@ -110,7 +102,7 @@ mod tests {
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
-        assert_eq!(request.title, "Request policy creation".to_string());
+        assert_eq!(request.title, "Add approval policy".to_string());
     }
 
     #[tokio::test]
@@ -175,6 +167,7 @@ pub mod add_request_policy_test_utils {
             title: None,
             summary: None,
             execution_plan: None,
+            expiration_dt: None,
         }
     }
 }

--- a/core/station/impl/src/factories/requests/add_user.rs
+++ b/core/station/impl/src/factories/requests/add_user.rs
@@ -26,7 +26,7 @@ impl Create<station_api::AddUserOperationInput> for AddUserRequestCreate {
                 user_id: None,
                 input: operation_input.into(),
             }),
-            "Create user".to_string(),
+            "Add user".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_user.rs
+++ b/core/station/impl/src/factories/requests/add_user.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{AddUserOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{AddUserOperation, Request, RequestOperation},
     services::USER_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,20 +18,15 @@ impl Create<station_api::AddUserOperationInput> for AddUserRequestCreate {
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddUserOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddUser(AddUserOperation {
                 user_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "User creation".to_string()),
-            input.summary,
+            "Create user".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_user_group.rs
+++ b/core/station/impl/src/factories/requests/add_user_group.rs
@@ -23,7 +23,7 @@ impl Create<station_api::AddUserGroupOperationInput> for AddUserGroupRequestCrea
             requested_by_user,
             input,
             RequestOperation::AddUserGroup(operation_input.into()),
-            "Create user group".to_string(),
+            "Add user group".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/add_user_group.rs
+++ b/core/station/impl/src/factories/requests/add_user_group.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{AddUserGroupOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{AddUserGroupOperation, Request, RequestOperation},
     services::USER_GROUP_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,19 +18,12 @@ impl Create<station_api::AddUserGroupOperationInput> for AddUserGroupRequestCrea
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddUserGroupOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddUserGroup(operation_input.into()),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "User group creation".to_string()),
-            input.summary,
+            "Create user group".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/call_canister.rs
+++ b/core/station/impl/src/factories/requests/call_canister.rs
@@ -1,10 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{
-        CallExternalCanisterOperation, CanisterMethod, Request, RequestExecutionPlan,
-        RequestOperation,
-    },
+    models::{CallExternalCanisterOperation, CanisterMethod, Request, RequestOperation},
     services::ExternalCanisterService,
 };
 use async_trait::async_trait;
@@ -67,10 +64,10 @@ impl Create<CallExternalCanisterOperationInput> for CallExternalCanisterRequestC
             None => None,
         };
 
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::CallExternalCanister(CallExternalCanisterOperation {
                 arg_checksum: operation_input.arg.as_ref().map(|arg| {
                     let mut hasher = Sha256::new();
@@ -81,14 +78,7 @@ impl Create<CallExternalCanisterOperationInput> for CallExternalCanisterRequestC
                 execution_method_reply: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "CallExternalCanister".to_string()),
-            input.summary,
+            "Call canister".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/change_external_canister.rs
+++ b/core/station/impl/src/factories/requests/change_external_canister.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{ChangeExternalCanisterOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{ChangeExternalCanisterOperation, Request, RequestOperation},
     services::ChangeCanisterService,
 };
 use async_trait::async_trait;
@@ -21,10 +21,10 @@ impl Create<ChangeExternalCanisterOperationInput> for ChangeExternalCanisterRequ
         input: CreateRequestInput,
         operation_input: ChangeExternalCanisterOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::ChangeExternalCanister(ChangeExternalCanisterOperation {
                 arg_checksum: operation_input.arg.as_ref().map(|arg| {
                     let mut hasher = Sha256::new();
@@ -42,14 +42,7 @@ impl Create<ChangeExternalCanisterOperationInput> for ChangeExternalCanisterRequ
                 },
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "ChangeExternalCanister".to_string()),
-            input.summary,
+            "Change canister".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/configure_external_canister.rs
+++ b/core/station/impl/src/factories/requests/configure_external_canister.rs
@@ -3,7 +3,7 @@ use crate::{
     errors::{RequestError, RequestExecuteError},
     models::{
         ConfigureExternalCanisterOperation, ConfigureExternalCanisterOperationKind,
-        ExternalCanister, Request, RequestExecutionPlan, RequestOperation,
+        ExternalCanister, Request, RequestOperation,
     },
     services::ExternalCanisterService,
 };
@@ -23,19 +23,12 @@ impl Create<ConfigureExternalCanisterOperationInput> for ConfigureExternalCanist
         input: CreateRequestInput,
         operation_input: ConfigureExternalCanisterOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::ConfigureExternalCanister(operation_input.into()),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Configure canister".to_string()),
-            input.summary,
+            "Configure canister".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/create_canister.rs
+++ b/core/station/impl/src/factories/requests/create_canister.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{CreateExternalCanisterOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{CreateExternalCanisterOperation, Request, RequestOperation},
     services::ExternalCanisterService,
 };
 use async_trait::async_trait;
@@ -20,22 +20,15 @@ impl Create<CreateExternalCanisterOperationInput> for CreateExternalCanisterRequ
         input: CreateRequestInput,
         operation_input: CreateExternalCanisterOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::CreateExternalCanister(CreateExternalCanisterOperation {
                 canister_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "CreateExternalCanister".to_string()),
-            input.summary,
+            "Create canister".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/edit_account.rs
+++ b/core/station/impl/src/factories/requests/edit_account.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{EditAccountOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{EditAccountOperation, Request, RequestOperation},
     services::ACCOUNT_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,19 +18,14 @@ impl Create<station_api::EditAccountOperationInput> for EditAccountRequestCreate
         input: station_api::CreateRequestInput,
         operation_input: station_api::EditAccountOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditAccount(EditAccountOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Account edit".to_string()),
-            input.summary,
+            "Edit account".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/edit_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/edit_address_book_entry.rs
@@ -4,7 +4,7 @@ use crate::{
     mappers::HelperMapper,
     models::{
         EditAddressBookEntryOperation, EditAddressBookEntryOperationInput, Request,
-        RequestExecutionPlan, RequestOperation,
+        RequestOperation,
     },
     services::ADDRESS_BOOK_SERVICE,
 };
@@ -27,10 +27,10 @@ impl Create<station_api::EditAddressBookEntryOperationInput> for EditAddressBook
                 info: format!("Invalid address book entry id: {}", e),
             })?;
 
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditAddressBookEntry(EditAddressBookEntryOperation {
                 input: EditAddressBookEntryOperationInput {
                     address_book_entry_id: *address_book_entry_id.as_bytes(),
@@ -39,14 +39,7 @@ impl Create<station_api::EditAddressBookEntryOperationInput> for EditAddressBook
                     labels: operation_input.labels,
                 },
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Address book entry update".to_string()),
-            input.summary,
+            "Edit address book entry".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/edit_permission.rs
+++ b/core/station/impl/src/factories/requests/edit_permission.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{EditPermissionOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{EditPermissionOperation, Request, RequestOperation},
     services::permission::PermissionService,
 };
 use async_trait::async_trait;
@@ -19,21 +19,14 @@ impl Create<station_api::EditPermissionOperationInput> for EditPermissionRequest
         input: station_api::CreateRequestInput,
         operation_input: station_api::EditPermissionOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditPermission(EditPermissionOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Permission update".to_string()),
-            input.summary,
+            "Edit permission".to_string(),
         );
 
         Ok(request)
@@ -107,7 +100,7 @@ mod tests {
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
-        assert_eq!(request.title, "Permission update".to_string());
+        assert_eq!(request.title, "Edit permission".to_string());
     }
 
     #[tokio::test]
@@ -181,6 +174,7 @@ pub mod edit_permission_test_utils {
             title: None,
             summary: None,
             execution_plan: None,
+            expiration_dt: None,
         }
     }
 }

--- a/core/station/impl/src/factories/requests/edit_request_policy.rs
+++ b/core/station/impl/src/factories/requests/edit_request_policy.rs
@@ -2,8 +2,7 @@ use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
     models::{
-        EditRequestPolicyOperation, EditRequestPolicyOperationInput, Request, RequestExecutionPlan,
-        RequestOperation,
+        EditRequestPolicyOperation, EditRequestPolicyOperationInput, Request, RequestOperation,
     },
     services::{RequestPolicyService, REQUEST_POLICY_SERVICE},
 };
@@ -33,21 +32,14 @@ impl Create<station_api::EditRequestPolicyOperationInput> for EditRequestPolicyR
                 ),
             })?;
 
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditRequestPolicy(EditRequestPolicyOperation {
                 input: operation_input,
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Request policy update".to_string()),
-            input.summary,
+            "Edit approval policy".to_string(),
         );
 
         Ok(request)
@@ -127,7 +119,7 @@ mod tests {
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
-        assert_eq!(request.title, "Request policy update".to_string());
+        assert_eq!(request.title, "Edit approval policy".to_string());
     }
 
     #[tokio::test]
@@ -255,6 +247,7 @@ pub mod edit_request_policy_test_utils {
             title: None,
             summary: None,
             execution_plan: None,
+            expiration_dt: None,
         }
     }
 }

--- a/core/station/impl/src/factories/requests/edit_user.rs
+++ b/core/station/impl/src/factories/requests/edit_user.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{EditUserOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{EditUserOperation, Request, RequestOperation},
     services::USER_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,19 +18,14 @@ impl Create<station_api::EditUserOperationInput> for EditUserRequestCreate {
         input: station_api::CreateRequestInput,
         operation_input: station_api::EditUserOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditUser(EditUserOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "User edit".to_string()),
-            input.summary,
+            "Edit user".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/edit_user_group.rs
+++ b/core/station/impl/src/factories/requests/edit_user_group.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{EditUserGroupOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{EditUserGroupOperation, Request, RequestOperation},
     services::USER_GROUP_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,17 +18,12 @@ impl Create<station_api::EditUserGroupOperationInput> for EditUserGroupRequestCr
         input: station_api::CreateRequestInput,
         operation_input: station_api::EditUserGroupOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditUserGroup(operation_input.into()),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "User group edit".to_string()),
-            input.summary,
+            "Edit user group".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/fund_external_canister.rs
+++ b/core/station/impl/src/factories/requests/fund_external_canister.rs
@@ -2,8 +2,7 @@ use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
     models::{
-        FundExternalCanisterOperation, FundExternalCanisterOperationKind, Request,
-        RequestExecutionPlan, RequestOperation,
+        FundExternalCanisterOperation, FundExternalCanisterOperationKind, Request, RequestOperation,
     },
     services::ExternalCanisterService,
 };
@@ -22,17 +21,12 @@ impl Create<station_api::FundExternalCanisterOperationInput> for FundExternalCan
         input: station_api::CreateRequestInput,
         operation_input: station_api::FundExternalCanisterOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::FundExternalCanister(operation_input.into()),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Fund canister".to_string()),
-            input.summary,
+            "Fund canister".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/manage_system_info.rs
+++ b/core/station/impl/src/factories/requests/manage_system_info.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{ManageSystemInfoOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{ManageSystemInfoOperation, Request, RequestOperation},
     services::SYSTEM_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,21 +18,14 @@ impl Create<station_api::ManageSystemInfoOperationInput> for ManageSystemInfoReq
         input: station_api::CreateRequestInput,
         operation_input: station_api::ManageSystemInfoOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::ManageSystemInfo(ManageSystemInfoOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Manage System Info".to_string()),
-            input.summary,
+            "Manage System".to_string(),
         );
 
         Ok(request)
@@ -66,7 +59,7 @@ mod tests {
     use super::*;
     use crate::{
         core::{read_system_info, test_utils},
-        models::ManageSystemInfoOperationInput,
+        models::{ManageSystemInfoOperationInput, RequestExecutionPlan},
     };
     use tests::mnanage_system_info_test_utils::{
         mock_manage_system_info_api_input, mock_request_api_operation,
@@ -155,6 +148,7 @@ mod mnanage_system_info_test_utils {
             title: Some("title".to_string()),
             summary: Some("summary".to_string()),
             execution_plan: Some(station_api::RequestExecutionScheduleDTO::Immediate),
+            expiration_dt: None,
             operation: station_api::RequestOperationInput::ManageSystemInfo(
                 mock_manage_system_info_api_input(),
             ),

--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -376,6 +376,7 @@ pub mod requests_test_utils {
             title: None,
             summary: None,
             execution_plan: None,
+            expiration_dt: None,
         }
     }
 }

--- a/core/station/impl/src/factories/requests/remove_address_book_entry.rs
+++ b/core/station/impl/src/factories/requests/remove_address_book_entry.rs
@@ -4,7 +4,7 @@ use crate::{
     mappers::HelperMapper,
     models::{
         RemoveAddressBookEntryOperation, RemoveAddressBookEntryOperationInput, Request,
-        RequestExecutionPlan, RequestOperation,
+        RequestOperation,
     },
     services::ADDRESS_BOOK_SERVICE,
 };
@@ -29,23 +29,16 @@ impl Create<station_api::RemoveAddressBookEntryOperationInput>
                 info: format!("Invalid address book entry id: {}", e),
             })?;
 
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::RemoveAddressBookEntry(RemoveAddressBookEntryOperation {
                 input: RemoveAddressBookEntryOperationInput {
                     address_book_entry_id: *address_book_entry_id.as_bytes(),
                 },
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Address book entry removal".to_string()),
-            input.summary,
+            "Remove address book entry".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/remove_request_policy.rs
+++ b/core/station/impl/src/factories/requests/remove_request_policy.rs
@@ -2,8 +2,7 @@ use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
     models::{
-        RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, Request,
-        RequestExecutionPlan, RequestOperation,
+        RemoveRequestPolicyOperation, RemoveRequestPolicyOperationInput, Request, RequestOperation,
     },
     services::{RequestPolicyService, REQUEST_POLICY_SERVICE},
 };
@@ -33,21 +32,14 @@ impl Create<station_api::RemoveRequestPolicyOperationInput> for RemoveRequestPol
                 ),
             })?;
 
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::RemoveRequestPolicy(RemoveRequestPolicyOperation {
                 input: operation_input,
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "Request policy remove".to_string()),
-            input.summary,
+            "Remove approval policy".to_string(),
         );
 
         Ok(request)
@@ -128,7 +120,7 @@ mod tests {
 
         assert_eq!(request.id, request_id);
         assert_eq!(request.requested_by, requested_by_user);
-        assert_eq!(request.title, "Request policy remove".to_string());
+        assert_eq!(request.title, "Remove approval policy".to_string());
     }
 
     #[tokio::test]
@@ -255,6 +247,7 @@ pub mod remove_request_policy_test_utils {
             title: None,
             summary: None,
             execution_plan: None,
+            expiration_dt: None,
         }
     }
 }

--- a/core/station/impl/src/factories/requests/remove_user_group.rs
+++ b/core/station/impl/src/factories/requests/remove_user_group.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{RemoveUserGroupOperation, Request, RequestExecutionPlan, RequestOperation},
+    models::{RemoveUserGroupOperation, Request, RequestOperation},
     services::USER_GROUP_SERVICE,
 };
 use async_trait::async_trait;
@@ -18,19 +18,12 @@ impl Create<station_api::RemoveUserGroupOperationInput> for RemoveUserGroupReque
         input: station_api::CreateRequestInput,
         operation_input: station_api::RemoveUserGroupOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::RemoveUserGroup(operation_input.into()),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "User group removal".to_string()),
-            input.summary,
+            "Remove user group".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/set_disaster_recovery.rs
+++ b/core/station/impl/src/factories/requests/set_disaster_recovery.rs
@@ -1,7 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{Request, RequestExecutionPlan, RequestOperation, SetDisasterRecoveryOperation},
+    models::{Request, RequestOperation, SetDisasterRecoveryOperation},
     services::SystemService,
 };
 use async_trait::async_trait;
@@ -19,21 +19,14 @@ impl Create<SetDisasterRecoveryOperationInput> for SetDisasterRecoveryRequestCre
         input: CreateRequestInput,
         operation_input: SetDisasterRecoveryOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::SetDisasterRecovery(SetDisasterRecoveryOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input
-                .title
-                .unwrap_or_else(|| "SetDisasterRecovery".to_string()),
-            input.summary,
+            "Configure disaster recovery".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/system_upgrade.rs
+++ b/core/station/impl/src/factories/requests/system_upgrade.rs
@@ -1,10 +1,7 @@
 use super::{Create, Execute, RequestExecuteStage};
 use crate::{
     errors::{RequestError, RequestExecuteError},
-    models::{
-        Request, RequestExecutionPlan, RequestOperation, SystemUpgradeOperation,
-        SystemUpgradeTarget,
-    },
+    models::{Request, RequestOperation, SystemUpgradeOperation, SystemUpgradeTarget},
     services::{DisasterRecoveryService, SystemService},
 };
 use async_trait::async_trait;
@@ -25,10 +22,10 @@ impl Create<SystemUpgradeOperationInput> for SystemUpgradeRequestCreate {
         input: CreateRequestInput,
         operation_input: SystemUpgradeOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::SystemUpgrade(SystemUpgradeOperation {
                 arg_checksum: operation_input.arg.as_ref().map(|arg| {
                     let mut hasher = Sha256::new();
@@ -46,12 +43,7 @@ impl Create<SystemUpgradeOperationInput> for SystemUpgradeRequestCreate {
                 },
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "ChangeCanister".to_string()),
-            input.summary,
+            "Upgrade System".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/transfer.rs
+++ b/core/station/impl/src/factories/requests/transfer.rs
@@ -5,8 +5,8 @@ use crate::{
     factories::blockchains::BlockchainApiFactory,
     mappers::HelperMapper,
     models::{
-        Account, Metadata, Request, RequestExecutionPlan, RequestOperation, Transfer,
-        TransferOperation, TransferOperationInput,
+        Account, Metadata, Request, RequestOperation, Transfer, TransferOperation,
+        TransferOperationInput,
     },
     repositories::ACCOUNT_REPOSITORY,
     services::TransferService,
@@ -38,10 +38,11 @@ impl Create<station_api::TransferOperationInput> for TransferRequestCreate {
                     info: format!("Invalid from_account_id: {}", e),
                 }
             })?;
-        let request = Request::new(
+
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::Transfer(TransferOperation {
                 transfer_id: None,
                 fee: None,
@@ -59,12 +60,7 @@ impl Create<station_api::TransferOperationInput> for TransferRequestCreate {
                     },
                 },
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Transfer".to_string()),
-            input.summary,
+            "Transfer".to_string(),
         );
 
         request.validate()?;

--- a/core/station/impl/src/mappers/request.rs
+++ b/core/station/impl/src/mappers/request.rs
@@ -81,6 +81,30 @@ impl Request {
     pub fn to_dto(self) -> RequestDTO {
         self.inner_to_dto(false)
     }
+
+    pub fn from_request_creation_input(
+        request_id: UUID,
+        requested_by_user: UserId,
+        request_config: station_api::CreateRequestInput,
+        request_operation: RequestOperation,
+        request_default_title: String,
+    ) -> Request {
+        Request::new(
+            request_id,
+            requested_by_user,
+            request_config
+                .expiration_dt
+                .map(|dt| rfc3339_to_timestamp(&dt))
+                .unwrap_or(Request::default_expiration_dt_ns()),
+            request_operation,
+            request_config
+                .execution_plan
+                .map(Into::into)
+                .unwrap_or(RequestExecutionPlan::Immediate),
+            request_config.title.unwrap_or(request_default_title),
+            request_config.summary,
+        )
+    }
 }
 
 impl From<RequestExecutionScheduleDTO> for RequestExecutionPlan {

--- a/core/station/impl/src/services/request.rs
+++ b/core/station/impl/src/services/request.rs
@@ -712,6 +712,7 @@ mod tests {
                     title: None,
                     summary: None,
                     execution_plan: None,
+                    expiration_dt: None,
                 },
                 &ctx.call_context,
             )
@@ -754,6 +755,7 @@ mod tests {
                     title: None,
                     summary: None,
                     execution_plan: Some(station_api::RequestExecutionScheduleDTO::Immediate),
+                    expiration_dt: None,
                 },
                 &ctx.call_context,
             )

--- a/tests/integration/src/rate_limiter.rs
+++ b/tests/integration/src/rate_limiter.rs
@@ -74,6 +74,7 @@ fn test_request_size_rate_limiter() {
             title: None,
             summary: None,
             execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+            expiration_dt: None,
         };
         let bytes = Encode!(&create_request_input).unwrap();
         assert!(arg_length <= bytes.len() && bytes.len() <= request_size);
@@ -131,6 +132,7 @@ where
             title: None,
             summary: None,
             execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+            expiration_dt: None,
         };
         let create_request_bytes = Encode!(&create_request_input).unwrap();
         update_candid_as::<_, ()>(

--- a/tests/integration/src/register_tests.rs
+++ b/tests/integration/src/register_tests.rs
@@ -29,6 +29,7 @@ fn register_user_successful() {
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+        expiration_dt: None,
     };
 
     let res: (Result<CreateRequestResponse, ApiErrorDTO>,) = update_candid_as(

--- a/tests/integration/src/transfer_tests.rs
+++ b/tests/integration/src/transfer_tests.rs
@@ -71,6 +71,7 @@ fn make_transfer_successful() {
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+        expiration_dt: None,
     };
     let res: (ApiResult<CreateRequestResponse>,) = update_candid_as(
         &env,
@@ -167,6 +168,7 @@ fn make_transfer_successful() {
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+        expiration_dt: None,
     };
     let res: (Result<CreateRequestResponse, ApiErrorDTO>,) = update_candid_as(
         &env,

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -177,6 +177,7 @@ pub fn submit_request_raw(
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+        expiration_dt: None,
     };
     update_candid_as(
         env,
@@ -615,6 +616,7 @@ pub fn create_icp_account(env: &PocketIc, station_id: Principal, user_id: UuidDT
         title: None,
         summary: None,
         execution_plan: Some(RequestExecutionScheduleDTO::Immediate),
+        expiration_dt: None,
     };
     let res: (ApiResult<CreateRequestResponse>,) = update_candid_as(
         env,

--- a/tools/dfx-orbit/src/args.rs
+++ b/tools/dfx-orbit/src/args.rs
@@ -188,6 +188,7 @@ impl RequestArgs {
             title: self.title,
             summary: self.summary,
             execution_plan: None,
+            expiration_dt: None,
         })
     }
 }


### PR DESCRIPTION
The requests have an expiration date, however, up until now that was forced to 30 days in the Orbit Station and was not exposed to the API, this change enables request creators to set the expiration date.