### PR TITLE
chore(ci): support local replica for local deployment

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -151,8 +151,27 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
-      - name: 'Start local replica'
+      - name: 'Start PocketIC'
         run: dfx start --clean --pocketic --host 127.0.0.1:4943 --background
+      - name: 'Perform local deployment'
+        run: ./orbit --init
+      - name: 'Test local deployment'
+        run: |
+          curl http://werw6-ayaaa-aaaaa-774aa-cai.localhost:4943/ | grep "<title>Orbit Wallet</title>"
+  deployment-test-replica:
+    name: 'deployment-test-replica:required'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+      - name: 'Setup Node'
+        uses: ./.github/actions/setup-node
+      - name: 'Run sccache-cache'
+        uses: mozilla-actions/sccache-action@v0.0.4
+      - name: 'Install dfx'
+        uses: dfinity/setup-dfx@main
+      - name: 'Start local replica'
+        run: dfx start --clean --host 127.0.0.1:4943 --background
       - name: 'Perform local deployment'
         run: ./orbit --init
       - name: 'Test local deployment'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -164,6 +164,9 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
+      - name: 'Setup Python'
+        uses: actions/setup-python@v5
+        run: pip install cbor2
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
       - name: 'Run sccache-cache'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/checkout@v4
       - name: 'Setup Python'
         uses: actions/setup-python@v5
+      - name: 'Install cbor2'
         run: pip install cbor2
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -168,6 +168,8 @@ jobs:
         uses: actions/setup-python@v5
       - name: 'Install cbor2'
         run: pip install cbor2
+      - name: 'Install crc32'
+        run: sudo apt install -y libarchive-zip-perl
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
       - name: 'Run sccache-cache'

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ dfx start --clean --pocketic --host 127.0.0.1:4943
 
 Note that the local replica should be stopped using `dfx stop` rather than by CTRL^C.
 
+If you want to resume your local replica after `dfx stop`, then you need to install the Python package `cbor2`,
+have the binary `crc32` to compute CRC32 checksums on your executable path,
+and use the following command for the first time:
+
+```
+dfx start --clean --host 127.0.0.1:4943
+```
+
 Then the following steps can be used to setup the Orbit canister ecosystem for local development.
 
 ```bash

--- a/orbit
+++ b/orbit
@@ -113,10 +113,23 @@ function install_cmc() {
 "
 }
 
+function textual_encode() {
+  ( echo "$1" | xxd -r -p | /usr/bin/crc32 /dev/stdin; echo -n "$1" ) |
+  xxd -r -p | base32 | tr A-Z a-z |
+  tr -d = | fold -w5 | paste -sd'-' -
+}
+
 function setup_cmc() {
   uninstall_cmc
   install_cmc
-  SUBNET_IDS="$(curl http://localhost:4943/_/topology 2>/dev/null | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
+  TOPO="$(curl http://localhost:4943/_/topology 2>/dev/null)"
+  if [[ "$?" != "0" || "$TOPO" == "Endpoint not found." ]]
+  then
+    SUBNET_ID_HEX="$(curl http://localhost:4943/api/v2/status 2>/dev/null | python3 -c "import cbor2; import hashlib; import sys; status=cbor2.loads(sys.stdin.buffer.read()); hash=hashlib.sha224(status['root_key']).digest(); principal=hash+b'\x02'; print(principal.hex())")"
+    SUBNET_IDS="principal\"$(textual_encode $SUBNET_ID_HEX)\";"
+  else
+    SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
+  fi
   dfx canister call cmc set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {$SUBNET_IDS};

--- a/orbit
+++ b/orbit
@@ -114,7 +114,7 @@ function install_cmc() {
 }
 
 function textual_encode() {
-  ( echo "$1" | xxd -r -p | /usr/bin/crc32 /dev/stdin; echo -n "$1" ) |
+  ( echo "$1" | xxd -r -p | crc32 /dev/stdin; echo -n "$1" ) |
   xxd -r -p | base32 | tr A-Z a-z |
   tr -d = | fold -w5 | paste -sd'-' -
 }


### PR DESCRIPTION
This PR adds support for local replica in addition to PocketIC for local deployment. The motivation is that PocketIC started by dfx doesn't properly support resuming a local deployment after `dfx stop`.