### PR TITLE
fix(station): add missing metadata field from UI

### DIFF
--- a/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterSetupDialog.vue
@@ -204,6 +204,7 @@ const createNewExternalCanister = async (): Promise<Request> => {
         rule: item.rule as RequestPolicyRule,
       })),
   };
+  changes.metadata = [];
   if (wizard.value.configuration.canisterId) {
     changes.kind = {
       AddExisting: {


### PR DESCRIPTION
BE otherwise rejects the creation of new external canister with "Missing field 'metadata'"