### PR TITLE
feat(wallet): add close btn to error dialog

### DIFF
--- a/apps/wallet/src/components/ui/ErrorCard.vue
+++ b/apps/wallet/src/components/ui/ErrorCard.vue
@@ -5,6 +5,7 @@
         <VToolbarTitle>
           {{ props.title }}
         </VToolbarTitle>
+        <VBtn :icon="mdiClose" @click="emit('close')" />
       </VToolbar>
       <VDivider />
     </slot>
@@ -28,6 +29,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiClose } from '@mdi/js';
 import {
   VAlert,
   VCard,
@@ -41,14 +43,19 @@ import {
 
 const props = withDefaults(
   defineProps<{
-    title?: string;
     error: string;
+    title?: string;
     errorDetails?: string;
+    open?: boolean;
   }>(),
   {
     title: undefined,
-    error: '',
     errorDetails: undefined,
+    open: true,
   },
 );
+
+const emit = defineEmits<{
+  (event: 'close'): void;
+}>();
 </script>

--- a/apps/wallet/src/components/ui/ErrorDialog.vue
+++ b/apps/wallet/src/components/ui/ErrorDialog.vue
@@ -1,13 +1,18 @@
 <template>
   <VDialog v-model="open" width="600">
-    <ErrorCard :title="title" :error="error" :error-details="props.errorDetails" />
+    <ErrorCard
+      :title="title"
+      :error="error"
+      :error-details="props.errorDetails"
+      @close="open = false"
+    />
   </VDialog>
 </template>
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { VDialog } from 'vuetify/components';
 import ErrorCard from './ErrorCard.vue';
-import { useI18n } from 'vue-i18n';
 
 const props = withDefaults(
   defineProps<{
@@ -17,7 +22,7 @@ const props = withDefaults(
     errorDetails?: string;
   }>(),
   {
-    modelValue: true,
+    modelValue: undefined,
     title: undefined,
     error: '',
     errorDetails: undefined,
@@ -28,9 +33,18 @@ const emit = defineEmits<{
   (event: 'update:modelValue', payload: boolean): void;
 }>();
 
+// Used to control the dialog visibility when the model value is not provided.
+const defaultOpenedHandler = ref(true);
+
 const open = computed({
-  get: () => props.modelValue,
-  set: value => emit('update:modelValue', value),
+  get: () => props.modelValue ?? defaultOpenedHandler.value,
+  set: value => {
+    if (props.modelValue !== undefined) {
+      emit('update:modelValue', value);
+    } else {
+      defaultOpenedHandler.value = value;
+    }
+  },
 });
 
 const i18n = useI18n();


### PR DESCRIPTION
The default error dialog that is used when certain components fail to load was missing a close button (e.g. if the webassembly dependency for didc parsing fails to load), this change enables to user to continue to navigate in the user interface by closing it.