### PR TITLE
feat(control-panel): remove waiting list

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact/merge@v4
         with:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz
@@ -108,7 +108,7 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact/merge@v4
         with:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz
@@ -108,7 +108,7 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,6 @@ jobs:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz
           retention-days: 10
-          if-no-files-found: error
   download-canisters:
     name: Download Canister
     runs-on: ubuntu-latest
@@ -113,7 +112,6 @@ jobs:
           name: integration-tests
           path: artifacts/${{ matrix.canister }}.wasm.gz
           retention-days: 10
-          if-no-files-found: error
   integration-tests:
     name: 'integration-tests:required'
     needs: [build-wasms, download-canisters]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,11 +78,12 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact@v4
         with:
-          name: integration-tests
-          pattern: artifacts/${{ matrix.canister }}.wasm.gz
+          name: integration-tests-${{ matrix.canister }}
+          path: artifacts/${{ matrix.canister }}.wasm.gz
           retention-days: 10
+          if-no-files-found: error
   download-canisters:
     name: Download Canister
     runs-on: ubuntu-latest
@@ -107,14 +108,24 @@ jobs:
           mkdir -p artifacts
           mv tests/integration/wasms/* artifacts
       - name: 'Upload Artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-${{ matrix.canister }}
+          path: artifacts/${{ matrix.canister }}.wasm.gz
+          retention-days: 10
+          if-no-files-found: error
+  merge-artifacts:
+    runs-on: ubuntu-latest
+    needs: [build-wasms, download-canisters]
+    steps:
+      - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
           name: integration-tests
-          pattern: artifacts/${{ matrix.canister }}.wasm.gz
-          retention-days: 10
+          pattern: integration-tests-*
   integration-tests:
     name: 'integration-tests:required'
-    needs: [build-wasms, download-canisters]
+    needs: [merge-artifacts]
     runs-on: ubuntu-latest
     env:
       BUILD_WASMS: 'false'
@@ -125,7 +136,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: 'Download Artifacts'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integration-tests
           path: tests/integration/wasms

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           name: integration-tests
-          path: artifacts/${{ matrix.canister }}.wasm.gz
+          pattern: artifacts/${{ matrix.canister }}.wasm.gz
           retention-days: 10
   download-canisters:
     name: Download Canister
@@ -110,7 +110,7 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           name: integration-tests
-          path: artifacts/${{ matrix.canister }}.wasm.gz
+          pattern: artifacts/${{ matrix.canister }}.wasm.gz
           retention-days: 10
   integration-tests:
     name: 'integration-tests:required'

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY package.json .
 RUN eval "$(fnm env)" && \
     fnm install && \
     fnm use && \
+    npm install -g corepack@0.31.0 && \
     corepack enable && \
     fnm alias default production
 # Install the monorepo dependencies

--- a/apps/wallet/src/components/add-station/DeployStation.spec.ts
+++ b/apps/wallet/src/components/add-station/DeployStation.spec.ts
@@ -77,29 +77,6 @@ describe('DeployStation', () => {
     expect(wrapper.find('[data-test-id="deploy-check-error"]').exists()).toBe(true);
   });
 
-  it('will show the waitlist screen if the user is not on the waitlist', async () => {
-    vi.spyOn(services().controlPanel, 'canDeployStation').mockResolvedValueOnce({
-      NotAllowed: { Unsubscribed: null },
-    } as CanDeployStationResponse);
-    const wrapper = mount(DeployStation);
-
-    await flushPromises();
-
-    expect(wrapper.find('[data-test-id="join-waitlist-form"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test-id="join-waitlist-form-email"]').exists()).toBe(true);
-  });
-
-  it("will show the pending screen if the user's waitlist status is still pending", async () => {
-    vi.spyOn(services().controlPanel, 'canDeployStation').mockResolvedValueOnce({
-      NotAllowed: { Pending: null },
-    } as CanDeployStationResponse);
-    const wrapper = mount(DeployStation);
-
-    await flushPromises();
-
-    expect(wrapper.find('[data-test-id="deploy-in-waiting-list"]').exists()).toBe(true);
-  });
-
   it("will show the denied screen if the user's waitlist status is denied", async () => {
     vi.spyOn(services().controlPanel, 'canDeployStation').mockResolvedValueOnce({
       NotAllowed: { Denylisted: null },

--- a/apps/wallet/src/generated/control-panel/control_panel.did
+++ b/apps/wallet/src/generated/control-panel/control_panel.did
@@ -73,47 +73,11 @@ type ManageUserStationsResult = variant {
   Err : ApiError;
 };
 
-// The result of subscribing to the waiting list.
-type SubscribeToWaitingListResult = variant {
-  // Successfull operation result.
-  Ok;
-  // The error that occurred during the operation.
-  Err : ApiError;
-};
-
 type UserSubscriptionStatus = variant {
   Unsubscribed;
   Pending;
   Approved;
   Denylisted;
-};
-
-type SubscribedUser = record {
-  user_principal : principal;
-  email : text;
-};
-
-type GetWaitingListResponse = record {
-  subscribed_users : vec SubscribedUser;
-};
-
-type GetWaitingListResult = variant {
-  // Successfull operation result.
-  Ok : GetWaitingListResponse;
-  // The error that occurred during the operation.
-  Err : ApiError;
-};
-
-type UpdateWaitingListInput = record {
-  users : vec principal;
-  new_status : UserSubscriptionStatus;
-};
-
-type UpdateWaitingListResult = variant {
-  // Successfull operation result.
-  Ok;
-  // The error that occurred during the operation.
-  Err : ApiError;
 };
 
 // The station information associated with the user.
@@ -679,13 +643,6 @@ service : () -> {
   set_user_active : () -> (SetUserActiveResult);
   // Get the user information for the caller.
   get_user : () -> (GetUserResult) query;
-  // Subscribe the user associated with the caller to the waiting list.
-  // Takes the user's e-mail address to which notifications can be pushed.
-  subscribe_to_waiting_list : (text) -> (SubscribeToWaitingListResult);
-  // Retrieves the users (principal and e-mail address) subscribed to the waiting list.
-  get_waiting_list : () -> (GetWaitingListResult);
-  // Updates the status of users on the waiting list.
-  update_waiting_list : (input : UpdateWaitingListInput) -> (UpdateWaitingListResult);
   // Create a new user for the caller.
   register_user : (input : RegisterUserInput) -> (RegisterUserResult);
   // Delete user associated with the caller.

--- a/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
@@ -58,11 +58,6 @@ export type GetRegistryEntryResult = { 'Ok' : GetRegistryEntryResponse } |
   { 'Err' : ApiError };
 export type GetUserResult = { 'Ok' : { 'user' : User } } |
   { 'Err' : ApiError };
-export interface GetWaitingListResponse {
-  'subscribed_users' : Array<SubscribedUser>,
-}
-export type GetWaitingListResult = { 'Ok' : GetWaitingListResponse } |
-  { 'Err' : ApiError };
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -167,20 +162,8 @@ export type StationID = Principal;
 export interface SubnetFilter { 'subnet_type' : [] | [string] }
 export type SubnetSelection = { 'Filter' : SubnetFilter } |
   { 'Subnet' : { 'subnet' : Principal } };
-export type SubscribeToWaitingListResult = { 'Ok' : null } |
-  { 'Err' : ApiError };
-export interface SubscribedUser {
-  'user_principal' : Principal,
-  'email' : string,
-}
 export type TimestampRFC3339 = string;
 export type UUID = string;
-export interface UpdateWaitingListInput {
-  'users' : Array<Principal>,
-  'new_status' : UserSubscriptionStatus,
-}
-export type UpdateWaitingListResult = { 'Ok' : null } |
-  { 'Err' : ApiError };
 export interface UploadCanisterModulesInput {
   'station_wasm_module_extra_chunks' : [] | [[] | [WasmModuleExtraChunks]],
   'station_wasm_module' : [] | [Uint8Array | number[]],
@@ -247,7 +230,6 @@ export interface _SERVICE {
     GetRegistryEntryResult
   >,
   'get_user' : ActorMethod<[], GetUserResult>,
-  'get_waiting_list' : ActorMethod<[], GetWaitingListResult>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'list_user_stations' : ActorMethod<
     [ListUserStationsInput],
@@ -264,14 +246,6 @@ export interface _SERVICE {
   'register_user' : ActorMethod<[RegisterUserInput], RegisterUserResult>,
   'search_registry' : ActorMethod<[SearchRegistryInput], SearchRegistryResult>,
   'set_user_active' : ActorMethod<[], SetUserActiveResult>,
-  'subscribe_to_waiting_list' : ActorMethod<
-    [string],
-    SubscribeToWaitingListResult
-  >,
-  'update_waiting_list' : ActorMethod<
-    [UpdateWaitingListInput],
-    UpdateWaitingListResult
-  >,
   'upload_canister_modules' : ActorMethod<
     [UploadCanisterModulesInput],
     UploadUploadCanisterModulesInputResult

--- a/apps/wallet/src/generated/control-panel/control_panel.did.js
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.js
@@ -151,17 +151,6 @@ export const idlFactory = ({ IDL }) => {
     'Ok' : IDL.Record({ 'user' : User }),
     'Err' : ApiError,
   });
-  const SubscribedUser = IDL.Record({
-    'user_principal' : IDL.Principal,
-    'email' : IDL.Text,
-  });
-  const GetWaitingListResponse = IDL.Record({
-    'subscribed_users' : IDL.Vec(SubscribedUser),
-  });
-  const GetWaitingListResult = IDL.Variant({
-    'Ok' : GetWaitingListResponse,
-    'Err' : ApiError,
-  });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
@@ -246,18 +235,6 @@ export const idlFactory = ({ IDL }) => {
     'Ok' : IDL.Null,
     'Err' : ApiError,
   });
-  const SubscribeToWaitingListResult = IDL.Variant({
-    'Ok' : IDL.Null,
-    'Err' : ApiError,
-  });
-  const UpdateWaitingListInput = IDL.Record({
-    'users' : IDL.Vec(IDL.Principal),
-    'new_status' : UserSubscriptionStatus,
-  });
-  const UpdateWaitingListResult = IDL.Variant({
-    'Ok' : IDL.Null,
-    'Err' : ApiError,
-  });
   const UploadCanisterModulesInput = IDL.Record({
     'station_wasm_module_extra_chunks' : IDL.Opt(
       IDL.Opt(WasmModuleExtraChunks)
@@ -303,7 +280,6 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_user' : IDL.Func([], [GetUserResult], ['query']),
-    'get_waiting_list' : IDL.Func([], [GetWaitingListResult], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'list_user_stations' : IDL.Func(
         [ListUserStationsInput],
@@ -327,16 +303,6 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'set_user_active' : IDL.Func([], [SetUserActiveResult], []),
-    'subscribe_to_waiting_list' : IDL.Func(
-        [IDL.Text],
-        [SubscribeToWaitingListResult],
-        [],
-      ),
-    'update_waiting_list' : IDL.Func(
-        [UpdateWaitingListInput],
-        [UpdateWaitingListResult],
-        [],
-      ),
     'upload_canister_modules' : IDL.Func(
         [UploadCanisterModulesInput],
         [UploadUploadCanisterModulesInputResult],

--- a/apps/wallet/src/locales/en.locale.ts
+++ b/apps/wallet/src/locales/en.locale.ts
@@ -950,25 +950,16 @@ export default {
       station_name_field: 'Wallet Name',
       admin_name_field: 'Your username',
 
-      check_permissions_title: 'Checking waiting list status...',
-      join_waitlist_title: 'Join waiting list',
-      join_waitlist_body:
-        "Join Orbit's waiting list! Enter your email to get early access and exclusive updates. Your journey starts now.",
-      join_waitlist_email_field: 'Enter your email address',
-      join_waitlist: 'Sign up now',
-
-      waitlist_pending_title: 'You are on the waiting list!',
-      waitlist_pending_body:
-        'Please wait for the approval. You will receive an email once your request is approved.',
-
-      waitlist_check_error_title: 'Failed to check waiting list status',
-      waitlist_check_error_body: 'Failed to check waiting list status, please try again.',
+      check_permissions_title: 'Checking deployment eligibility...',
 
       quota_exceed_error_title: 'Quota exceeded',
       quota_exceed_error_body: 'You have reached the maximum number of wallets you can create.',
 
       waitlist_denied_title: "You've been denied access.",
-      waitlist_denied_body: 'Unfortunately, you are not eligible to join the waiting list.',
+      waitlist_denied_body: 'Unfortunately, you are not eligible to deploy a wallet.',
+
+      deployment_check_error_title: 'Failed to check deployment eligibility',
+      deployment_check_error_body: 'Failed to check deployment eligibility, please try again.',
 
       status_starting: 'Initializing, please wait ...',
       status_deploying: 'Deploying your wallet to the Internet Computer ...',

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -950,12 +950,12 @@ export default {
       add_station_title: 'Comment aimeriez-vous ajouter un portefeuille?',
       option_join_existing_station: 'Rejoindre un portefeuille existant',
       option_deploy_new_station: 'Déployer un nouveau portefeuille',
-      check_permissions_title: 'Vérification du statut de la liste d attente...',
-      join_waitlist_title: 'Rejoindre la liste d attente',
-      join_waitlist_body:
-        "Rejoignez la liste d'attente d'Orbit! Entrez votre email pour obtenir un accès anticipé et des mises à jour exclusives. Votre voyage commence maintenant.",
-      join_waitlist_email_field: 'Entrez votre adresse e-mail',
-      join_waitlist: "S'inscrire maintenant",
+      join_station_title: 'Rejoindre un portefeuille existant',
+      join_station_body:
+        "Contactez le propriétaire pour obtenir l'ID du portefeuille et envoyez-lui votre identité afin qu'un utilisateur puisse être créé pour vous.",
+      join_station_canister_id: 'ID du Portefeuille',
+      join_station_name: 'Nom du Portefeuille',
+      join_station: 'Rejoindre le portefeuille',
 
       station_title: 'Créer un portefeuille',
       station_body:
@@ -963,26 +963,19 @@ export default {
       station_name_field: 'Nom du Portefeuille',
       admin_name_field: "Ton nom d'utilisateur",
 
-      waitlist_pending_title: 'Vous êtes sur la liste d attente!',
-      waitlist_pending_body:
-        'Veuillez attendre l approbation. Vous recevrez un email une fois votre demande approuvée.',
-      waitlist_denied_title: 'Vous avez été refusé l accès.',
-      waitlist_denied_body:
-        'Malheureusement, vous n êtes pas éligible pour rejoindre la liste d attente.',
-
-      waitlist_check_error_title: 'Échec de vérification du statut de la liste d attente',
-      waitlist_check_error_body:
-        "Échec de la vérification du statut de la liste d'attente, veuillez réessayer.",
+      check_permissions_title: "Vérification de l'éligibilité au déploiement...",
 
       quota_exceed_error_title: 'Quota dépassé',
-      quota_exceed_error_body: 'Le nombre maximum de portefeuilles a été atteint.',
+      quota_exceed_error_body:
+        'Vous avez atteint le nombre maximum de portefeuilles que vous pouvez créer.',
 
-      join_station_title: 'Rejoindre un portefeuille existant',
-      join_station_body:
-        "Contactez le propriétaire pour obtenir l'ID du portefeuille et envoyez-lui votre identité afin qu'un utilisateur puisse être créé pour vous.",
-      join_station_canister_id: 'ID du Portefeuille',
-      join_station_name: 'Nom du Portefeuille',
-      join_station: 'Rejoindre le portefeuille',
+      waitlist_denied_title: 'Accès refusé.',
+      waitlist_denied_body:
+        "Malheureusement, vous n'êtes pas éligible pour déployer un portefeuille.",
+
+      deployment_check_error_title: "Échec de la vérification d'éligibilité au déploiement",
+      deployment_check_error_body:
+        "Échec de la vérification d'éligibilité au déploiement, veuillez réessayer.",
 
       status_starting: 'Initialization, veuillez patienter...',
       status_deploying: 'Deploiement de votre portefeuille au Internet Computer ...',

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -958,25 +958,17 @@ export default {
       station_name_field: 'Nome da carteira',
       admin_name_field: 'Seu nome de usuário',
 
-      check_permissions_title: 'Verificando o estado da lista de espera ...',
-      join_waitlist_title: 'Junte-se à lista de espera',
-      join_waitlist_body:
-        'Junte-se à lista de espera da Orbit! Insira o seu email para obter acesso antecipado e atualizações exclusivas. A sua jornada começa agora.',
-      join_waitlist_email_field: 'Insira o seu endereço de email',
-      join_waitlist: 'Inscreva-se agora',
-
-      waitlist_pending_title: 'Você está na lista de espera!',
-      waitlist_pending_body:
-        'Por favor, aguarde a aprovação. Você receberá um email assim que o seu pedido for aprovado.',
-      waitlist_denied_title: 'Você foi negado o acesso.',
-      waitlist_denied_body: 'Infelizmente, você não é elegível para se juntar à lista de espera.',
-
-      waitlist_check_error_title: 'Falha ao verificar o estado da lista de espera',
-      waitlist_check_error_body:
-        'Falha ao verificar o estado da lista de espera, por favor, tente novamente.',
+      check_permissions_title: 'Verificando a elegibilidade para o deployment...',
 
       quota_exceed_error_title: 'Limite de carteiras excedido',
       quota_exceed_error_body: 'Você atingiu o limite de carteiras que pode criar.',
+
+      waitlist_denied_title: 'Você foi negado o acesso.',
+      waitlist_denied_body: 'Infelizmente, você não é elegível para se juntar à lista de espera.',
+
+      deployment_check_error_title: 'Erro ao verificar a elegibilidade para o deployment',
+      deployment_check_error_body:
+        'Erro ao verificar a elegibilidade para o deployment, por favor, tente novamente.',
 
       status_starting: 'Inicializando, por favor, aguarde ...',
       status_deploying: 'Instalando a sua carteira no Internet Computer ...',

--- a/apps/wallet/src/services/control-panel.service.ts
+++ b/apps/wallet/src/services/control-panel.service.ts
@@ -54,14 +54,6 @@ export class ControlPanelService {
     return result.Ok.user;
   }
 
-  async subscribeToWaitlist(email: string): Promise<void> {
-    const result = await this.actor.subscribe_to_waiting_list(email);
-
-    if (variantIs(result, 'Err')) {
-      throw result.Err;
-    }
-  }
-
   async hasRegistration(verifiedCall = false): Promise<boolean> {
     return await this.getCurrentUser(verifiedCall)
       .then(_ => true)

--- a/core/control-panel/api/spec.did
+++ b/core/control-panel/api/spec.did
@@ -73,47 +73,11 @@ type ManageUserStationsResult = variant {
   Err : ApiError;
 };
 
-// The result of subscribing to the waiting list.
-type SubscribeToWaitingListResult = variant {
-  // Successfull operation result.
-  Ok;
-  // The error that occurred during the operation.
-  Err : ApiError;
-};
-
 type UserSubscriptionStatus = variant {
   Unsubscribed;
   Pending;
   Approved;
   Denylisted;
-};
-
-type SubscribedUser = record {
-  user_principal : principal;
-  email : text;
-};
-
-type GetWaitingListResponse = record {
-  subscribed_users : vec SubscribedUser;
-};
-
-type GetWaitingListResult = variant {
-  // Successfull operation result.
-  Ok : GetWaitingListResponse;
-  // The error that occurred during the operation.
-  Err : ApiError;
-};
-
-type UpdateWaitingListInput = record {
-  users : vec principal;
-  new_status : UserSubscriptionStatus;
-};
-
-type UpdateWaitingListResult = variant {
-  // Successfull operation result.
-  Ok;
-  // The error that occurred during the operation.
-  Err : ApiError;
 };
 
 // The station information associated with the user.
@@ -679,13 +643,6 @@ service : () -> {
   set_user_active : () -> (SetUserActiveResult);
   // Get the user information for the caller.
   get_user : () -> (GetUserResult) query;
-  // Subscribe the user associated with the caller to the waiting list.
-  // Takes the user's e-mail address to which notifications can be pushed.
-  subscribe_to_waiting_list : (text) -> (SubscribeToWaitingListResult);
-  // Retrieves the users (principal and e-mail address) subscribed to the waiting list.
-  get_waiting_list : () -> (GetWaitingListResult);
-  // Updates the status of users on the waiting list.
-  update_waiting_list : (input : UpdateWaitingListInput) -> (UpdateWaitingListResult);
   // Create a new user for the caller.
   register_user : (input : RegisterUserInput) -> (RegisterUserResult);
   // Delete user associated with the caller.

--- a/core/control-panel/api/src/user.rs
+++ b/core/control-panel/api/src/user.rs
@@ -14,17 +14,6 @@ pub struct GetUserResponse {
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct SubscribedUserDTO {
-    pub user_principal: Principal,
-    pub email: String,
-}
-
-#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct GetWaitingListResponse {
-    pub subscribed_users: Vec<SubscribedUserDTO>,
-}
-
-#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum UserSubscriptionStatusDTO {
     Unsubscribed,
     Pending,
@@ -41,10 +30,4 @@ impl std::fmt::Display for UserSubscriptionStatusDTO {
             UserSubscriptionStatusDTO::Denylisted => write!(f, "denylisted"),
         }
     }
-}
-
-#[derive(CandidType, serde::Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct UpdateWaitingListInput {
-    pub users: Vec<Principal>,
-    pub new_status: UserSubscriptionStatusDTO,
 }

--- a/core/control-panel/impl/src/controllers/canister.rs
+++ b/core/control-panel/impl/src/controllers/canister.rs
@@ -2,15 +2,13 @@
 use super::AVAILABLE_TOKENS_USER_REGISTRATION;
 use crate::core::ic_cdk::{api::set_certified_data, spawn};
 use crate::core::metrics::recompute_all_metrics;
-use crate::repositories::USER_REPOSITORY;
-use crate::services::CANISTER_SERVICE;
+use crate::services::{CANISTER_SERVICE, USER_SERVICE};
 use control_panel_api::UploadCanisterModulesInput;
 use ic_cdk_macros::{init, post_upgrade};
 use ic_cdk_timers::{set_timer, set_timer_interval};
 use orbit_essentials::api::ApiResult;
 use orbit_essentials::cdk::update;
 use orbit_essentials::http::certified_data_for_skip_certification;
-use orbit_essentials::repository::Repository;
 use std::time::Duration;
 
 pub const MINUTE: u64 = 60;
@@ -75,8 +73,8 @@ async fn post_upgrade() {
     recompute_all_metrics();
     init_timers_fn();
 
-    // deserialize all users to fail control panel upgrade in case of deserialization failures
-    let _users = USER_REPOSITORY.list();
+    // approve all users
+    USER_SERVICE.approve_all_users();
 
     CANISTER_SERVICE
         .init_canister()

--- a/core/control-panel/impl/src/core/config.rs
+++ b/core/control-panel/impl/src/core/config.rs
@@ -37,7 +37,7 @@ impl Default for CanisterConfig {
             station_wasm_module: vec![],
             station_wasm_module_extra_chunks: None,
             last_upgrade_timestamp: time(),
-            version: None,
+            version: Some(SYSTEM_VERSION.to_string()),
             global_rate_limiter: RateLimiter::new_global(),
         }
     }

--- a/core/control-panel/impl/src/mappers/mod.rs
+++ b/core/control-panel/impl/src/mappers/mod.rs
@@ -3,7 +3,6 @@
 mod artifact;
 
 mod user;
-pub use user::*;
 
 pub mod user_station;
 

--- a/core/control-panel/impl/src/mappers/user.rs
+++ b/core/control-panel/impl/src/mappers/user.rs
@@ -2,13 +2,9 @@ use crate::{
     errors::UserError,
     models::{CanDeployStation, User, UserSubscriptionStatus},
 };
-use control_panel_api::{
-    CanDeployStationResponse, SubscribedUserDTO, UserDTO, UserSubscriptionStatusDTO,
-};
+use control_panel_api::{CanDeployStationResponse, UserDTO, UserSubscriptionStatusDTO};
 use orbit_essentials::api::ApiError;
 use orbit_essentials::utils::timestamp_to_rfc3339;
-
-pub type SubscribedUser = SubscribedUserDTO;
 
 impl From<User> for UserDTO {
     fn from(user: User) -> Self {

--- a/core/control-panel/impl/src/models/user.rs
+++ b/core/control-panel/impl/src/models/user.rs
@@ -104,14 +104,6 @@ impl User {
     }
 
     pub fn can_deploy_station(&self) -> CanDeployStation {
-        match self.subscription_status {
-            UserSubscriptionStatus::Approved => (),
-            UserSubscriptionStatus::Unsubscribed
-            | UserSubscriptionStatus::Pending(_)
-            | UserSubscriptionStatus::Denylisted => {
-                return CanDeployStation::NotAllowed(self.subscription_status.clone());
-            }
-        };
         self.user_rate_limiter.can_deploy_station()
     }
 
@@ -129,7 +121,7 @@ impl User {
         User {
             id: new_user_id,
             identity: user_identity,
-            subscription_status: UserSubscriptionStatus::Unsubscribed,
+            subscription_status: UserSubscriptionStatus::Approved,
             stations: stations.into_iter().map(|station| station.into()).collect(),
             deployed_stations: vec![],
             user_rate_limiter: RateLimiter::new_user(),
@@ -272,7 +264,7 @@ pub mod user_model_utils {
         User {
             id: *Uuid::new_v4().as_bytes(),
             identity: test_utils::random_principal(),
-            subscription_status: UserSubscriptionStatus::Unsubscribed,
+            subscription_status: UserSubscriptionStatus::Approved,
             stations: vec![],
             deployed_stations: vec![],
             user_rate_limiter: RateLimiter::new_user(),

--- a/tests/integration/src/control_panel_tests.rs
+++ b/tests/integration/src/control_panel_tests.rs
@@ -10,8 +10,8 @@ use crate::TestEnv;
 use candid::{Encode, Principal};
 use control_panel_api::{
     AssociateWithCallerInput, CanDeployStationResponse, DeployStationAdminUserInput,
-    DeployStationInput, DeployStationResponse, ListUserStationsInput, ManageUserStationsInput,
-    RegisterUserInput, RegisterUserResponse, UpdateWaitingListInput, UserStationDTO,
+    DeployStationInput, DeployStationResponse, GetUserResponse, ListUserStationsInput,
+    ManageUserStationsInput, RegisterUserInput, RegisterUserResponse, UserDTO, UserStationDTO,
     UserSubscriptionStatusDTO,
 };
 use control_panel_api::{ListUserStationsResponse, UploadCanisterModulesInput};
@@ -156,96 +156,16 @@ fn deploy_user_station() {
     let user_dto = res.0.unwrap().user;
     assert_eq!(user_dto.identity, user_id);
 
-    let deploy_station_args = DeployStationInput {
-        name: "station".to_string(),
-        admins: vec![DeployStationAdminUserInput {
-            identity: user_id,
-            username: "admin".to_string(),
-        }],
-        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
-        subnet_selection: None,
-    };
-
-    // user can't deploy station before being approved
-    let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "deploy_station",
-        (deploy_station_args,),
-    )
-    .unwrap();
-    res.0.unwrap_err();
-
-    // subscribe to waiting list
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "subscribe_to_waiting_list",
-        ("john@example.com".to_string(),),
-    )
-    .unwrap();
-    res.0.unwrap();
-
-    let deploy_station_args = DeployStationInput {
-        name: "station".to_string(),
-        admins: vec![DeployStationAdminUserInput {
-            identity: user_id,
-            username: "admin".to_string(),
-        }],
-        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
-        subnet_selection: None,
-    };
-
-    // user can't deploy station before being approved
-    let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "deploy_station",
-        (deploy_station_args,),
-    )
-    .unwrap();
-    res.0.unwrap_err();
-
-    // only canister controllers can approve users
-    let update_waiting_list_args = UpdateWaitingListInput {
-        users: vec![user_id],
-        new_status: UserSubscriptionStatusDTO::Approved,
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "update_waiting_list",
-        (update_waiting_list_args.clone(),),
-    )
-    .unwrap();
-    res.0.unwrap_err();
-
-    // approve user
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller_test_id(),
-        "update_waiting_list",
-        (update_waiting_list_args,),
-    )
-    .unwrap();
-    res.0.unwrap();
-
-    let deploy_station_args = DeployStationInput {
-        name: "station".to_string(),
-        admins: vec![DeployStationAdminUserInput {
-            identity: user_id,
-            username: "admin".to_string(),
-        }],
-        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
-        subnet_selection: None,
-    };
-
     // deploy user station
+    let deploy_station_args = DeployStationInput {
+        name: "station".to_string(),
+        admins: vec![DeployStationAdminUserInput {
+            identity: user_id,
+            username: "admin".to_string(),
+        }],
+        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
+        subnet_selection: None,
+    };
     let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
         &env,
         canister_ids.control_panel,
@@ -333,36 +253,6 @@ fn deploy_too_many_stations() {
     // top up the control panel to deploy all the many stations
     env.add_cycles(canister_ids.control_panel, 10_000_000_000_000_000);
 
-    let bootstrap_user = |user_id: Principal| {
-        // register user
-        let register_args = RegisterUserInput { station: None };
-        let res: (ApiResult<RegisterUserResponse>,) = update_candid_as(
-            &env,
-            canister_ids.control_panel,
-            user_id,
-            "register_user",
-            (register_args,),
-        )
-        .unwrap();
-        let user_dto = res.0.unwrap().user;
-        assert_eq!(user_dto.identity, user_id);
-
-        // approve user
-        let update_waiting_list_args = UpdateWaitingListInput {
-            users: vec![user_id],
-            new_status: UserSubscriptionStatusDTO::Approved,
-        };
-        let res: (ApiResult<()>,) = update_candid_as(
-            &env,
-            canister_ids.control_panel,
-            controller_test_id(),
-            "update_waiting_list",
-            (update_waiting_list_args,),
-        )
-        .unwrap();
-        res.0.unwrap();
-    };
-
     let can_deploy = |user_id: Principal| -> ApiResult<CanDeployStationResponse> {
         update_candid_as::<_, (ApiResult<CanDeployStationResponse>,)>(
             &env,
@@ -375,32 +265,11 @@ fn deploy_too_many_stations() {
         .0
     };
 
-    let deploy = |user_id: Principal, day: usize, i: usize| -> ApiResult<DeployStationResponse> {
-        let deploy_station_args = DeployStationInput {
-            name: format!("station_{}_{}_{}", user_id, day, i),
-            admins: vec![DeployStationAdminUserInput {
-                identity: user_id,
-                username: "admin".to_string(),
-            }],
-            associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
-            subnet_selection: None,
-        };
-        update_candid_as::<_, (ApiResult<DeployStationResponse>,)>(
-            &env,
-            canister_ids.control_panel,
-            user_id,
-            "deploy_station",
-            (deploy_station_args,),
-        )
-        .unwrap()
-        .0
-    };
-
     let max_stations_per_user = 2;
     let max_stations_per_day = 100;
 
     for i in 0..(max_stations_per_day + 1) {
-        bootstrap_user(user_test_id(i));
+        register_user(&env, canister_ids.control_panel, user_test_id(i));
         // to prevent rate-limiting
         env.advance_time(std::time::Duration::from_secs(60));
     }
@@ -414,7 +283,9 @@ fn deploy_too_many_stations() {
                 can_deploy(user_id).unwrap(),
                 CanDeployStationResponse::Allowed(remaining) if max_stations_per_user == remaining + i
             ));
-            let station_id = deploy(user_id, day, i).unwrap().canister_id;
+            let station_id = deploy_station(&env, canister_ids.control_panel, user_id, day, i)
+                .unwrap()
+                .canister_id;
             stations.push(station_id);
         }
 
@@ -450,9 +321,15 @@ fn deploy_too_many_stations() {
             "DEPLOY_STATION_QUOTA_EXCEEDED"
         );
         assert_eq!(
-            deploy(user_id, day, max_stations_per_user)
-                .unwrap_err()
-                .code,
+            deploy_station(
+                &env,
+                canister_ids.control_panel,
+                user_id,
+                day,
+                max_stations_per_user
+            )
+            .unwrap_err()
+            .code,
             "DEPLOY_STATION_QUOTA_EXCEEDED"
         );
 
@@ -463,7 +340,7 @@ fn deploy_too_many_stations() {
                 can_deploy(user_test_id(i)).unwrap(),
                 CanDeployStationResponse::Allowed(remaining) if remaining == std::cmp::min(max_stations_per_user, max_stations_per_day as usize - max_stations_per_user - (i as usize - 1))
             ));
-            deploy(user_test_id(i), day, 0).unwrap();
+            deploy_station(&env, canister_ids.control_panel, user_test_id(i), day, 0).unwrap();
         }
 
         // deploying one more station on behalf of yet another use should fail due to global rate limit
@@ -474,9 +351,15 @@ fn deploy_too_many_stations() {
             "DEPLOY_STATION_QUOTA_EXCEEDED"
         );
         assert_eq!(
-            deploy(user_test_id(max_stations_per_day), day, 0)
-                .unwrap_err()
-                .code,
+            deploy_station(
+                &env,
+                canister_ids.control_panel,
+                user_test_id(max_stations_per_day),
+                day,
+                0
+            )
+            .unwrap_err()
+            .code,
             "DEPLOY_STATION_QUOTA_EXCEEDED"
         );
 
@@ -513,21 +396,6 @@ fn no_upload_canister_modules() {
     .unwrap();
     let user_dto = res.0.unwrap().user;
     assert_eq!(user_dto.identity, user_id);
-
-    // approve user
-    let update_waiting_list_args = UpdateWaitingListInput {
-        users: vec![user_id],
-        new_status: UserSubscriptionStatusDTO::Approved,
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller_test_id(),
-        "update_waiting_list",
-        (update_waiting_list_args,),
-    )
-    .unwrap();
-    res.0.unwrap();
 
     // deploying user station fails before uploading canister modules
     let deploy_station_args = DeployStationInput {
@@ -633,32 +501,6 @@ fn deploy_user_station_to_different_subnet() {
     let user_dto = res.0.unwrap().user;
     assert_eq!(user_dto.identity, user_id);
 
-    // subscribe to waiting list
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        user_id,
-        "subscribe_to_waiting_list",
-        ("john@example.com".to_string(),),
-    )
-    .unwrap();
-    res.0.unwrap();
-
-    // approve user
-    let update_waiting_list_args = UpdateWaitingListInput {
-        users: vec![user_id],
-        new_status: UserSubscriptionStatusDTO::Approved,
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller_test_id(),
-        "update_waiting_list",
-        (update_waiting_list_args,),
-    )
-    .unwrap();
-    res.0.unwrap();
-
     // deploy user station
     let deploy_station_args = DeployStationInput {
         name: "station".to_string(),
@@ -722,21 +564,6 @@ fn insufficient_control_panel_cycles() {
         .unwrap();
         let user_dto = res.0.unwrap().user;
         assert_eq!(user_dto.identity, user_id);
-
-        // approve user
-        let update_waiting_list_args = UpdateWaitingListInput {
-            users: vec![user_id],
-            new_status: UserSubscriptionStatusDTO::Approved,
-        };
-        let res: (ApiResult<()>,) = update_candid_as(
-            &env,
-            canister_ids.control_panel,
-            controller_test_id(),
-            "update_waiting_list",
-            (update_waiting_list_args,),
-        )
-        .unwrap();
-        res.0.unwrap();
 
         // deploy station
         let deploy_station_args = DeployStationInput {
@@ -881,4 +708,145 @@ fn deploy_station_with_insufficient_cycles() {
 
     // and the station should eventually become healthy
     await_station_healthy(&env, station, WALLET_ADMIN_USER);
+}
+
+#[test]
+fn control_panel_upgrade() {
+    let TestEnv {
+        env,
+        canister_ids,
+        controller,
+        ..
+    } = setup_new_env();
+
+    // register users
+    let num_users = 3;
+    for i in 0..num_users {
+        register_user(&env, canister_ids.control_panel, user_test_id(i));
+    }
+
+    // deploy stations
+    let main_stations: Vec<_> = (0..num_users)
+        .map(|i| {
+            deploy_station(&env, canister_ids.control_panel, user_test_id(i), 0, 0)
+                .unwrap()
+                .canister_id
+        })
+        .collect();
+    let stations: Vec<_> = (0..num_users)
+        .map(|i| {
+            deploy_station(&env, canister_ids.control_panel, user_test_id(i), 0, 1)
+                .unwrap()
+                .canister_id
+        })
+        .collect();
+
+    // check users and their stations before upgrade
+    let users: Vec<_> = (0..num_users)
+        .map(|i| get_user(&env, canister_ids.control_panel, user_test_id(i)))
+        .collect();
+    for (i, user) in users.iter().enumerate() {
+        assert_eq!(user.identity, user_test_id(i as u64));
+        assert_eq!(
+            user.subscription_status,
+            UserSubscriptionStatusDTO::Approved
+        );
+    }
+    let user_stations: Vec<_> = (0..num_users)
+        .map(|i| list_user_stations(&env, canister_ids.control_panel, user_test_id(i)))
+        .collect();
+    for (i, user_stations) in user_stations.iter().enumerate() {
+        assert_eq!(user_stations[0].canister_id, main_stations[i]);
+        assert_eq!(user_stations[1].canister_id, stations[i]);
+    }
+
+    // upgrade control panel: post-upgrade hook iterates over all users and sets their subscription status to `UserSubscriptionStatusDTO::Approved`
+    let control_panel_wasm = get_canister_wasm("control_panel").to_vec();
+    env.upgrade_canister(
+        canister_ids.control_panel,
+        control_panel_wasm,
+        Encode!(&()).unwrap(),
+        Some(controller),
+    )
+    .unwrap();
+
+    // check users and their stations after upgrade
+    let users_after_upgrade: Vec<_> = (0..num_users)
+        .map(|i| get_user(&env, canister_ids.control_panel, user_test_id(i)))
+        .collect();
+    assert_eq!(users_after_upgrade, users);
+    let user_stations_after_upgrade: Vec<_> = (0..num_users)
+        .map(|i| list_user_stations(&env, canister_ids.control_panel, user_test_id(i)))
+        .collect();
+    assert_eq!(user_stations_after_upgrade, user_stations);
+}
+
+fn get_user(env: &PocketIc, control_panel_id: Principal, user_id: Principal) -> UserDTO {
+    let res: (ApiResult<GetUserResponse>,) =
+        update_candid_as(env, control_panel_id, user_id, "get_user", ((),)).unwrap();
+    let user_dto = res.0.unwrap().user;
+    assert_eq!(user_dto.identity, user_id);
+    user_dto
+}
+
+fn list_user_stations(
+    env: &PocketIc,
+    control_panel_id: Principal,
+    user_id: Principal,
+) -> Vec<UserStationDTO> {
+    update_candid_as::<_, (ApiResult<ListUserStationsResponse>,)>(
+        env,
+        control_panel_id,
+        user_id,
+        "list_user_stations",
+        (ListUserStationsInput {
+            filter_by_labels: None,
+        },),
+    )
+    .unwrap()
+    .0
+    .unwrap()
+    .stations
+}
+
+fn register_user(env: &PocketIc, control_panel_id: Principal, user_id: Principal) -> UserDTO {
+    let register_args = RegisterUserInput { station: None };
+    let res: (ApiResult<RegisterUserResponse>,) = update_candid_as(
+        env,
+        control_panel_id,
+        user_id,
+        "register_user",
+        (register_args,),
+    )
+    .unwrap();
+    let user_dto = res.0.unwrap().user;
+    assert_eq!(user_dto.identity, user_id);
+    user_dto
+}
+
+fn deploy_station(
+    env: &PocketIc,
+    control_panel_id: Principal,
+    user_id: Principal,
+    day: usize,
+    i: usize,
+) -> ApiResult<DeployStationResponse> {
+    let deploy_station_args = DeployStationInput {
+        name: format!("station_{}_{}_{}", user_id, day, i),
+        admins: vec![DeployStationAdminUserInput {
+            identity: user_id,
+            username: "admin".to_string(),
+        }],
+        associate_with_caller: Some(AssociateWithCallerInput { labels: vec![] }),
+        subnet_selection: None,
+    };
+    update_candid_as::<_, (ApiResult<DeployStationResponse>,)>(
+        env,
+        control_panel_id,
+        user_id,
+        "deploy_station",
+        (deploy_station_args,),
+    )
+    .unwrap()
+    .0
 }

--- a/tests/integration/src/cycles_monitor_tests.rs
+++ b/tests/integration/src/cycles_monitor_tests.rs
@@ -3,15 +3,13 @@ use crate::setup::{
     get_canister_wasm, setup_new_env, setup_new_env_with_config, SetupConfig, WALLET_ADMIN_USER,
 };
 use crate::utils::{
-    advance_time_to_burn_cycles, controller_test_id, create_icp_account,
-    get_core_canister_health_status, get_icp_account_identifier, get_system_info, get_user,
-    user_test_id, NNS_ROOT_CANISTER_ID,
+    advance_time_to_burn_cycles, create_icp_account, get_core_canister_health_status,
+    get_icp_account_identifier, get_system_info, get_user, user_test_id, NNS_ROOT_CANISTER_ID,
 };
 use crate::TestEnv;
 use control_panel_api::{
     AssociateWithCallerInput, DeployStationAdminUserInput, DeployStationInput,
-    DeployStationResponse, RegisterUserInput, RegisterUserResponse, UpdateWaitingListInput,
-    UserSubscriptionStatusDTO,
+    DeployStationResponse, RegisterUserInput, RegisterUserResponse,
 };
 use ic_ledger_types::AccountIdentifier;
 use orbit_essentials::api::ApiResult;
@@ -93,21 +91,7 @@ fn successful_monitors_stations_and_tops_up() {
     let user_dto = res.0.unwrap().user;
     assert_eq!(user_dto.identity, user_id);
 
-    // approve user
-    let update_waiting_list_args = UpdateWaitingListInput {
-        users: vec![user_id],
-        new_status: UserSubscriptionStatusDTO::Approved,
-    };
-    let res: (ApiResult<()>,) = update_candid_as(
-        &env,
-        canister_ids.control_panel,
-        controller_test_id(),
-        "update_waiting_list",
-        (update_waiting_list_args,),
-    )
-    .unwrap();
-    res.0.unwrap();
-
+    // deploy user station
     let deploy_station_args = DeployStationInput {
         name: "test_station".to_string(),
         admins: vec![DeployStationAdminUserInput {
@@ -117,8 +101,6 @@ fn successful_monitors_stations_and_tops_up() {
         associate_with_caller: Some(AssociateWithCallerInput { labels: Vec::new() }),
         subnet_selection: None,
     };
-
-    // deploy user station
     let res: (ApiResult<DeployStationResponse>,) = update_candid_as(
         &env,
         canister_ids.control_panel,


### PR DESCRIPTION
This PR removes the waiting list and sets the stable memory version in `CanisterConfig::default()` so that memory migration is not triggered for upgrades from new control panel deployments.