### PR TITLE
feat(wallet): requesters can cancel their requests

### DIFF
--- a/apps/wallet/src/components/requests/OpenRequestOverlay.vue
+++ b/apps/wallet/src/components/requests/OpenRequestOverlay.vue
@@ -4,6 +4,7 @@
     v-model:open="open"
     :request-id="requestId"
     @approved="open = false"
+    @cancelled="open = false"
     @request-changed="updateRequestId"
   />
 </template>

--- a/apps/wallet/src/components/requests/PolicyRuleResultView.vue
+++ b/apps/wallet/src/components/requests/PolicyRuleResultView.vue
@@ -180,11 +180,13 @@ function getApprovalSummary(approverIds: string[], status: EvaluationStatus): st
       n: approvals,
       m: rejections,
     });
-  } else {
+  } else if (variantIs(status, 'Pending')) {
     append = i18n.t('requests.evaluation.approval_summary_pending', {
       n: approvals,
       m: rejections,
     });
+  } else {
+    unreachable(status);
   }
 
   return append;

--- a/apps/wallet/src/components/requests/RequestDetailView.spec.ts
+++ b/apps/wallet/src/components/requests/RequestDetailView.spec.ts
@@ -376,7 +376,7 @@ describe('RequestDetailView', () => {
     expect(wrapper.emitted().cancel).toBeTruthy();
   });
 
-  it("shows doesn't show cancel button for cancelled requests", async () => {
+  it("doesn't show cancel button for cancelled requests", async () => {
     const wrapper = mount(RequestDetailView, {
       props: cancelledProps,
     });
@@ -390,7 +390,7 @@ describe('RequestDetailView', () => {
     expect(wrapper.find('[data-test-id="request-details-cancel"]').exists()).toBeFalsy();
   });
 
-  it("shows doesn't show cancel button for non-requester", async () => {
+  it("doesn't show cancel button for non-requester", async () => {
     const wrapper = mount(RequestDetailView, {
       props: pendingProps,
     });

--- a/apps/wallet/src/components/requests/RequestDetailView.vue
+++ b/apps/wallet/src/components/requests/RequestDetailView.vue
@@ -73,7 +73,7 @@
         hide-details
         rows="1"
         auto-grow
-        :readonly="props.loading || !props.details.can_approve"
+        :readonly="props.loading || (!props.details.can_approve && !canCancel)"
       />
     </VCardText>
 
@@ -173,6 +173,17 @@
         :class="{ 'mt-8': props.details.can_approve }"
       />
       <div class="d-flex flex-column flex-md-row ga-1 justify-end flex-grow-1 w-100 w-md-auto">
+        <VBtn
+          v-if="canCancel"
+          data-test-id="request-details-cancel"
+          variant="plain"
+          class="ma-0"
+          :disabled="props.loading"
+          @click="$emit('cancel', reasonOrUndefined)"
+        >
+          {{ $t('terms.cancel_request') }}
+        </VBtn>
+
         <template v-if="props.details.can_approve">
           <VBtn
             data-test-id="request-details-reject"
@@ -261,8 +272,10 @@ import TransferOperation from './operations/TransferOperation.vue';
 import UnsupportedOperation from './operations/UnsupportedOperation.vue';
 import EditAssetOperation from './operations/EditAssetOperation.vue';
 import RemoveAssetOperation from './operations/RemoveAssetOperation.vue';
+import { useStationStore } from '~/stores/station.store';
 
 const i18n = useI18n();
+const store = useStationStore();
 
 const props = withDefaults(
   defineProps<{
@@ -315,6 +328,7 @@ const componentsMap: {
 defineEmits<{
   (event: 'approve', reason?: string): void;
   (event: 'reject', reason?: string): void;
+  (event: 'cancel', reason?: string): void;
 }>();
 
 const detailView = computed<{
@@ -339,6 +353,10 @@ const detailView = computed<{
         operation: props.request.operation[unknownOperationType as keyof RequestOperation],
       }
     : null;
+});
+
+const canCancel = computed(() => {
+  return props.request.requested_by === store.user.id && variantIs(props.request.status, 'Created');
 });
 
 const requestType = computed(() => {

--- a/apps/wallet/src/components/requests/RequestDialog.spec.ts
+++ b/apps/wallet/src/components/requests/RequestDialog.spec.ts
@@ -12,6 +12,7 @@ import { services } from '~/plugins/services.plugin';
 import { mount } from '~/test.utils';
 import { ExtractOk } from '~/types/helper.types';
 import RequestDialog from './RequestDialog.vue';
+import RequestDetailView from './RequestDetailView.vue';
 
 const mockAsset: Asset = {
   blockchain: 'icp',
@@ -263,6 +264,34 @@ describe('RequestDialog', () => {
 
     expect(contents.find('[data-test-id="no-more-requests"]').exists()).toBeTruthy();
 
+    vi.restoreAllMocks();
+  });
+
+  it('cancels the request when the cancel button is clicked', async () => {
+    vi.spyOn(services().station, 'getRequest').mockResolvedValueOnce(approvableRequestResponse);
+    vi.spyOn(services().station, 'cancelRequest').mockResolvedValueOnce(
+      approvableRequestResponse.request,
+    );
+
+    const wrapper = mount(RequestDialog, {
+      props: {
+        requestId: '123',
+        open: true,
+      },
+    });
+
+    await flushPromises();
+
+    const detailView = wrapper.findComponent(RequestDetailView);
+
+    expect(detailView.exists()).toBeTruthy();
+
+    detailView.vm.$emit('cancel');
+
+    expect(services().station.cancelRequest).toHaveBeenCalledWith({
+      request_id: '123',
+      reason: [],
+    });
     vi.restoreAllMocks();
   });
 });

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -711,6 +711,7 @@ export default {
     see_all: 'See All',
     requests: 'Requests',
     cancel: 'Cancel',
+    cancel_request: 'Cancel Request',
     checksum: 'Checksum',
     module_checksum: 'Module Checksum',
     rejected: 'Rejected',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -719,6 +719,7 @@ export default {
     save: 'Sauvegarder',
     see_all: 'Voir Tout',
     cancel: 'Annuler',
+    cancel_request: 'Annuler la demande',
     checksum: 'Checksum',
     module_checksum: 'Checksum du Module',
     rejected: 'Rejetté',

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -708,6 +708,7 @@ export default {
     approved: 'Aprovado',
     confirm: 'Confirmar',
     cancel: 'Cancelar',
+    cancel_request: 'Cancelar pedido',
     see_all: 'Ver todos',
     min: 'Mínimo',
     rule: 'Regra',

--- a/apps/wallet/src/services/station.service.ts
+++ b/apps/wallet/src/services/station.service.ts
@@ -10,6 +10,7 @@ import {
   AddRequestPolicyOperationInput,
   AddUserGroupOperationInput,
   AddUserOperationInput,
+  CancelRequestInput,
   CanisterMethod,
   CanisterSnapshotsResult,
   CanisterStatusResult,
@@ -516,6 +517,16 @@ export class StationService {
 
   async submitRequestApproval(input: SubmitRequestApprovalInput): Promise<Request> {
     const result = await this.actor.submit_request_approval(input);
+
+    if (variantIs(result, 'Err')) {
+      throw result.Err;
+    }
+
+    return result.Ok.request;
+  }
+
+  async cancelRequest(input: CancelRequestInput): Promise<Request> {
+    const result = await this.actor.cancel_request(input);
 
     if (variantIs(result, 'Err')) {
       throw result.Err;


### PR DESCRIPTION
When a request is pending approval the requester can cancel it from the request dialog.

<img width="818" alt="image" src="https://github.com/user-attachments/assets/efc3a2b4-0539-49b1-a90a-670be3d8b94d" />
