### PR TITLE
fix(wallet): transfer requests page should only show transfers

### DIFF
--- a/apps/wallet/src/composables/request.composable.ts
+++ b/apps/wallet/src/composables/request.composable.ts
@@ -21,7 +21,9 @@ export type AvailableDomain = {
   types: ListRequestsOperationType[];
 };
 
-export const useAvailableDomains = (): Ref<AvailableDomain[]> => {
+export const useAvailableDomains = (
+  opts: { filterBy?: RequestDomains[] } = {},
+): Ref<AvailableDomain[]> => {
   const domains: Ref<AvailableDomain[]> = ref([]);
   domains.value.push({
     id: RequestDomains.All,
@@ -85,6 +87,11 @@ export const useAvailableDomains = (): Ref<AvailableDomain[]> => {
       { ManageSystemInfo: null },
     ],
   });
+
+  const filterBy = opts?.filterBy ?? [];
+  if (filterBy.length) {
+    domains.value = domains.value.filter(domain => filterBy.includes(domain.id));
+  }
 
   return domains;
 };

--- a/apps/wallet/src/pages/RequestsPage.vue
+++ b/apps/wallet/src/pages/RequestsPage.vue
@@ -173,7 +173,7 @@ const props = withDefaults(defineProps<RequestsPageProps>(), {
 const i18n = useI18n();
 const pageTitle = computed(() => props.title || i18n.t('pages.requests.title'));
 const station = useStationStore();
-const availableDomains = useAvailableDomains();
+const availableDomains = useAvailableDomains({ filterBy: props.domains });
 const statuses = useRequestStatusItems();
 const filterUtils = useFilterUtils();
 const disableRefresh = ref(false);
@@ -200,7 +200,9 @@ const slideGroupIdIndex = ref<number>(
 watch(
   slideGroupIdIndex,
   index => {
-    filters.value.groupBy = availableDomains.value[index].id ?? RequestDomains.All;
+    const fallbackDomain = props.domains.length ? props.domains[0] : RequestDomains.All;
+
+    filters.value.groupBy = availableDomains.value?.[index]?.id ?? fallbackDomain;
   },
   { immediate: true },
 );

--- a/core/station/impl/src/core/init.rs
+++ b/core/station/impl/src/core/init.rs
@@ -15,7 +15,7 @@ lazy_static! {
     pub static ref DEFAULT_PERMISSIONS: Vec<(Allow, Resource)> = vec![
         // all authenticated users can read the capabilities of the canister
         (
-            Allow::public(),
+            Allow::authenticated(),
             Resource::System(SystemResourceAction::Capabilities),
         ),
         // Admins can read the system info which includes the canister's version, cycles, etc.


### PR DESCRIPTION
Ensures that the capabilities of the station are only available to authenticated users, as well as, fixes a bug in the UI that was showing more request types in the Transfer Requests page.