### PR TITLE
chore(upgrader): remove deprecated log API and stable storage

### DIFF
--- a/core/upgrader/api/spec.did
+++ b/core/upgrader/api/spec.did
@@ -296,5 +296,4 @@ service : (InitArg) -> {
   "get_disaster_recovery_state" : () -> (GetDisasterRecoveryStateResult) query;
   "request_disaster_recovery" : (RequestDisasterRecoveryInput) -> (RequestDisasterRecoveryResult);
   "get_logs" : (GetLogsInput) -> (GetLogsResult) query;
-  "deprecated_get_logs" : (GetLogsInput) -> (GetLogsResult) query;
 };

--- a/core/upgrader/impl/src/controllers/logs.rs
+++ b/core/upgrader/impl/src/controllers/logs.rs
@@ -28,13 +28,6 @@ fn get_logs(input: upgrader_api::GetLogsInput) -> ApiResult<upgrader_api::GetLog
     CONTROLLER.get_logs(input)
 }
 
-#[query]
-fn deprecated_get_logs(
-    input: upgrader_api::GetLogsInput,
-) -> ApiResult<upgrader_api::GetLogsResponse> {
-    CONTROLLER.deprecated_get_logs(input)
-}
-
 pub struct LogsController {
     disaster_recover_service: Arc<DisasterRecoveryService>,
     logger_service: Arc<LoggerService>,
@@ -53,33 +46,6 @@ impl LogsController {
                 next_offset,
                 total,
             } = self.logger_service.get_logs(
-                input.pagination.as_ref().and_then(|p| p.offset),
-                input.pagination.as_ref().and_then(|p| p.limit),
-            );
-
-            Ok(upgrader_api::GetLogsResponse {
-                logs: logs.into_iter().map(|l| l.into()).collect(),
-                total,
-                next_offset,
-            })
-        } else {
-            Err(UpgraderApiError::Unauthorized.into())
-        }
-    }
-
-    // Supports fetching the logs from the deprecated log storage.
-    pub fn deprecated_get_logs(
-        &self,
-        input: upgrader_api::GetLogsInput,
-    ) -> ApiResult<upgrader_api::GetLogsResponse> {
-        let caller = caller();
-
-        if is_controller(&caller) || self.disaster_recover_service.is_committee_member(&caller) {
-            let GetLogsResult {
-                logs,
-                next_offset,
-                total,
-            } = self.logger_service.deprecated_get_logs(
                 input.pagination.as_ref().and_then(|p| p.offset),
                 input.pagination.as_ref().and_then(|p| p.limit),
             );

--- a/core/upgrader/impl/src/lib.rs
+++ b/core/upgrader/impl/src/lib.rs
@@ -33,8 +33,6 @@ type LocalRef<T> = &'static LocalKey<RefCell<T>>;
 
 const MEMORY_ID_TARGET_CANISTER_ID: u8 = 0;
 const MEMORY_ID_DISASTER_RECOVERY: u8 = 1;
-const DEPRECATED_MEMORY_ID_LOG_INDEX: u8 = 2;
-const DEPRECATED_MEMORY_ID_LOG_DATA: u8 = 3;
 const MEMORY_ID_LOGS: u8 = 4;
 
 thread_local! {


### PR DESCRIPTION
This PR removes the deprecated log API and stable memories in the upgrader, reducing its default stable memory footprint from 40MiB to 24MiB. The deprecated upgrader logs [do not get](https://github.com/dfinity/orbit/blob/7fd45ed6e053fdac2cea05f9807ab45a40244c06/core/upgrader/impl/src/services/logger.rs#L239) any new logs since the last upgrader [release](https://github.com/dfinity/orbit/releases/tag/%40orbit%2Fupgrader-v0.1.0) (end of Nov).