### PR TITLE
perf(station): make concurrent balance queries more efficient

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1661,12 +1661,19 @@ type GetAccountResult = variant {
 type AccountBalance = record {
   // The account id.
   account_id : UUID;
+  // The account id.
+  asset_id : UUID;
   // The balance of the account.
   balance : nat;
   // The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
   decimals : nat32;
   // The time at which the balance was last updated.
   last_update_timestamp : TimestampRFC3339;
+  // The state of balance query:
+  //  - `fresh`: The balance was recently updated and is considered fresh.
+  //  - `stale`: The balance may be out of date.
+  //  - `stale_refreshing`: The balance may be out of date but it is being refreshed in the background.
+  query_state : text;
 };
 
 // Input type for getting a account balance.
@@ -1680,7 +1687,7 @@ type FetchAccountBalancesResult = variant {
   // The result data for a successful execution.
   Ok : record {
     // The account balance that was retrieved.
-    balances : vec AccountBalance;
+    balances : vec opt AccountBalance;
   };
   // The error that occurred (e.g. the user does not have the necessary permissions).
   Err : Error;

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1661,7 +1661,7 @@ type GetAccountResult = variant {
 type AccountBalance = record {
   // The account id.
   account_id : UUID;
-  // The account id.
+  // The asset id.
   asset_id : UUID;
   // The balance of the account.
   balance : nat;

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -22,6 +22,8 @@ export interface AccountBalance {
   'decimals' : number,
   'balance' : bigint,
   'last_update_timestamp' : TimestampRFC3339,
+  'query_state' : string,
+  'asset_id' : UUID,
 }
 export interface AccountBalanceInfo {
   'decimals' : number,
@@ -563,7 +565,7 @@ export type ExternalCanisterState = { 'Active' : null } |
   { 'Archived' : null };
 export interface FetchAccountBalancesInput { 'account_ids' : Array<UUID> }
 export type FetchAccountBalancesResult = {
-    'Ok' : { 'balances' : Array<AccountBalance> }
+    'Ok' : { 'balances' : Array<[] | [AccountBalance]> }
   } |
   { 'Err' : Error };
 export type FundExternalCanisterOperation = FundExternalCanisterOperationInput;

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -550,6 +550,8 @@ export const idlFactory = ({ IDL }) => {
     'decimals' : IDL.Nat32,
     'balance' : IDL.Nat,
     'last_update_timestamp' : TimestampRFC3339,
+    'query_state' : IDL.Text,
+    'asset_id' : UUID,
   });
   const AccountAsset = IDL.Record({
     'balance' : IDL.Opt(AccountBalance),
@@ -907,7 +909,7 @@ export const idlFactory = ({ IDL }) => {
     'account_ids' : IDL.Vec(UUID),
   });
   const FetchAccountBalancesResult = IDL.Variant({
-    'Ok' : IDL.Record({ 'balances' : IDL.Vec(AccountBalance) }),
+    'Ok' : IDL.Record({ 'balances' : IDL.Vec(IDL.Opt(AccountBalance)) }),
     'Err' : Error,
   });
   const GetAccountInput = IDL.Record({ 'account_id' : UUID });

--- a/apps/wallet/src/pages/AccountAssetPage.vue
+++ b/apps/wallet/src/pages/AccountAssetPage.vue
@@ -492,18 +492,20 @@ const loadAccount = async (): Promise<{
       account_ids: [accountId],
     });
 
-    if (balances.length) {
-      accountAsset.value = {
-        ...accountAsset.value,
-        balance: [
-          {
-            account_id: accountId,
-            balance: balances[0].balance,
-            decimals: balances[0].decimals,
-            last_update_timestamp: balances[0].last_update_timestamp,
-          },
-        ],
-      };
+    for (const balance of balances) {
+      if (!balance[0]) {
+        continue;
+      }
+
+      const accountBalance = balance[0];
+
+      if (accountBalance.account_id === accountId && accountBalance.asset_id == assetId) {
+        accountAsset.value = {
+          ...accountAsset.value,
+          balance: [accountBalance],
+        };
+        break;
+      }
     }
   }
 

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -3,7 +3,6 @@ import { Principal } from '@dfinity/principal';
 import { idlFactory } from '~/generated/station';
 import {
   Account,
-  AccountBalance,
   AccountCallerPrivileges,
   AddAccountOperationInput,
   AddAddressBookEntryOperationInput,
@@ -29,6 +28,7 @@ import {
   EditUserGroupOperationInput,
   EditUserOperationInput,
   FetchAccountBalancesInput,
+  FetchAccountBalancesResult,
   FundExternalCanisterOperationInput,
   GetAccountInput,
   GetAccountResult,
@@ -956,7 +956,9 @@ export class StationService {
     return variantIs(result, 'Healthy');
   }
 
-  async fetchAccountBalances(input: FetchAccountBalancesInput): Promise<AccountBalance[]> {
+  async fetchAccountBalances(
+    input: FetchAccountBalancesInput,
+  ): Promise<ExtractOk<FetchAccountBalancesResult>['balances']> {
     const result = await this.actor.fetch_account_balances(input);
 
     if (variantIs(result, 'Err')) {

--- a/apps/wallet/src/workers/accounts.worker.ts
+++ b/apps/wallet/src/workers/accounts.worker.ts
@@ -1,8 +1,9 @@
 import { Principal } from '@dfinity/principal';
 import { icAgent } from '~/core/ic-agent.core';
 import { logger } from '~/core/logger.core';
-import { AccountBalance, UUID } from '~/generated/station/station.did';
+import { AccountBalance, FetchAccountBalancesResult, UUID } from '~/generated/station/station.did';
 import { StationService } from '~/services/station.service';
+import { ExtractOk } from '~/types/helper.types';
 import { arrayBatchMaker, timer, unreachable } from '~/utils/helper.utils';
 
 const DEFAULT_INTERVAL_MS = 10000;
@@ -42,7 +43,7 @@ export interface AccountsWorkerErrorResponse {
 }
 
 export interface AccountBalancesWorkerResponse {
-  balances: AccountBalance[];
+  balances: Array<[] | [AccountBalance]>;
 }
 
 export type AccountsWorkerResponseMessage =
@@ -130,7 +131,7 @@ class AccountsWorkerImpl {
         this.stationService.fetchAccountBalances({ account_ids: accountIds }).catch(err => {
           logger.error('Failed to update the balance for the given account ids', { err });
 
-          return [] as AccountBalance[];
+          return [] as ExtractOk<FetchAccountBalancesResult>['balances'];
         }),
       );
 

--- a/core/control-panel/impl/src/controllers/station.rs
+++ b/core/control-panel/impl/src/controllers/station.rs
@@ -130,7 +130,7 @@ impl StationController {
     async fn deploy_station(&self, input: DeployStationInput) -> ApiResult<DeployStationResponse> {
         let ctx = CallContext::get();
         let _lock = STATE
-            .with(|state| CallerGuard::new(state.clone(), ctx.caller()))
+            .with(|state| CallerGuard::new(state.clone(), ctx.caller(), None))
             .ok_or(UserError::ConcurrentStationDeployment)?;
 
         let deployed_station_id = self.deploy_service.deploy_station(input, &ctx).await?;

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1661,12 +1661,19 @@ type GetAccountResult = variant {
 type AccountBalance = record {
   // The account id.
   account_id : UUID;
+  // The account id.
+  asset_id : UUID;
   // The balance of the account.
   balance : nat;
   // The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
   decimals : nat32;
   // The time at which the balance was last updated.
   last_update_timestamp : TimestampRFC3339;
+  // The state of balance query:
+  //  - `fresh`: The balance was recently updated and is considered fresh.
+  //  - `stale`: The balance may be out of date.
+  //  - `stale_refreshing`: The balance may be out of date but it is being refreshed in the background.
+  query_state : text;
 };
 
 // Input type for getting a account balance.
@@ -1680,7 +1687,7 @@ type FetchAccountBalancesResult = variant {
   // The result data for a successful execution.
   Ok : record {
     // The account balance that was retrieved.
-    balances : vec AccountBalance;
+    balances : vec opt AccountBalance;
   };
   // The error that occurred (e.g. the user does not have the necessary permissions).
   Err : Error;

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1661,7 +1661,7 @@ type GetAccountResult = variant {
 type AccountBalance = record {
   // The account id.
   account_id : UUID;
-  // The account id.
+  // The asset id.
   asset_id : UUID;
   // The balance of the account.
   balance : nat;

--- a/core/station/api/src/account.rs
+++ b/core/station/api/src/account.rs
@@ -101,9 +101,11 @@ pub struct FetchAccountBalancesInput {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct AccountBalanceDTO {
     pub account_id: String,
+    pub asset_id: String,
     pub balance: candid::Nat,
     pub decimals: u32,
     pub last_update_timestamp: String,
+    pub query_state: String,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -115,7 +117,7 @@ pub struct AccountBalanceInfoDTO {
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct FetchAccountBalancesResponse {
-    pub balances: Vec<AccountBalanceDTO>,
+    pub balances: Vec<Option<AccountBalanceDTO>>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/models/account.rs
+++ b/core/station/impl/src/models/account.rs
@@ -270,7 +270,7 @@ impl From<&AccountBalance> for BalanceQueryState {
     fn from(balance: &AccountBalance) -> Self {
         let balance_age_ms = crate::core::ic_cdk::api::time()
             .saturating_sub(balance.last_modification_timestamp)
-            / 1000;
+            / 1_000_000;
         if balance_age_ms <= ACCOUNT_BALANCE_FRESHNESS_IN_MS {
             BalanceQueryState::Fresh
         } else {

--- a/core/station/impl/src/services/account.rs
+++ b/core/station/impl/src/services/account.rs
@@ -527,7 +527,6 @@ impl AccountService {
                     continue;
                 };
 
-                // let balance_query_result: BalanceQueryResult =
                 match (&account_asset.balance, balance_considered_fresh) {
                     (None, _) | (_, false) => {
                         let balance_update_guard_key = BalanceFetchGuardKey {

--- a/libs/orbit-essentials/src/utils/lock.rs
+++ b/libs/orbit-essentials/src/utils/lock.rs
@@ -1,19 +1,22 @@
 use std::cell::RefCell;
 use std::cmp::Ord;
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
-// The following code implementing canister locks is adapted from
+use crate::cdk::api::time;
+use std::fmt::Debug;
+
+// The following code implementing canister locks with optional expiration is adapted from
 // https://internetcomputer.org/docs/current/developer-docs/security/rust-canister-development-security-best-practices#recommendation-10
 
 pub struct State<T: Ord> {
-    pending_requests: BTreeSet<T>,
+    pending_requests: BTreeMap<T, Option<u64>>,
 }
 
 impl<T: Ord> Default for State<T> {
     fn default() -> Self {
         Self {
-            pending_requests: BTreeSet::new(),
+            pending_requests: BTreeMap::new(),
         }
     }
 }
@@ -23,15 +26,27 @@ pub struct CallerGuard<T: Ord> {
     lock: T,
 }
 
-impl<T: Clone + Ord> CallerGuard<T> {
-    pub fn new(state: Rc<RefCell<State<T>>>, lock: T) -> Option<Self> {
+impl<T: Clone + Ord + Debug> CallerGuard<T> {
+    pub fn new(state: Rc<RefCell<State<T>>>, lock: T, expires_at_ns: Option<u64>) -> Option<Self> {
         {
             let pending_requests = &mut state.borrow_mut().pending_requests;
-            if pending_requests.contains(&lock) {
-                return None;
+            if let Some(existing_request) = pending_requests.get(&lock) {
+                if let Some(expires_at_ns) = existing_request {
+                    if expires_at_ns > &time() {
+                        // Lock is already held by another caller and has not expired.
+                        return None;
+                    } else {
+                        // Lock has expired, fall through to update the lock.
+                        crate::cdk::api::print(format!("Lock has expired for {:?}", lock));
+                    }
+                } else {
+                    // Lock is held indefinitely.
+                    return None;
+                }
             }
-            pending_requests.insert(lock.clone());
+            pending_requests.insert(lock.clone(), expires_at_ns);
         }
+
         Some(Self { state, lock })
     }
 }

--- a/tests/integration/src/account_tests.rs
+++ b/tests/integration/src/account_tests.rs
@@ -1,0 +1,203 @@
+use std::time::Duration;
+
+use crate::interfaces::mint_icp;
+use crate::setup::{setup_new_env, WALLET_ADMIN_USER};
+use crate::utils::{create_account, expect_await_call_result, get_icp_asset};
+use crate::TestEnv;
+use candid::Encode;
+use ic_ledger_types::AccountIdentifier;
+use orbit_essentials::api::ApiResult;
+use pocket_ic::update_candid_as;
+use station_api::{
+    AddAccountOperationInput, AllowDTO, FetchAccountBalancesInput, FetchAccountBalancesResponse,
+    MeResponse, RequestPolicyRuleDTO,
+};
+
+#[test]
+fn test_fetch_balances() {
+    let TestEnv {
+        env,
+        canister_ids,
+        // controller,
+        minter,
+        ..
+    } = setup_new_env();
+
+    // register user
+    let res: (ApiResult<MeResponse>,) =
+        update_candid_as(&env, canister_ids.station, WALLET_ADMIN_USER, "me", ()).unwrap();
+    let user_dto = res.0.unwrap().me;
+
+    let icp_asset = get_icp_asset(&env, canister_ids.station, WALLET_ADMIN_USER);
+
+    let permission = AllowDTO {
+        auth_scope: station_api::AuthScopeDTO::Restricted,
+        user_groups: vec![],
+        users: vec![user_dto.id.clone()],
+    };
+
+    let account = create_account(
+        &env,
+        canister_ids.station,
+        user_dto.identities[0],
+        AddAccountOperationInput {
+            name: "test account".to_owned(),
+            assets: vec![icp_asset.id.clone()],
+            metadata: vec![],
+            read_permission: permission.clone(),
+            configs_permission: permission.clone(),
+            transfer_permission: permission.clone(),
+            configs_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+            transfer_request_policy: Some(RequestPolicyRuleDTO::AutoApproved),
+        },
+    );
+
+    let icp_account_identifier = AccountIdentifier::from_hex(
+        &account
+            .addresses
+            .iter()
+            .find(|a| a.format == "icp_account_identifier")
+            .expect("cannot get ICP account identifier")
+            .address,
+    )
+    .expect("cannot parse ICP account identifier");
+
+    mint_icp(&env, minter, &icp_account_identifier, 10 * 100_000_000)
+        .expect("failed to mint ICP to account");
+
+    let messages_ids = [
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+    ];
+
+    let results = messages_ids
+        .into_iter()
+        .map(|message_id| {
+            expect_await_call_result::<(ApiResult<FetchAccountBalancesResponse>,)>(
+                env.await_call(message_id).expect("failed to await call"),
+            )
+            .0
+            .expect("failed to get result")
+        })
+        .collect::<Vec<_>>();
+
+    results.iter().any(|result| {
+        result.balances[0]
+            .as_ref()
+            .map_or(false, |account_balance| {
+                account_balance.query_state == "fresh"
+            })
+    });
+    results.iter().any(|result| result.balances[0].is_none());
+
+    let messages_ids = [
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+    ];
+
+    let results = messages_ids
+        .into_iter()
+        .map(|message_id| {
+            expect_await_call_result::<(ApiResult<FetchAccountBalancesResponse>,)>(
+                env.await_call(message_id).expect("failed to await call"),
+            )
+            .0
+            .expect("failed to get result")
+        })
+        .collect::<Vec<_>>();
+
+    results.iter().all(|result| {
+        result.balances[0]
+            .as_ref()
+            .map_or(false, |account_balance| {
+                account_balance.query_state == "fresh"
+            })
+    });
+
+    env.advance_time(Duration::from_secs(10));
+
+    let messages_ids = [
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+        env.submit_call(
+            canister_ids.station,
+            user_dto.identities[0],
+            "fetch_account_balances",
+            Encode!(&FetchAccountBalancesInput {
+                account_ids: vec![account.id.clone()],
+            })
+            .unwrap(),
+        )
+        .expect("failed to submit call"),
+    ];
+
+    let results = messages_ids
+        .into_iter()
+        .map(|message_id| {
+            expect_await_call_result::<(ApiResult<FetchAccountBalancesResponse>,)>(
+                env.await_call(message_id).expect("failed to await call"),
+            )
+            .0
+            .expect("failed to get result")
+        })
+        .collect::<Vec<_>>();
+
+    results.iter().any(|result| {
+        result.balances[0]
+            .as_ref()
+            .map_or(false, |account_balance| {
+                account_balance.query_state == "fresh"
+            })
+    });
+    results.iter().any(|result| {
+        result.balances[0]
+            .as_ref()
+            .map_or(false, |account_balance| {
+                account_balance.query_state == "stale_refreshing"
+            })
+    });
+}

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -3,6 +3,7 @@
 use candid::Principal;
 use pocket_ic::PocketIc;
 
+mod account_tests;
 mod address_book_tests;
 mod asset_tests;
 mod control_panel_tests;

--- a/tests/integration/src/transfer_tests.rs
+++ b/tests/integration/src/transfer_tests.rs
@@ -447,7 +447,10 @@ fn make_icrc1_transfer() {
     );
 
     assert_eq!(
-        account_balances.balances[0].balance,
+        account_balances.balances[0]
+            .as_ref()
+            .expect("should have balance")
+            .balance,
         candid::Nat::from(999_850u128)
     );
 
@@ -555,7 +558,10 @@ fn make_icrc1_icp_transfer() {
     );
     assert_eq!(account_balances.balances.len(), 1);
     assert_eq!(
-        account_balances.balances[0].balance,
+        account_balances.balances[0]
+            .as_ref()
+            .expect("should have balance")
+            .balance,
         candid::Nat::from(30 * 100_000_000u64)
     );
 
@@ -589,7 +595,10 @@ fn make_icrc1_icp_transfer() {
     );
     assert_eq!(account_balances.balances.len(), 1);
     assert_eq!(
-        account_balances.balances[0].balance,
+        account_balances.balances[0]
+            .as_ref()
+            .expect("should have balance")
+            .balance,
         candid::Nat::from(5 * 100_000_000u64 - 10_000)
     );
 }

--- a/tests/integration/src/utils.rs
+++ b/tests/integration/src/utils.rs
@@ -1,7 +1,8 @@
 use crate::setup::{create_canister, get_canister_wasm, WALLET_ADMIN_USER};
 use crate::test_data::asset::list_assets;
+use candid::utils::ArgumentDecoder;
 use candid::Principal;
-use candid::{CandidType, Encode};
+use candid::{decode_args, CandidType, Encode};
 use control_panel_api::UploadCanisterModulesInput;
 use flate2::{write::GzEncoder, Compression};
 use ic_certified_assets::types::{
@@ -1093,4 +1094,17 @@ pub(crate) fn add_external_canister_call_any_method_permission_and_approval(
         }),
     )
     .expect("Failed to add approval policy to call external canister");
+}
+
+pub fn expect_await_call_result<T>(result: WasmResult) -> T
+where
+    T: for<'a> ArgumentDecoder<'a>,
+{
+    match result {
+        WasmResult::Reply(vec) => {
+            let result: T = decode_args(&vec).expect("Failed to decode result");
+            result
+        }
+        WasmResult::Reject(error) => panic!("Unexpected reject: {error}"),
+    }
 }


### PR DESCRIPTION
At the moment concurrent calls to fetch the balances of the assets of an account result in all of them fetching the balances with inter canister calls.

If an account asset balance is getting queried concurrent calls should not result in additional balance queries, but those should return the last balance value.