### PR TITLE
chore(upgrader): harden upgrader stable memory migration tests

### DIFF
--- a/tests/integration/src/system_upgrade_tests.rs
+++ b/tests/integration/src/system_upgrade_tests.rs
@@ -13,7 +13,7 @@ use station_api::{
 };
 use upgrader_api::InitArg;
 
-const EXTRA_TICKS: u64 = 200;
+pub(crate) const STATION_UPGRADE_EXTRA_TICKS: u64 = 200;
 
 fn do_successful_station_upgrade(
     env: &PocketIc,
@@ -33,7 +33,7 @@ fn do_successful_station_upgrade(
         WALLET_ADMIN_USER,
         canister_ids.station,
         station_upgrade_operation.clone(),
-        EXTRA_TICKS,
+        STATION_UPGRADE_EXTRA_TICKS,
     )
     .unwrap();
 
@@ -52,7 +52,7 @@ fn do_successful_station_upgrade(
         WALLET_ADMIN_USER,
         canister_ids.station,
         station_upgrade_operation,
-        EXTRA_TICKS,
+        STATION_UPGRADE_EXTRA_TICKS,
     )
     .unwrap();
 
@@ -104,7 +104,7 @@ fn do_failed_system_upgrade(
         WALLET_ADMIN_USER,
         canister_ids.station,
         system_upgrade_operation,
-        EXTRA_TICKS,
+        STATION_UPGRADE_EXTRA_TICKS,
     )
     .unwrap_err()
     .unwrap();

--- a/tests/integration/src/upgrader_migration_tests.rs
+++ b/tests/integration/src/upgrader_migration_tests.rs
@@ -1,6 +1,9 @@
 use crate::setup::{get_canister_wasm, setup_new_env_with_config, SetupConfig, WALLET_ADMIN_USER};
 use crate::upgrader_test_data::UpgraderDataGenerator;
-use crate::utils::{compress_to_gzip, create_file, get_system_info, read_file};
+use crate::utils::{
+    compress_to_gzip, create_file, get_disaster_recovery_committee, get_system_info, read_file,
+    request_disaster_recovery, upgrade_station,
+};
 use crate::TestEnv;
 use candid::{Encode, Principal};
 use pocket_ic::PocketIc;
@@ -27,6 +30,8 @@ fn upgrade_from_v0(env: &PocketIc, upgrader_id: Principal, station_id: Principal
         pocket_ic::common::rest::BlobCompression::Gzip,
     );
 
+    let stable_memory_size_before_upgrade = env.get_stable_memory(upgrader_id).len();
+
     // Then upgrade the canister to trigger the migration path
     let upgrader_wasm = get_canister_wasm("upgrader").to_vec();
     env.upgrade_canister(
@@ -36,11 +41,20 @@ fn upgrade_from_v0(env: &PocketIc, upgrader_id: Principal, station_id: Principal
         Some(station_id),
     )
     .expect("Unexpected failure upgrading canister.");
+
+    let stable_memory_size_after_upgrade = env.get_stable_memory(upgrader_id).len();
+
+    // Assert that stable memory size doesn't grow after upgrade.
+    assert!(stable_memory_size_after_upgrade <= stable_memory_size_before_upgrade);
 }
 
 fn upgrade_from_latest(env: &PocketIc, upgrader_id: Principal, station_id: Principal) {
-    // This is used to store the stable memory of the canister for future use
     let mut canister_memory = env.get_stable_memory(upgrader_id);
+
+    // Assert that stable memory size is 5 buckets of 8MiB each + stable structures header (64KiB) for the latest layout.
+    assert_eq!(canister_memory.len(), 5 * (8 << 20) + (64 << 10));
+
+    // This is used to store the stable memory of the canister for future use
     canister_memory = compress_to_gzip(&canister_memory);
     create_file("upgrader-memory-latest.bin", &canister_memory);
 
@@ -82,6 +96,9 @@ where
 
     upgrade_from(&env, upgrader_id, canister_ids.station);
 
+    let canister_memory = env.get_stable_memory(upgrader_id);
+    let stable_memory_size_after_upgrade = canister_memory.len();
+
     env.start_canister(upgrader_id, Some(canister_ids.station))
         .expect("Unexpected failure starting canister.");
 
@@ -93,6 +110,42 @@ where
 
     // Assert that the canister api is still working after adding more test data
     test_data_generator.test_api();
+
+    // Submit a few more large disaster recovery requests to test that
+    // stable memory can grow with the latest stable memory layout.
+    let committee =
+        get_disaster_recovery_committee(&env, upgrader_id, canister_ids.station).unwrap();
+    for (i, user) in committee.users.into_iter().take(20).enumerate() {
+        let wasm_module = vec![i as u8; 2_000_000];
+        let large_request = upgrader_api::RequestDisasterRecoveryInput {
+            module: wasm_module,
+            module_extra_chunks: None,
+            arg: vec![],
+            install_mode: upgrader_api::InstallMode::Reinstall,
+        };
+        request_disaster_recovery(
+            &env,
+            upgrader_id,
+            *user.identities.first().unwrap(),
+            large_request,
+        )
+        .unwrap();
+    }
+    let canister_memory = env.get_stable_memory(upgrader_id);
+    let stable_memory_size = canister_memory.len();
+    assert!(stable_memory_size > stable_memory_size_after_upgrade);
+
+    // Test that the station can still be upgraded via the upgrader with the latest stable memory layout.
+    let current_station_name = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station).name;
+    assert_eq!(current_station_name, "Station");
+    upgrade_station(
+        &env,
+        WALLET_ADMIN_USER,
+        canister_ids.station,
+        Some("Upgraded Station".to_string()),
+    );
+    let current_station_name = get_system_info(&env, WALLET_ADMIN_USER, canister_ids.station).name;
+    assert_eq!(current_station_name, "Upgraded Station");
 }
 
 /// Tests that canister upgrades work if the stable memory version does not change.


### PR DESCRIPTION
This PR hardens upgrader stable memory migration tests by testing:
- stable memory size doesn't grow after upgrade;
- latest stable memory size structure (5 buckets of 8MiB each and stable structures header);
- stable memory can grow with the latest stable memory layout;
- the station can still be upgraded via the upgrader with the latest stable memory layout.