### PR TITLE
feat(enable): wallet ui accepts wasm chunk store from registry

### DIFF
--- a/apps/wallet/src/components/system-upgrade/RegistryUpdateMode.vue
+++ b/apps/wallet/src/components/system-upgrade/RegistryUpdateMode.vue
@@ -134,7 +134,8 @@ const prepareUpdateWithWasmModule = async (): Promise<void> => {
 
     modelValue.value = {
       ...modelValue.value,
-      wasmModule: toArrayBuffer(artifact.artifact),
+      wasmModule: artifact.artifact.length ? toArrayBuffer(artifact.artifact) : undefined,
+      wasmModuleExtraChunks: registryEntry.value.WasmModule.module_extra_chunks?.[0],
       wasmInitArg: undefined,
     };
 

--- a/apps/wallet/src/components/system-upgrade/system-upgrade.types.ts
+++ b/apps/wallet/src/components/system-upgrade/system-upgrade.types.ts
@@ -1,9 +1,10 @@
-import { SystemUpgradeTarget } from '~/generated/station/station.did';
+import { SystemUpgradeTarget, WasmModuleExtraChunks } from '~/generated/station/station.did';
 
 export interface SystemUpgradeFormValue {
   target?: SystemUpgradeTarget;
   wasmModule?: ArrayBuffer;
   wasmInitArg?: string;
+  wasmModuleExtraChunks?: WasmModuleExtraChunks;
   comment?: string;
 }
 

--- a/cli/src/registry/publish.ts
+++ b/cli/src/registry/publish.ts
@@ -189,7 +189,7 @@ command.action(async options => {
 
     const moduleStoredFileName =
       `${entry.name}_${entry.version}_${moduleHashHex.substring(0, 8)}`.replace(
-        /[^a-zA-Z0-9_]/g,
+        /[^a-zA-Z0-9_.]/g,
         '',
       );
     const tempFilePath = join(tmpdir(), moduleStoredFileName);

--- a/cli/src/registry/publish.ts
+++ b/cli/src/registry/publish.ts
@@ -188,8 +188,8 @@ command.action(async options => {
     const moduleUint8Array = new Uint8Array(moduleHashBuffer);
 
     const moduleStoredFileName =
-      `${entry.name}_${entry.version}_${moduleHashHex.substring(0, 8)}`.replace(
-        /[^a-zA-Z0-9_.]/g,
+      `${entry.name}_v${entry.version}_sha256-${moduleHashHex.substring(0, 8)}`.replace(
+        /[^a-zA-Z0-9_.-]/g,
         '',
       );
     const tempFilePath = join(tmpdir(), moduleStoredFileName);

--- a/cli/src/registry/publish.ts
+++ b/cli/src/registry/publish.ts
@@ -6,19 +6,24 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { AddRegistryEntryResult, EditRegistryEntryResult } from '../generated/control_panel';
 import {
+  assertCommandExists,
   assertReplicaIsHealthy,
   cargoProjectVersion,
   execAsync,
+  getIdentityPemFilePath,
+  getReplicaUrl,
   readFileIntoUint8Array,
   toBlobString,
 } from '../utils';
 import {
   Application,
   applicationToRegistryEntryMap,
+  getWasmChunkStoreId,
   parseRegistryApplication,
   registryEntryToApplicationMap,
   searchRegistry,
 } from './registry.core';
+import { createHash } from 'crypto';
 
 const artifactsRootPath = join(__dirname, '../../../artifacts');
 
@@ -136,6 +141,14 @@ const saveArgumentInTempFile = async (argument: string): Promise<string> => {
 
 command.action(async options => {
   assertReplicaIsHealthy(options.network);
+  assertCommandExists('dfx');
+  assertCommandExists('icx-asset');
+
+  const replicaUrl = await getReplicaUrl(options.network);
+  const identityPemPath = await getIdentityPemFilePath(options.identity);
+
+  // Finds the wasm chunk store canister id.
+  const wasmChunkStoreId = getWasmChunkStoreId(options.network);
 
   // Determine whether to build the release artifacts before publishing. This is `false` by default since
   // artifacts are expected to be built before with a deterministic build.
@@ -170,6 +183,26 @@ command.action(async options => {
         'WasmModule' in foundEntry.value && foundEntry.value.WasmModule.version === entry.version,
     )?.id;
 
+    const moduleHashBuffer = createHash('sha256').update(entry.module).digest();
+    const moduleHashHex = moduleHashBuffer.toString('hex');
+    const moduleUint8Array = new Uint8Array(moduleHashBuffer);
+
+    const moduleStoredFileName =
+      `${entry.name}_${entry.version}_${moduleHashHex.substring(0, 8)}`.replace(
+        /[^a-zA-Z0-9_]/g,
+        '',
+      );
+    const tempFilePath = join(tmpdir(), moduleStoredFileName);
+
+    // first write the module to a temporary file
+    await writeFile(tempFilePath, entry.module, { encoding: 'binary' });
+
+    // then use icx-asset to upload the module to the wasm chunk store, this already takes care of chunking if needed
+    console.log(`Uploading the module for '${entry.name}' to the wasm chunk store...`);
+    await execAsync(`
+      icx-asset --pem '${identityPemPath}' --replica ${replicaUrl} upload ${wasmChunkStoreId.toText()} ${tempFilePath}
+    `);
+
     if (maybeRegistryId) {
       console.log(`Updating the registry entry for ${entry.name} with id(${maybeRegistryId})...`);
       const argumentFile = await saveArgumentInTempFile(`
@@ -188,7 +221,8 @@ command.action(async options => {
             value = opt variant {
               WasmModule = record {
                 version = "${entry.version}";
-                wasm_module = blob "${toBlobString(entry.module)}";
+                wasm_module = vec {};
+                module_extra_chunks = opt record { store_canister = principal "${wasmChunkStoreId.toText()}"; wasm_module_hash = blob "${toBlobString(moduleUint8Array)}"; extra_chunks_key = "/${moduleStoredFileName}" };
                 dependencies = vec { ${entry.dependencies.map(dependency => `record { name = "${dependency.name}"; version = "${dependency.version}"; }`).join('; ')} }
               }
             }
@@ -226,7 +260,8 @@ command.action(async options => {
             value = variant {
               WasmModule = record {
                 version = "${entry.version}";
-                wasm_module = blob "${toBlobString(entry.module)}";
+                wasm_module = vec {};
+                module_extra_chunks = opt record { store_canister = principal "${wasmChunkStoreId.toText()}"; wasm_module_hash = blob "${toBlobString(moduleUint8Array)}"; extra_chunks_key = "/${moduleStoredFileName}" };
                 dependencies = vec { ${entry.dependencies.map(dependency => `record { name = "${dependency.name}"; version = "${dependency.version}"; }`).join('; ')} }
               }
             }

--- a/cli/src/registry/registry.core.ts
+++ b/cli/src/registry/registry.core.ts
@@ -1,10 +1,18 @@
+import { execSync } from 'child_process';
 import { RegistryEntry, SearchRegistryResult } from '../generated/control_panel';
 import { execAsync } from '../utils';
+import { Principal } from '@dfinity/principal';
 
 export enum Application {
   Station = 'station',
   Upgrader = 'upgrader',
 }
+
+export const getWasmChunkStoreId = (network: string = 'local'): Principal => {
+  const maybeCanisterId = execSync(`dfx canister id wasm_chunk_store --network ${network}`);
+
+  return Principal.fromText(maybeCanisterId.toString().split('\n').join(''));
+};
 
 export const applicationToRegistryEntryMap: Record<Application, string> = {
   [Application.Station]: '@orbit/station',

--- a/cli/src/registry/registry.core.ts
+++ b/cli/src/registry/registry.core.ts
@@ -9,9 +9,11 @@ export enum Application {
 }
 
 export const getWasmChunkStoreId = (network: string = 'local'): Principal => {
-  const maybeCanisterId = execSync(`dfx canister id wasm_chunk_store --network ${network}`);
+  const maybeCanisterId = execSync(`dfx canister id wasm_chunk_store --network ${network}`)
+    .toString()
+    .trim();
 
-  return Principal.fromText(maybeCanisterId.toString().split('\n').join(''));
+  return Principal.fromText(maybeCanisterId);
 };
 
 export const applicationToRegistryEntryMap: Record<Application, string> = {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -104,9 +104,18 @@ export const getReplicaUrl = async (network: string): Promise<string> => {
   }
 
   if (dfxFile.networks[network].bind) {
-    return dfxFile.networks[network].bind.startsWith('http')
+    const bind = dfxFile.networks[network].bind.startsWith('http')
       ? dfxFile.networks[network].bind
       : `http://${dfxFile.networks[network].bind}`;
+
+    const validLocalBinds = ['http://localhost', 'http://127.0.0.1', 'http://[::1]'];
+    if (!validLocalBinds.some(validLocalBind => bind.startsWith(validLocalBind))) {
+      throw new Error(
+        `Network '${network}' has a bind URL that is not a valid local bind: ${bind}.`,
+      );
+    }
+
+    return bind;
   }
 
   throw new Error(`Network '${network}' does not have a replica URL.`);

--- a/core/control-panel/impl/src/models/artifact.rs
+++ b/core/control-panel/impl/src/models/artifact.rs
@@ -106,16 +106,6 @@ impl Artifact {
     }
 }
 
-fn validate_artifact(artifact: &[u8]) -> ModelValidatorResult<ArtifactError> {
-    if artifact.is_empty() {
-        return Err(ArtifactError::ValidationError {
-            info: "Artifact cannot be empty".to_string(),
-        });
-    }
-
-    Ok(())
-}
-
 fn validate_unique_hash(self_id: &ArtifactId, hash: &[u8]) -> ModelValidatorResult<ArtifactError> {
     ARTIFACT_REPOSITORY
         .find_by_hash(hash)
@@ -132,7 +122,6 @@ fn validate_unique_hash(self_id: &ArtifactId, hash: &[u8]) -> ModelValidatorResu
 
 impl ModelValidator<ArtifactError> for Artifact {
     fn validate(&self) -> ModelValidatorResult<ArtifactError> {
-        validate_artifact(&self.artifact)?;
         validate_unique_hash(self.id(), &self.hash)?;
 
         Ok(())
@@ -143,6 +132,20 @@ impl ModelValidator<ArtifactError> for Artifact {
 mod tests {
     use super::*;
     use orbit_essentials::repository::Repository;
+
+    #[test]
+    fn test_empty_artifact_is_accepted() {
+        let artifact = Artifact::new(Vec::new());
+
+        assert_eq!(artifact.artifact(), b"");
+        assert_eq!(
+            artifact.hash(),
+            vec![
+                227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39,
+                174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85
+            ]
+        );
+    }
 
     #[test]
     fn test_artifact_creation() {

--- a/core/control-panel/impl/src/models/artifact.rs
+++ b/core/control-panel/impl/src/models/artifact.rs
@@ -162,22 +162,6 @@ mod tests {
     }
 
     #[test]
-    fn empty_artifact_is_invalid() {
-        let artifact = Artifact::new(b"".to_vec());
-
-        assert_eq!(
-            artifact.hash(),
-            vec![
-                227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39,
-                174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85
-            ]
-        );
-        assert_eq!(artifact.artifact(), b"");
-
-        assert!(artifact.validate().is_err());
-    }
-
-    #[test]
     fn artifact_with_same_hash_is_invalid() {
         let artifact1 = Artifact::new(b"hello world".to_vec());
 


### PR DESCRIPTION
Updates the control panel registry CLI script to operate with the large wasms, as well as, the frontend to correctly work if the control panel returns the large wasm information.