### PR TITLE
fix(ci): install CMC in Orbit local deployment

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
       - name: 'Start local replica'
-        run: dfx start --clean --host 127.0.0.1:4943 --background
+        run: dfx start --clean --pocketic --host 127.0.0.1:4943 --background
       - name: 'Perform local deployment'
         run: ./orbit --init
       - name: 'Test local deployment'
@@ -180,7 +180,7 @@ jobs:
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
       - name: 'Start local replica'
-        run: dfx start --clean --host 127.0.0.1:4943 --background
+        run: dfx start --clean --pocketic --host 127.0.0.1:4943 --background
       - name: 'Test prod deployment script'
         run: |
           echo y | ./scripts/deploy.sh --local # install

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ Please make sure you have the following installed:
 Start a local replica listening on port 4943:
 
 ```
-dfx start --clean --host 127.0.0.1:4943
+dfx start --clean --pocketic --host 127.0.0.1:4943
 ```
+
+Note that the local replica should be stopped using `dfx stop` rather than by CTRL^C.
 
 Then the following steps can be used to setup the Orbit canister ecosystem for local development.
 

--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,16 @@
 {
   "__ref_dfx": "dfx.json reference: https://internetcomputer.org/docs/current/references/dfx-json-reference/",
   "canisters": {
+    "cmc": {
+      "type": "custom",
+      "candid": "https://raw.githubusercontent.com/dfinity/ic/ee52ab3056cf5f39b09b08de70bdd20485c8b2dc/rs/nns/cmc/cmc.did",
+      "wasm": "https://download.dfinity.systems/ic/ee52ab3056cf5f39b09b08de70bdd20485c8b2dc/canisters/cycles-minting-canister.wasm.gz",
+      "remote": {
+        "id": {
+          "ic": "rkp4c-7iaaa-aaaaa-aaaca-cai"
+        }
+      }
+    },
     "icp_ledger": {
       "type": "custom",
       "candid": "https://raw.githubusercontent.com/dfinity/ic/d87954601e4b22972899e9957e800406a0a6b929/rs/rosetta-api/icp_ledger/ledger.did",
@@ -145,6 +155,6 @@
       }
     }
   },
-  "dfx": "0.23.0",
+  "dfx": "0.24.3",
   "version": 1
 }

--- a/orbit
+++ b/orbit
@@ -116,10 +116,10 @@ function install_cmc() {
 function setup_cmc() {
   uninstall_cmc
   install_cmc
-  SUBNET_ID="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[0] | .key')"
+  SUBNET_IDS="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
   dfx canister call cmc set_authorized_subnetwork_list "(record {
     who=null;
-    subnets=vec {principal\"$SUBNET_ID\"};
+    subnets=vec {$SUBNET_IDS};
   })
 "
 }

--- a/orbit
+++ b/orbit
@@ -10,6 +10,8 @@ export NVM_DIR="$HOME/.nvm"
 
 MINTER_IDENTITY_NAME="minter"
 WHOAMI=$(dfx identity whoami)
+MY_PRINCIPAL=$(dfx identity get-principal)
+CANISTER_ID_CMC="rkp4c-7iaaa-aaaaa-aaaca-cai"
 CANISTER_ID_CONTROL_PANEL="wdqqk-naaaa-aaaaa-774aq-cai"
 CANISTER_ID_ICP_INDEX="qhbym-qaaaa-aaaaa-aaafq-cai"
 CANISTER_ID_ICP_LEDGER="ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -47,6 +49,7 @@ Usage:
 Options:
   --init configures all the dependencies for the development environment
   --init-control-panel fresh installs the control panel canister
+  --init-cmc fresh installs the cycles minting canister and sets the default subnets for canister deployment
   --init-icp-index fresh installs the icp index canister, used to query the ledger transactions
   --init-icp-ledger fresh installs the icp ledger canister, the current identity will be credited with ICP tokens
   --init-internet-identity fresh installs the internet identity canister
@@ -93,6 +96,30 @@ function build_wasm() {
 #############################################
 # SETUP                                     #
 #############################################
+
+function uninstall_cmc() {
+  dfx canister delete cmc -y >/dev/null 2>&1 || true
+}
+
+function install_cmc() {
+  dfx deploy --specified-id $CANISTER_ID_CMC cmc --argument "
+  (opt record {
+    ledger_canister_id=opt principal\"$CANISTER_ID_ICP_LEDGER\";
+    governance_canister_id=opt principal\"$MY_PRINCIPAL\";
+  })
+"
+}
+
+function setup_cmc() {
+  uninstall_cmc
+  install_cmc
+  SUBNET_ID="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key')"
+  dfx canister call cmc set_authorized_subnetwork_list "(record {
+    who=null;
+    subnets=vec {principal\"$SUBNET_ID\"};
+  })
+"
+}
 
 function uninstall_icp_ledger() {
   dfx canister delete icp_ledger -y >/dev/null 2>&1 || true
@@ -352,11 +379,18 @@ while [[ $# -gt 0 ]]; do
   --init)
     shift
     exec_function setup_devenv
+    exec_function setup_cmc
     exec_function setup_icp_ledger
     exec_function setup_icp_index
     exec_function setup_internet_identity
     exec_function setup_control_panel
     exec_function setup_app_wallet
+    echo
+    ;;
+  --init-cmc)
+    shift
+    exec_function setup_devenv
+    exec_function setup_cmc
     echo
     ;;
   --init-icp-ledger)

--- a/orbit
+++ b/orbit
@@ -101,6 +101,8 @@ function uninstall_cmc() {
   dfx canister delete cmc -y >/dev/null 2>&1 || true
 }
 
+# sets the user principal as the governance canister
+# so that the user principal can make privileged calls on CMC
 function install_cmc() {
   dfx deploy --specified-id $CANISTER_ID_CMC cmc --argument "
   (opt record {

--- a/orbit
+++ b/orbit
@@ -98,7 +98,8 @@ function build_wasm() {
 #############################################
 
 function uninstall_cmc() {
-  dfx canister delete cmc -y >/dev/null 2>&1 || true
+  dfx canister stop cmc >/dev/null 2>&1 || true
+  dfx canister delete cmc --no-withdrawal -y >/dev/null 2>&1 || true
 }
 
 # sets the user principal as the governance canister
@@ -115,7 +116,7 @@ function install_cmc() {
 function setup_cmc() {
   uninstall_cmc
   install_cmc
-  SUBNET_ID="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key')"
+  SUBNET_ID="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[0] | .key')"
   dfx canister call cmc set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {principal\"$SUBNET_ID\"};


### PR DESCRIPTION
This PR installs CMC ([proposal](https://dashboard.internetcomputer.org/proposal/134500)) in Orbit local deployments since CMC is required to create canisters (stations and external canisters). Additionally, this PR:
- updates README to use PocketIC as the local IC backend (to retrieve its topology at an HTTP endpoint not served by the replica) and stop it using `dfx stop` rather than by CTRL^C (due to an issue in dfx)
- updates dfx version (to include recent PocketIC serving its topology at an HTTP endpoint)