### PR TITLE
feat(upgrader): optimize stable memory serialization

### DIFF
--- a/core/upgrader/impl/src/model/disaster_recovery.rs
+++ b/core/upgrader/impl/src/model/disaster_recovery.rs
@@ -68,6 +68,7 @@ pub struct StationRecoveryRequest {
     /// The user ID of the station.
     pub user_id: UUID,
     /// The wasm module to be installed.
+    #[serde(with = "serde_bytes")]
     pub wasm_module: Vec<u8>,
     /// Optional extra chunks of the wasm module to be installed.
     pub wasm_module_extra_chunks: Option<WasmModuleExtraChunks>,
@@ -76,6 +77,7 @@ pub struct StationRecoveryRequest {
     /// The install mode: upgrade or reinstall.
     pub install_mode: InstallMode,
     /// The install arguments.
+    #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
     /// The SHA-256 hash of the install arguments.
     pub arg_sha256: Vec<u8>,


### PR DESCRIPTION
This PR optimizes stable memory serialization in the upgrader by using `#[serde(with = "serde_bytes")]` for WASM binaries and their args.