### PR TITLE
feat(control-panel): user can deploy 2 stations per day

### DIFF
--- a/core/control-panel/api/src/user_station.rs
+++ b/core/control-panel/api/src/user_station.rs
@@ -59,6 +59,6 @@ pub struct DeployStationResponse {
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum CanDeployStationResponse {
     NotAllowed(UserSubscriptionStatusDTO),
-    Allowed(u64),
+    Allowed(usize),
     QuotaExceeded,
 }

--- a/core/control-panel/api/src/user_station.rs
+++ b/core/control-panel/api/src/user_station.rs
@@ -59,6 +59,6 @@ pub struct DeployStationResponse {
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum CanDeployStationResponse {
     NotAllowed(UserSubscriptionStatusDTO),
-    Allowed(usize),
+    Allowed(u64),
     QuotaExceeded,
 }

--- a/core/control-panel/impl/src/controllers/canister.rs
+++ b/core/control-panel/impl/src/controllers/canister.rs
@@ -2,6 +2,7 @@
 use super::AVAILABLE_TOKENS_USER_REGISTRATION;
 use crate::core::ic_cdk::{api::set_certified_data, spawn};
 use crate::core::metrics::recompute_all_metrics;
+use crate::repositories::USER_REPOSITORY;
 use crate::services::CANISTER_SERVICE;
 use control_panel_api::UploadCanisterModulesInput;
 use ic_cdk_macros::{init, post_upgrade};
@@ -9,6 +10,7 @@ use ic_cdk_timers::{set_timer, set_timer_interval};
 use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::update;
 use orbit_essentials::http::certified_data_for_skip_certification;
+use orbit_essentials::repository::Repository;
 use std::time::Duration;
 
 pub const MINUTE: u64 = 60;
@@ -72,6 +74,9 @@ async fn post_upgrade() {
     set_certified_data_for_skip_certification();
     recompute_all_metrics();
     init_timers_fn();
+
+    // deserialize all users to fail control panel upgrade in case of deserialization failures
+    let _users = USER_REPOSITORY.list();
 
     CANISTER_SERVICE
         .init_canister()

--- a/core/control-panel/impl/src/controllers/http.rs
+++ b/core/control-panel/impl/src/controllers/http.rs
@@ -117,8 +117,9 @@ mod tests {
     #[tokio::test]
     async fn test_service_discovery() {
         let mut user = mock_user();
-        user.deployed_stations = vec![Principal::from_slice(&[0; 29])];
-        let station_host = format!("{}.raw.icp0.io", user.deployed_stations[0].to_text());
+        let station = Principal::from_slice(&[0; 29]);
+        user.add_deployed_station(station);
+        let station_host = format!("{}.raw.icp0.io", station.to_text());
 
         USER_REPOSITORY.insert(user.to_key(), user.clone());
 

--- a/core/control-panel/impl/src/core/metrics.rs
+++ b/core/control-panel/impl/src/core/metrics.rs
@@ -115,15 +115,15 @@ impl ApplicationMetric<User> for MetricDeployedStations {
     fn recalculate(&mut self, models: &[User]) {
         let mut deployed_stations = 0.0;
         for user in models {
-            deployed_stations += user.deployed_stations.len() as f64;
+            deployed_stations += user.get_num_deployed_stations() as f64;
         }
 
         self.set(SERVICE_NAME, deployed_stations);
     }
 
     fn sum(&mut self, current: &User, previous: Option<&User>) {
-        let diff_deployed_stations = current.deployed_stations.len() as f64
-            - previous.map_or(0.0, |user| user.deployed_stations.len() as f64);
+        let diff_deployed_stations = current.get_num_deployed_stations() as f64
+            - previous.map_or(0.0, |user| user.get_num_deployed_stations() as f64);
 
         let current_total = self.get(SERVICE_NAME);
 
@@ -135,7 +135,7 @@ impl ApplicationMetric<User> for MetricDeployedStations {
 
         self.set(
             SERVICE_NAME,
-            current_total.sub(model.deployed_stations.len() as f64),
+            current_total.sub(model.get_num_deployed_stations() as f64),
         );
     }
 }
@@ -270,10 +270,8 @@ mod tests {
             name: "Main Station".to_string(),
             labels: Vec::new(),
         }];
-        user.deployed_stations = vec![
-            Principal::from_slice(&[1; 29]),
-            Principal::from_slice(&[2; 29]),
-        ];
+        user.add_deployed_station(Principal::from_slice(&[1; 29]));
+        user.add_deployed_station(Principal::from_slice(&[2; 29]));
         user.subscription_status = UserSubscriptionStatus::Approved;
         let status = user.subscription_status.to_string();
 
@@ -305,10 +303,8 @@ mod tests {
             name: "Main Station".to_string(),
             labels: Vec::new(),
         }];
-        user.deployed_stations = vec![
-            Principal::from_slice(&[1; 29]),
-            Principal::from_slice(&[2; 29]),
-        ];
+        user.add_deployed_station(Principal::from_slice(&[1; 29]));
+        user.add_deployed_station(Principal::from_slice(&[2; 29]));
         user.subscription_status = UserSubscriptionStatus::Approved;
         let status = user.subscription_status.to_string();
 
@@ -320,7 +316,7 @@ mod tests {
             name: "Main Station".to_string(),
             labels: Vec::new(),
         }];
-        user2.deployed_stations = vec![Principal::from_slice(&[1; 29])];
+        user2.add_deployed_station(Principal::from_slice(&[1; 29]));
         user2.subscription_status = UserSubscriptionStatus::Pending("email".to_string());
         let status2 = user2.subscription_status.to_string();
 
@@ -360,10 +356,8 @@ mod tests {
             name: "Main Station".to_string(),
             labels: Vec::new(),
         }];
-        user.deployed_stations = vec![
-            Principal::from_slice(&[1; 29]),
-            Principal::from_slice(&[2; 29]),
-        ];
+        user.add_deployed_station(Principal::from_slice(&[1; 29]));
+        user.add_deployed_station(Principal::from_slice(&[2; 29]));
         user.subscription_status = UserSubscriptionStatus::Approved;
         let status = user.subscription_status.to_string();
 
@@ -388,11 +382,7 @@ mod tests {
                 labels: Vec::new(),
             },
         ];
-        user.deployed_stations = vec![
-            Principal::from_slice(&[1; 29]),
-            Principal::from_slice(&[2; 29]),
-            Principal::from_slice(&[3; 29]),
-        ];
+        user.add_deployed_station(Principal::from_slice(&[3; 29]));
         user.subscription_status = UserSubscriptionStatus::Pending("test@email.com".to_string());
         let new_status = user.subscription_status.to_string();
 

--- a/core/control-panel/impl/src/mappers/user.rs
+++ b/core/control-panel/impl/src/mappers/user.rs
@@ -1,46 +1,14 @@
 use crate::{
-    core::ic_cdk::next_time,
     errors::UserError,
     models::{CanDeployStation, User, UserSubscriptionStatus},
 };
-use candid::Principal;
 use control_panel_api::{
-    CanDeployStationResponse, RegisterUserInput, SubscribedUserDTO, UserDTO,
-    UserSubscriptionStatusDTO,
+    CanDeployStationResponse, SubscribedUserDTO, UserDTO, UserSubscriptionStatusDTO,
 };
 use orbit_essentials::api::ApiError;
-use orbit_essentials::types::UUID;
 use orbit_essentials::utils::timestamp_to_rfc3339;
 
 pub type SubscribedUser = SubscribedUserDTO;
-
-#[derive(Default)]
-pub struct UserMapper {}
-
-impl UserMapper {
-    /// Maps the registration input to an user entity.
-    pub fn from_register_input(
-        new_user_id: UUID,
-        input: RegisterUserInput,
-        user_identity: Principal,
-    ) -> User {
-        let registration_time = next_time();
-        let stations = match input.station {
-            Some(station) => vec![station],
-            None => vec![],
-        };
-
-        User {
-            id: new_user_id,
-            identity: user_identity,
-            subscription_status: UserSubscriptionStatus::Unsubscribed,
-            stations: stations.into_iter().map(|station| station.into()).collect(),
-            deployed_stations: vec![],
-            last_active: registration_time,
-            last_update_timestamp: registration_time,
-        }
-    }
-}
 
 impl From<User> for UserDTO {
     fn from(user: User) -> Self {
@@ -96,7 +64,8 @@ impl From<CanDeployStation> for CanDeployStationResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use control_panel_api::UserStationDTO;
+    use candid::Principal;
+    use control_panel_api::{RegisterUserInput, UserStationDTO};
 
     #[test]
     fn mapped_user_registration_with_no_station() {
@@ -104,7 +73,7 @@ mod tests {
         let user_identity = Principal::from_slice(&[u8::MAX; 29]);
         let input = RegisterUserInput { station: None };
 
-        let user = UserMapper::from_register_input(user_id, input, user_identity);
+        let user = User::new_from_register_input(user_id, input, user_identity);
 
         assert_eq!(user.id, user_id);
         assert_eq!(user.identity, user_identity);
@@ -124,7 +93,7 @@ mod tests {
             }),
         };
 
-        let user = UserMapper::from_register_input(user_id, input, user_identity);
+        let user = User::new_from_register_input(user_id, input, user_identity);
 
         assert_eq!(user.id, user_id);
         assert_eq!(user.identity, user_identity);

--- a/core/control-panel/impl/src/models/user.rs
+++ b/core/control-panel/impl/src/models/user.rs
@@ -1,6 +1,9 @@
 use super::UserStation;
+use crate::core::ic_cdk::api::time;
+use crate::core::ic_cdk::next_time;
 use crate::errors::UserError;
 use candid::Principal;
+use control_panel_api::RegisterUserInput;
 use email_address::EmailAddress;
 use orbit_essentials::model::ModelKey;
 use orbit_essentials::storable;
@@ -26,7 +29,7 @@ pub enum UserSubscriptionStatus {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum CanDeployStation {
     NotAllowed(UserSubscriptionStatus),
-    Allowed(usize),
+    Allowed(u64),
     QuotaExceeded,
 }
 
@@ -39,6 +42,13 @@ impl std::fmt::Display for UserSubscriptionStatus {
             UserSubscriptionStatus::Denylisted => write!(f, "denylisted"),
         }
     }
+}
+
+#[storable]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct UserRateLimiter {
+    pub unix_date: u64,
+    pub num_deployed_stations: u64,
 }
 
 /// The identity of an user.
@@ -57,7 +67,10 @@ pub struct User {
     pub stations: Vec<UserStation>,
     /// The stations that have ever been deployed for the user by the control panel.
     /// Used to bound the total number of stations a user could deploy via the control panel.
-    pub deployed_stations: Vec<Principal>,
+    deployed_stations: Vec<Principal>,
+    /// Used to rate limit the number of deployed stations per user by the control panel.
+    #[serde(default)]
+    user_rate_limiter: UserRateLimiter,
     /// The timestamp of last time the user was active.
     pub last_active: Timestamp,
     /// Last time the identity was updated.
@@ -78,10 +91,29 @@ impl User {
     pub const NAME_LEN_RANGE: (u8, u8) = (1, 100);
     pub const EMAIL_LEN_RANGE: (u8, u8) = (1, 100);
     pub const MAX_STATIONS: u8 = 15;
-    pub const MAX_DEPLOYED_STATIONS: u8 = 3;
+    pub const MAX_DEPLOYED_STATIONS_PER_DAY: u64 = 2;
 
     pub fn to_key(&self) -> UserKey {
         UserKey(self.id)
+    }
+
+    pub fn get_num_deployed_stations(&self) -> usize {
+        self.deployed_stations.len()
+    }
+
+    pub fn get_deployed_stations(&self) -> Vec<Principal> {
+        self.deployed_stations.clone()
+    }
+
+    pub fn add_deployed_station(&mut self, station: Principal) {
+        self.deployed_stations.push(station);
+        let current_unix_date = time() / 86_400_000_000_000;
+        if self.user_rate_limiter.unix_date == current_unix_date {
+            self.user_rate_limiter.num_deployed_stations += 1;
+        } else {
+            self.user_rate_limiter.unix_date = current_unix_date;
+            self.user_rate_limiter.num_deployed_stations = 1;
+        }
     }
 
     pub fn can_deploy_station(&self) -> CanDeployStation {
@@ -93,11 +125,42 @@ impl User {
                 return CanDeployStation::NotAllowed(self.subscription_status.clone());
             }
         };
-        let max_deployed_stations: usize = Self::MAX_DEPLOYED_STATIONS.into();
-        if self.deployed_stations.len() >= max_deployed_stations {
-            return CanDeployStation::QuotaExceeded;
+        let current_unix_date = time() / 86_400_000_000_000;
+        if self.user_rate_limiter.unix_date == current_unix_date {
+            if self.user_rate_limiter.num_deployed_stations >= Self::MAX_DEPLOYED_STATIONS_PER_DAY {
+                CanDeployStation::QuotaExceeded
+            } else {
+                CanDeployStation::Allowed(
+                    Self::MAX_DEPLOYED_STATIONS_PER_DAY
+                        - self.user_rate_limiter.num_deployed_stations,
+                )
+            }
+        } else {
+            CanDeployStation::Allowed(Self::MAX_DEPLOYED_STATIONS_PER_DAY)
         }
-        CanDeployStation::Allowed(max_deployed_stations - self.deployed_stations.len())
+    }
+
+    pub fn new_from_register_input(
+        new_user_id: UUID,
+        input: RegisterUserInput,
+        user_identity: Principal,
+    ) -> User {
+        let registration_time = next_time();
+        let stations = match input.station {
+            Some(station) => vec![station],
+            None => vec![],
+        };
+
+        User {
+            id: new_user_id,
+            identity: user_identity,
+            subscription_status: UserSubscriptionStatus::Unsubscribed,
+            stations: stations.into_iter().map(|station| station.into()).collect(),
+            deployed_stations: vec![],
+            user_rate_limiter: UserRateLimiter::default(),
+            last_active: registration_time,
+            last_update_timestamp: registration_time,
+        }
     }
 }
 
@@ -227,6 +290,7 @@ mod tests {
 pub mod user_model_utils {
     use super::{User, UserSubscriptionStatus};
     use crate::core::test_utils;
+    use crate::models::UserRateLimiter;
     use uuid::Uuid;
 
     pub fn mock_user() -> User {
@@ -236,6 +300,7 @@ pub mod user_model_utils {
             subscription_status: UserSubscriptionStatus::Unsubscribed,
             stations: vec![],
             deployed_stations: vec![],
+            user_rate_limiter: UserRateLimiter::default(),
             last_active: 0,
             last_update_timestamp: 0,
         }

--- a/core/control-panel/impl/src/models/user.rs
+++ b/core/control-panel/impl/src/models/user.rs
@@ -29,7 +29,7 @@ pub enum UserSubscriptionStatus {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum CanDeployStation {
     NotAllowed(UserSubscriptionStatus),
-    Allowed(u64),
+    Allowed(usize),
     QuotaExceeded,
 }
 
@@ -48,7 +48,7 @@ impl std::fmt::Display for UserSubscriptionStatus {
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct UserRateLimiter {
     pub unix_date: u64,
-    pub num_deployed_stations: u64,
+    pub num_deployed_stations: usize,
 }
 
 /// The identity of an user.
@@ -91,7 +91,7 @@ impl User {
     pub const NAME_LEN_RANGE: (u8, u8) = (1, 100);
     pub const EMAIL_LEN_RANGE: (u8, u8) = (1, 100);
     pub const MAX_STATIONS: u8 = 15;
-    pub const MAX_DEPLOYED_STATIONS_PER_DAY: u64 = 2;
+    pub const MAX_DEPLOYED_STATIONS_PER_DAY: usize = 2;
 
     pub fn to_key(&self) -> UserKey {
         UserKey(self.id)

--- a/core/control-panel/impl/src/services/canister.rs
+++ b/core/control-panel/impl/src/services/canister.rs
@@ -95,11 +95,13 @@ impl CanisterService {
         let deployed_stations = users
             .iter()
             .flat_map(|user| {
-                user.deployed_stations.iter().filter(|canister_id| {
-                    user.stations
-                        .iter()
-                        .any(|station| station.canister_id == **canister_id)
-                })
+                user.get_deployed_stations()
+                    .into_iter()
+                    .filter(|canister_id| {
+                        user.stations
+                            .iter()
+                            .any(|station| station.canister_id == *canister_id)
+                    })
             })
             .collect::<HashSet<_>>();
 
@@ -118,7 +120,7 @@ impl CanisterService {
 
             for canister_id in deployed_stations {
                 fund_manager.register(
-                    *canister_id,
+                    canister_id,
                     RegisterOpts::new().with_cycles_fetcher(self.create_station_cycles_fetcher()),
                 );
             }

--- a/core/control-panel/impl/src/services/user.rs
+++ b/core/control-panel/impl/src/services/user.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{generate_uuid_v4, ic_cdk::next_time, CallContext},
     errors::UserError,
-    mappers::{SubscribedUser, UserMapper},
+    mappers::SubscribedUser,
     models::{CanDeployStation, User, UserId, UserKey, UserSubscriptionStatus},
     repositories::{UserRepository, USER_REPOSITORY},
     services::canister::FUND_MANAGER,
@@ -98,8 +98,7 @@ impl UserService {
 
         let user_id = generate_uuid_v4().await;
         let user_identity = ctx.caller();
-        let user =
-            UserMapper::from_register_input(*user_id.as_bytes(), input.clone(), user_identity);
+        let user = User::new_from_register_input(*user_id.as_bytes(), input.clone(), user_identity);
 
         user.validate()?;
         self.user_repository.insert(UserKey(user.id), user.clone());
@@ -181,7 +180,7 @@ impl UserService {
 
         users
             .into_iter()
-            .flat_map(|user| user.deployed_stations)
+            .flat_map(|user| user.get_deployed_stations())
             .collect()
     }
 
@@ -193,7 +192,7 @@ impl UserService {
     ) -> ServiceResult<User> {
         let mut user = self.get_user(user_id, ctx)?;
 
-        user.deployed_stations.push(station_canister_id);
+        user.add_deployed_station(station_canister_id);
 
         user.validate()?;
 

--- a/tests/integration/src/control_panel_tests.rs
+++ b/tests/integration/src/control_panel_tests.rs
@@ -5,9 +5,10 @@ use crate::utils::{
 use crate::TestEnv;
 use candid::Principal;
 use control_panel_api::{
-    AssociateWithCallerInput, DeployStationAdminUserInput, DeployStationInput,
-    DeployStationResponse, ListUserStationsInput, ManageUserStationsInput, RegisterUserInput,
-    RegisterUserResponse, UpdateWaitingListInput, UserStationDTO, UserSubscriptionStatusDTO,
+    AssociateWithCallerInput, CanDeployStationResponse, DeployStationAdminUserInput,
+    DeployStationInput, DeployStationResponse, ListUserStationsInput, ManageUserStationsInput,
+    RegisterUserInput, RegisterUserResponse, UpdateWaitingListInput, UserStationDTO,
+    UserSubscriptionStatusDTO,
 };
 use control_panel_api::{ListUserStationsResponse, UploadCanisterModulesInput};
 use orbit_essentials::api::ApiResult;
@@ -350,9 +351,70 @@ fn deploy_too_many_stations() {
 
     // deploy the maximum amount of user stations
     let mut stations = vec![];
-    for i in 0..3 {
+    for day in 0..2 {
+        for i in 0..2 {
+            let deploy_station_args = DeployStationInput {
+                name: format!("station_{}_{}", day, i),
+                admins: vec![DeployStationAdminUserInput {
+                    identity: user_id,
+                    username: "admin".to_string(),
+                }],
+                associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
+                subnet_selection: None,
+            };
+
+            let res: (ApiResult<CanDeployStationResponse>,) = update_candid_as(
+                &env,
+                canister_ids.control_panel,
+                user_id,
+                "can_deploy_station",
+                ((),),
+            )
+            .unwrap();
+            assert!(
+                matches!(res.0.unwrap(), CanDeployStationResponse::Allowed(remaining) if remaining == 2 - i)
+            );
+
+            let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
+                &env,
+                canister_ids.control_panel,
+                user_id,
+                "deploy_station",
+                (deploy_station_args,),
+            )
+            .unwrap();
+            stations.push(res.0.unwrap().canister_id);
+        }
+
+        // check that the user has 2 more stations and the first deployed station is the main station
+        let res: (ApiResult<ListUserStationsResponse>,) = update_candid_as(
+            &env,
+            canister_ids.control_panel,
+            user_id,
+            "list_user_stations",
+            (ListUserStationsInput {
+                filter_by_labels: None,
+            },),
+        )
+        .unwrap();
+        let associated_stations = res.0.unwrap().stations;
+        assert_eq!(associated_stations.len(), day + 2);
+        assert_eq!(associated_stations[0].canister_id, stations[0]);
+
+        // reset all but one deployed station
+        let manage_user_stations_args = ManageUserStationsInput::Remove(stations[1..].to_vec());
+        let res: (ApiResult<()>,) = update_candid_as(
+            &env,
+            canister_ids.control_panel,
+            user_id,
+            "manage_user_stations",
+            (manage_user_stations_args,),
+        )
+        .unwrap();
+        assert!(res.0.is_ok());
+
         let deploy_station_args = DeployStationInput {
-            name: format!("station_{}", i),
+            name: format!("last_station_{}", day),
             admins: vec![DeployStationAdminUserInput {
                 identity: user_id,
                 username: "admin".to_string(),
@@ -361,6 +423,7 @@ fn deploy_too_many_stations() {
             subnet_selection: None,
         };
 
+        // deploying an additional station should fail nonetheless
         let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
             &env,
             canister_ids.control_panel,
@@ -369,56 +432,11 @@ fn deploy_too_many_stations() {
             (deploy_station_args,),
         )
         .unwrap();
-        stations.push(res.0.unwrap().canister_id);
+        assert_eq!(res.0.unwrap_err().code, "DEPLOY_STATION_QUOTA_EXCEEDED");
+
+        // tomorrow the user should again be able to deploy stations
+        env.advance_time(std::time::Duration::from_secs(86400));
     }
-
-    // check that the user has 3 stations and the first deployed station is the main station
-    let res: (ApiResult<ListUserStationsResponse>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "list_user_stations",
-        (ListUserStationsInput {
-            filter_by_labels: None,
-        },),
-    )
-    .unwrap();
-    let associated_stations = res.0.unwrap().stations;
-    assert_eq!(associated_stations.len(), 3);
-    assert_eq!(associated_stations[0].canister_id, stations[0]);
-
-    // reset all but one deployed station
-    let manage_user_stations_args = ManageUserStationsInput::Remove(stations[1..].to_vec());
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "manage_user_stations",
-        (manage_user_stations_args,),
-    )
-    .unwrap();
-    assert!(res.0.is_ok());
-
-    let deploy_station_args = DeployStationInput {
-        name: "last_station".to_string(),
-        admins: vec![DeployStationAdminUserInput {
-            identity: user_id,
-            username: "admin".to_string(),
-        }],
-        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
-        subnet_selection: None,
-    };
-
-    // deploying an additional station should fail nonetheless
-    let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "deploy_station",
-        (deploy_station_args,),
-    )
-    .unwrap();
-    assert_eq!(res.0.unwrap_err().code, "DEPLOY_STATION_QUOTA_EXCEEDED");
 }
 
 #[test]


### PR DESCRIPTION
This PR updates the rate limiting policy in the control panel to allow every user to deploy 2 stations per day (instead of 3 stations in total).