### PR TITLE
fix(upgrader): only retain requests from current committee members

### DIFF
--- a/tests/integration/src/upgrader_test_data.rs
+++ b/tests/integration/src/upgrader_test_data.rs
@@ -103,6 +103,7 @@ impl<'a> UpgraderDataGenerator<'a> {
         )
         .unwrap();
         self.committee = Some(committee);
+        self.recovery_requests.clear();
 
         let accounts: Vec<_> = (0..6)
             .map(|_| Account {


### PR DESCRIPTION
This PR ensures that only disaster recovery requests from current committee members are considered, i.e., requests from past committee members who left the committee are discarded.