### PR TITLE
chore(control-panel,station): always use CMC for canister creation

### DIFF
--- a/libs/orbit-essentials/src/cmc.rs
+++ b/libs/orbit-essentials/src/cmc.rs
@@ -1,7 +1,7 @@
 use crate::utils::check_balance_before_transfer;
 use candid::{CandidType, Deserialize, Principal};
 use ic_cdk::api::call::call_with_payment128;
-use ic_cdk::api::management_canister::main::{self as mgmt, CanisterSettings};
+use ic_cdk::api::management_canister::main::CanisterSettings;
 use serde::Serialize;
 
 /// The CMC canister is used to deploy a canister on a subnet of choice.

--- a/libs/orbit-essentials/src/cmc.rs
+++ b/libs/orbit-essentials/src/cmc.rs
@@ -46,28 +46,18 @@ pub async fn create_canister(
     initial_cycles: u128,
 ) -> Result<Principal, String> {
     check_balance_before_transfer(initial_cycles).await?;
-    if let Some(subnet_selection) = subnet_selection {
-        let create_canister = CreateCanister {
-            subnet_selection: Some(subnet_selection),
-            settings: None,
-        };
-        call_with_payment128::<_, (Result<Principal, CreateCanisterError>,)>(
-            CMC_CANISTER_ID,
-            "create_canister",
-            (create_canister,),
-            initial_cycles,
-        )
-        .await
-        .map(|res| res.0)
-        .map_err(|(_, err)| err.to_string())?
-        .map_err(|CreateCanisterError::Refunded { create_error, .. }| create_error)
-    } else {
-        mgmt::create_canister(
-            mgmt::CreateCanisterArgument { settings: None },
-            initial_cycles,
-        )
-        .await
-        .map(|res| res.0.canister_id)
-        .map_err(|(_, err)| err.to_string())
-    }
+    let create_canister = CreateCanister {
+        subnet_selection,
+        settings: None,
+    };
+    call_with_payment128::<_, (Result<Principal, CreateCanisterError>,)>(
+        CMC_CANISTER_ID,
+        "create_canister",
+        (create_canister,),
+        initial_cycles,
+    )
+    .await
+    .map(|res| res.0)
+    .map_err(|(_, err)| err.to_string())?
+    .map_err(|CreateCanisterError::Refunded { create_error, .. }| create_error)
 }


### PR DESCRIPTION
This PR updates the helper function for canister creation to always use CMC for canister creation: this way, stations created by the control panel and external canisters created by the station without specifying a subnet explicitly will be created at a (pseudo-)random application subnet instead of always creating those canisters on the same subnet. (The upgrader is still always created on the same subnet as its station.) This is supposed to achieve better load balancing. If external canisters need to be collocated, a subnet should be specified explicitly.