### PR TITLE
feat(wallet): searchable address book; pick from address book at transfer

### DIFF
--- a/apps/wallet/src/components/accounts/TransferForm.vue
+++ b/apps/wallet/src/components/accounts/TransferForm.vue
@@ -10,17 +10,27 @@
       :readonly="isViewMode"
       data-test-id="transfer-form-transfer-id"
     />
-    <VTextField
+    <AddressInput
+      v-if="!isViewMode"
       v-model="model.to"
       :label="$t('terms.destination_address')"
-      :variant="isViewMode ? 'plain' : 'filled'"
+      :readonly="isViewMode"
+      required
+      :prepend-icon="mdiSend"
+      data-test-id="transfer-form-destination-address"
+      :blockchain="input.asset.blockchain"
+    />
+
+    <VTextField
+      v-else
+      v-model="model.to"
+      :label="$t('terms.destination_address')"
+      variant="plain"
       density="comfortable"
       class="mb-2"
-      name="to"
-      :readonly="isViewMode"
+      readonly
       type="text"
       :prepend-icon="mdiSend"
-      :rules="[requiredRule, addressValidator]"
       data-test-id="transfer-form-destination-address"
     />
     <VTextField
@@ -48,8 +58,9 @@ import { computed, ref, toRefs, watch } from 'vue';
 import { VForm, VTextField } from 'vuetify/components';
 import { Account, Asset, Transfer } from '~/generated/station/station.did';
 import { VFormValidation } from '~/types/helper.types';
-import { requiredRule, validAddress, validTokenAmount } from '~/utils/form.utils';
+import { requiredRule, validTokenAmount } from '~/utils/form.utils';
 import { amountToBigInt, formatBalance } from '~/utils/helper.utils';
+import AddressInput from '../inputs/AddressInput.vue';
 
 export type TransferFormProps = {
   account: Account;
@@ -86,8 +97,6 @@ const emit = defineEmits<{
 
 const model = computed(() => props.modelValue.value);
 watch(model.value, newValue => emit('update:modelValue', newValue), { deep: true });
-
-const addressValidator = computed(() => validAddress(input.asset.blockchain));
 
 const amountInput = ref<HTMLInputElement | null>(null);
 const amount = ref<string | undefined>(undefined);

--- a/apps/wallet/src/components/inputs/AddressBookAutocomplete.spec.ts
+++ b/apps/wallet/src/components/inputs/AddressBookAutocomplete.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { StationService } from '~/services/station.service';
 import { mount } from '~/test.utils';
 import AddressBookAutocomplete from './AddressBookAutocomplete.vue';
+import { AddressBookEntry } from '~/generated/station/station.did';
 
 vi.mock('~/services/station.service', () => {
   const mock: Partial<StationService> = {
@@ -24,7 +25,11 @@ describe('AddressBookAutocomplete', () => {
   it('renders with selected ids', () => {
     const wrapper = mount(AddressBookAutocomplete, {
       props: {
-        modelValue: ['1'],
+        modelValue: [
+          {
+            id: '1',
+          } as AddressBookEntry,
+        ],
       },
     });
 
@@ -33,7 +38,7 @@ describe('AddressBookAutocomplete', () => {
     const autocomplete = wrapper.findComponent({ name: 'VAutocomplete' });
     expect(autocomplete.exists()).toBe(true);
 
-    expect(autocomplete.props('modelValue')).toEqual(['1']);
+    expect(autocomplete.props('modelValue')).toEqual([{ id: '1' }]);
   });
 
   it('renders with empty list of address book entries', async () => {

--- a/apps/wallet/src/components/inputs/AddressInput.spec.ts
+++ b/apps/wallet/src/components/inputs/AddressInput.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StationService } from '~/services/station.service';
+import { mount } from '~/test.utils';
+import AddressInput from './AddressInput.vue';
+import { AddressBookEntry } from '~/generated/station/station.did';
+import { flushPromises } from '@vue/test-utils';
+
+const validIcpAddress1 = '5c76bc95e544204de4928e4d901e52b49df248b9c346807040e7af75aa61f4b3';
+const validIcpAddress2 = '3d84432911eab50b97dfea077339ba2ffe2cfa075d6ae5da0bfabe4df6264b41';
+
+const addressBookEntry = {
+  id: '1',
+  address: validIcpAddress1,
+  address_owner: 'owner',
+} as AddressBookEntry;
+
+vi.mock('~/services/station.service', () => {
+  const mock: Partial<StationService> = {
+    withStationId: vi.fn().mockReturnThis(),
+    listAddressBook: vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        address_book_entries: [addressBookEntry],
+        next_offset: [BigInt(0)],
+        total: BigInt(0),
+      }),
+    ),
+  };
+
+  return {
+    StationService: vi.fn(() => mock),
+  };
+});
+
+describe('AddressInput', () => {
+  it('renders with empty address', () => {
+    const wrapper = mount(AddressInput, {
+      props: {
+        blockchain: 'icp',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+
+    const input = wrapper.findComponent({ name: 'VCombobox' });
+    expect(input.exists()).toBe(true);
+
+    expect(input.props('modelValue')).toEqual(null);
+  });
+
+  it('renders with starting address', async () => {
+    const wrapper = mount(AddressInput, {
+      props: {
+        blockchain: 'icp',
+        modelValue: validIcpAddress1,
+      },
+    });
+    const input = wrapper.findComponent({ name: 'VCombobox' });
+
+    expect(input.exists()).toBe(true);
+
+    await wrapper.vm.$nextTick();
+
+    expect(input.props('modelValue')).toEqual(validIcpAddress1);
+  });
+
+  it('loads addresses from the address book', async () => {
+    const wrapper = mount(AddressInput, {
+      props: {
+        blockchain: 'icp',
+      },
+    });
+    const input = wrapper.findComponent({ name: 'VCombobox' });
+
+    expect(input.exists()).toBe(true);
+
+    await wrapper.vm.$nextTick();
+    await flushPromises();
+
+    expect(input.props('items')).toEqual([addressBookEntry]);
+  });
+
+  it('accepts new addresses', async () => {
+    const wrapper = mount(AddressInput, {
+      props: {
+        blockchain: 'icp',
+      },
+    });
+    const input = wrapper.findComponent({ name: 'VCombobox' });
+    await input.find('input').setValue(validIcpAddress2);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[validIcpAddress2]]);
+  });
+});

--- a/apps/wallet/src/components/settings/StationInfoCard.vue
+++ b/apps/wallet/src/components/settings/StationInfoCard.vue
@@ -173,7 +173,7 @@
               </VListItemSubtitle>
             </VListItem>
           </template>
-          <VListItem class="px-0" v-else-if="loadingSystemInfoError">
+          <VListItem v-else-if="loadingSystemInfoError" class="px-0">
             <VListItemTitle class="font-weight-bold">{{ $t(`terms.upgrader_id`) }}</VListItemTitle>
             <VListItemSubtitle>
               <VAlert type="error" variant="tonal" density="compact" class="mb-4 mt-2">

--- a/apps/wallet/src/composables/autocomplete.composable.ts
+++ b/apps/wallet/src/composables/autocomplete.composable.ts
@@ -91,8 +91,8 @@ export const useAddressBookAutocomplete = () => {
 
   const autocomplete = useAutocomplete(async term => {
     const results = await station.service.listAddressBook({
-      addresses: term.trim().length > 0 ? [term.trim()] : undefined,
-      limit: 100,
+      search_term: term.trim().length > 0 ? term.trim() : undefined,
+      limit: 10,
       offset: 0,
     });
 

--- a/apps/wallet/src/generated/internet-identity/internet_identity.did
+++ b/apps/wallet/src/generated/internet-identity/internet_identity.did
@@ -257,6 +257,8 @@ type InternetIdentityInit = record {
     register_rate_limit : opt RateLimitConfig;
     // Configuration of the captcha in the registration flow.
     captcha_config: opt CaptchaConfig;
+    // Configuration for Related Origins Requests
+    related_origins: opt vec text;
 };
 
 type ChallengeKey = text;

--- a/apps/wallet/src/generated/internet-identity/internet_identity.did.d.ts
+++ b/apps/wallet/src/generated/internet-identity/internet_identity.did.d.ts
@@ -203,6 +203,7 @@ export interface InternetIdentityInit {
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
+  'related_origins' : [] | [Array<string>],
   'captcha_config' : [] | [CaptchaConfig],
   'register_rate_limit' : [] | [RateLimitConfig],
 }

--- a/apps/wallet/src/generated/internet-identity/internet_identity.did.js
+++ b/apps/wallet/src/generated/internet-identity/internet_identity.did.js
@@ -29,6 +29,7 @@ export const idlFactory = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });
@@ -558,6 +559,7 @@ export const init = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -1895,6 +1895,8 @@ type ListAddressBookEntriesInput = record {
   labels : opt vec text;
   // The address formats to search for.
   address_formats : opt vec text;
+  // The term to use for filtering the address book entries.
+  search_term : opt text;
   // The pagination parameters.
   paginate : opt PaginationInput;
 };

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -737,6 +737,7 @@ export interface ListAddressBookEntriesInput {
   'blockchain' : [] | [string],
   'addresses' : [] | [Array<string>],
   'paginate' : [] | [PaginationInput],
+  'search_term' : [] | [string],
 }
 export type ListAddressBookEntriesResult = {
     'Ok' : {

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -1296,6 +1296,7 @@ export const idlFactory = ({ IDL }) => {
     'blockchain' : IDL.Opt(IDL.Text),
     'addresses' : IDL.Opt(IDL.Vec(IDL.Text)),
     'paginate' : IDL.Opt(PaginationInput),
+    'search_term' : IDL.Opt(IDL.Text),
   });
   const ListAddressBookEntriesResult = IDL.Variant({
     'Ok' : IDL.Record({

--- a/apps/wallet/src/pages/AddressBookPage.vue
+++ b/apps/wallet/src/pages/AddressBookPage.vue
@@ -216,7 +216,7 @@ const fetchList = useFetchList(
       {
         offset,
         limit,
-        addresses: addressToSearch ? [addressToSearch] : undefined,
+        search_term: addressToSearch,
       },
       useVerifiedCall,
     );

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -603,6 +603,7 @@ export class StationService {
       ids,
       addresses,
       address_formats,
+      search_term,
     }: ListAddressBookEntriesArgs = {},
     verifiedCall = false,
   ): Promise<ExtractOk<ListAddressBookEntriesResult>> {
@@ -619,6 +620,7 @@ export class StationService {
       addresses: addresses ? [addresses] : [],
       ids: ids ? [ids] : [],
       address_formats: address_formats ? [address_formats] : [],
+      search_term: search_term ? [search_term] : [],
     });
 
     if (variantIs(result, 'Err')) {

--- a/apps/wallet/src/types/station.types.ts
+++ b/apps/wallet/src/types/station.types.ts
@@ -147,6 +147,7 @@ export interface ListAddressBookEntriesArgs {
   labels?: [];
   ids?: UUID[];
   address_formats?: string[];
+  search_term?: string;
 }
 
 export interface ListAssetsArgs {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -1895,6 +1895,8 @@ type ListAddressBookEntriesInput = record {
   labels : opt vec text;
   // The address formats to search for.
   address_formats : opt vec text;
+  // The term to use for filtering the address book entries.
+  search_term : opt text;
   // The pagination parameters.
   paginate : opt PaginationInput;
 };

--- a/core/station/api/src/address_book.rs
+++ b/core/station/api/src/address_book.rs
@@ -78,6 +78,7 @@ pub struct ListAddressBookEntriesInputDTO {
     pub labels: Option<Vec<String>>,
     pub paginate: Option<PaginationInput>,
     pub address_formats: Option<Vec<String>>,
+    pub search_term: Option<String>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/mappers/address_book.rs
+++ b/core/station/impl/src/mappers/address_book.rs
@@ -86,6 +86,7 @@ impl From<ListAddressBookEntriesInputDTO> for ListAddressBookEntriesInput {
                     })
                     .collect()
             }),
+            search_term: input.search_term,
         }
     }
 }

--- a/core/station/impl/src/models/address_book.rs
+++ b/core/station/impl/src/models/address_book.rs
@@ -144,6 +144,7 @@ pub struct ListAddressBookEntriesInput {
     pub blockchain: Option<Blockchain>,
     pub labels: Option<Vec<String>>,
     pub address_formats: Option<Vec<AddressFormat>>,
+    pub search_term: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/services/address_book.rs
+++ b/core/station/impl/src/services/address_book.rs
@@ -80,7 +80,7 @@ impl AddressBookService {
         input: ListAddressBookEntriesInput,
         paginate: Option<PaginationInput>,
     ) -> ServiceResult<PaginatedData<AddressBookEntry>> {
-        let entries = self
+        let mut entries = self
             .address_book_repository
             .find_where(AddressBookWhereClause {
                 ids: input.ids,
@@ -89,6 +89,14 @@ impl AddressBookService {
                 labels: input.labels,
                 address_formats: input.address_formats,
             });
+
+        if let Some(search_term) = input.search_term {
+            let search_term = search_term.to_lowercase();
+            entries.retain(|entry| {
+                entry.address_owner.to_lowercase().contains(&search_term)
+                    || entry.address.to_lowercase().contains(&search_term)
+            });
+        }
 
         Ok(paginated_items(PaginatedItemsArgs {
             offset: paginate.to_owned().and_then(|p| p.offset),

--- a/tests/integration/src/address_book_tests.rs
+++ b/tests/integration/src/address_book_tests.rs
@@ -133,6 +133,7 @@ fn address_book_entry_lifecycle() {
         ids: None,
         paginate: None,
         address_formats: None,
+        search_term: None,
     };
     let res: (Result<ListAddressBookEntriesResponseDTO, ApiErrorDTO>,) = update_candid_as(
         &env,
@@ -207,6 +208,7 @@ fn address_book_entry_lifecycle() {
         ids: None,
         paginate: None,
         address_formats: None,
+        search_term: None,
     };
     let res: (Result<ListAddressBookEntriesResponseDTO, ApiErrorDTO>,) = update_candid_as(
         &env,

--- a/tests/integration/src/migration_tests.rs
+++ b/tests/integration/src/migration_tests.rs
@@ -394,6 +394,7 @@ fn assert_can_list_address_book_entries(
                 offset: Some(0),
                 limit: Some(25),
             }),
+            search_term: None,
         },),
     )
     .unwrap();


### PR DESCRIPTION
What changed:
`AddressBookAutocomplete` now lets you search and pick from the entire address book.
New component: AddressInput that lets you input an address, aided with autocomplete from the address book.


## Create/Edit policy
### It now displays the address owner.
<img width="811" alt="image" src="https://github.com/user-attachments/assets/1ebd9d70-bf78-4117-908f-f52230b1b796" />

### It displays the address book entries in the dropdown - should we add the metadata/blockchain to the list items for more info?
<img width="822" alt="image" src="https://github.com/user-attachments/assets/1aaa01f0-1f77-4634-8ebf-9a575cdaca94" />

### Searching now works on both the address and the owner field, fetching the search results from the station
<img width="780" alt="image" src="https://github.com/user-attachments/assets/16117d49-4824-4ebf-9a18-2838fb092eca" />

### Address owner names are resolved on the policy page,
<img width="924" alt="image" src="https://github.com/user-attachments/assets/90816265-97de-49c6-889e-dec0469df240" />

### ...and on the request view
<img width="807" alt="image" src="https://github.com/user-attachments/assets/2ed89aa6-94ad-407f-8ace-af555df6a670" />

## New transfer dialog

### It now has an autocomplete from the address book
<img width="827" alt="image" src="https://github.com/user-attachments/assets/b08f960b-2eb1-4563-9c73-df2a07c371b5" />

### But it also accepts new addresses
<img width="807" alt="image" src="https://github.com/user-attachments/assets/57f4024f-9943-48cd-9b7f-e57e5f1c76f4" />

