### PR TITLE
fix(control-panel): fix initial station deploy

### DIFF
--- a/orbit
+++ b/orbit
@@ -187,7 +187,7 @@ function install_control_panel() {
   dfx build control_panel
   dfx canister install control_panel
   dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = opt blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = null; station_wasm_module_extra_chunks = null; })")
-  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = null; station_wasm_module_extra_chunks = opt opt record { store_canister = principal\"$wasm_chunk_store_id\"; extra_chunks_key = \"/station.wasm.gz\"; wasm_module_hash = blob\"$station_wasm_module_hash\" } })")
+  dfx canister call control_panel upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = opt vec {}; station_wasm_module_extra_chunks = opt opt record { store_canister = principal\"$wasm_chunk_store_id\"; extra_chunks_key = \"/station.wasm.gz\"; wasm_module_hash = blob\"$station_wasm_module_hash\" } })")
 }
 
 function setup_control_panel() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -223,7 +223,7 @@ function deploy_control_panel() {
 
   echo "Updating the control_panel canister with the new station and upgrader WASM modules..."
   dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = opt blob \"$upgrader_wasm_module_bytes\"; station_wasm_module = null; station_wasm_module_extra_chunks = null; })")
-  dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = null; station_wasm_module_extra_chunks = opt opt record { store_canister = principal\"$wasm_chunk_store_id\"; extra_chunks_key = \"/station-$station_version.wasm.gz\"; wasm_module_hash = blob\"$station_wasm_module_hash\" } })")
+  dfx canister call control_panel --network $network upload_canister_modules --argument-file <(echo "(record { upgrader_wasm_module = null; station_wasm_module = opt vec {}; station_wasm_module_extra_chunks = opt opt record { store_canister = principal\"$wasm_chunk_store_id\"; extra_chunks_key = \"/station-$station_version.wasm.gz\"; wasm_module_hash = blob\"$station_wasm_module_hash\" } })")
 }
 
 function deploy_app_wallet() {


### PR DESCRIPTION
This change enables us to drop the old unused wasm module from the the control panel, the new release process uses the asset chunk store instead.