### PR TITLE
chore(wallet): verify locale keys at dev/build

### DIFF
--- a/apps/wallet/build/main.build.ts
+++ b/apps/wallet/build/main.build.ts
@@ -16,6 +16,7 @@ import { withApiCompatibilityFile } from './plugins/with-compatibility-file.plug
 import { withIcAssetsFile } from './plugins/with-ic-assets.plugin';
 import { withVersionedEntrypoint } from './plugins/with-versioned-entrypoint.plugin';
 import { getCommitHash } from './utils/git.utils';
+import { withLocaleCheck } from './plugins/with-locale-check';
 
 // https://vitejs.dev/config/
 export default defineConfig(_ => {
@@ -53,6 +54,7 @@ export default defineConfig(_ => {
       withApiCompatibilityFile(),
       withVersionedEntrypoint(),
       withIcAssetsFile({ isProduction }),
+      withLocaleCheck(),
     ],
     build: {
       target: 'es2022',

--- a/apps/wallet/build/plugins/with-locale-check.ts
+++ b/apps/wallet/build/plugins/with-locale-check.ts
@@ -1,0 +1,72 @@
+import { Plugin } from 'vite';
+import { readdirSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import enLocale from '../../src/locales/en.locale';
+import ptLocale from '../../src/locales/pt.locale';
+import frLocale from '../../src/locales/fr.locale';
+
+type LocaleKey = {
+  [key: string]: LocaleKey | string;
+};
+
+function compareLocales(
+  enLocale: LocaleKey,
+  locale: LocaleKey,
+  root: string,
+  localeName: string,
+): boolean {
+  const enKeys = Object.keys(enLocale);
+  const localeKeys = Object.keys(locale);
+
+  let result = true;
+
+  for (const key of enKeys) {
+    const wholeKey = root ? root + '.' + key : key;
+
+    if (typeof enLocale[key] === 'object') {
+      if (!compareLocales(enLocale[key], locale[key] as LocaleKey, wholeKey, localeName)) {
+        result = false;
+      }
+    }
+
+    if (!localeKeys.includes(key)) {
+      console.error(`Key ${wholeKey} is missing in ${localeName}`);
+      result = false;
+    }
+  }
+
+  return result;
+}
+
+export const withLocaleCheck = (): Plugin => {
+  return {
+    name: 'with-locale-check',
+    async buildStart() {
+      const locales = [
+        { name: 'pt', locale: ptLocale },
+        { name: 'fr', locale: frLocale },
+      ];
+
+      // check if there are only these locale files in the src/locales folder
+      const localeFiles = readdirSync(resolve(__dirname, '../../src/locales'));
+      if (localeFiles.length !== locales.length + 1) {
+        console.error(
+          `ERROR: There are ${localeFiles.length} locale files in the src/locales folder, expected ${locales.length + 1}.`,
+        );
+        process.exit(1);
+      }
+
+      let result = true;
+      for (const locale of locales) {
+        if (!compareLocales(enLocale, locale.locale, '', locale.name)) {
+          console.error(`ERROR: Locale keys of ${locale.name} are not equal to en.locale.ts`);
+          result = false;
+        }
+      }
+
+      if (!result) {
+        process.exit(1);
+      }
+    },
+  };
+};

--- a/apps/wallet/src/locales/fr.locale.ts
+++ b/apps/wallet/src/locales/fr.locale.ts
@@ -219,6 +219,7 @@ export default {
       amount: 'Montant',
       fee: 'Frais',
       comment: 'Commentaire',
+      url: 'URL',
     },
     download: {
       user_group: "Groupes d'Usagers",
@@ -686,6 +687,7 @@ export default {
     comment: 'Commentaire',
     comment_optional: 'Commentaire (optionnel)',
     arg: 'Paramètre',
+    access: 'Accès',
     target: 'Cible',
     previous: 'Précédent',
     next: 'Suivant',
@@ -1006,7 +1008,7 @@ export default {
     },
     assets: {
       title: 'Actifs',
-      btn_new_asset: 'Nouvel Actif',
+      btn_new_entry: 'Nouvel Actif',
       no_results_found: 'Pas d actif trouvé.',
       error_fetching_assets: 'Erreur lors du chargement des actifs, veuillez essayer de nouveau.',
       forms: {

--- a/apps/wallet/src/locales/pt.locale.ts
+++ b/apps/wallet/src/locales/pt.locale.ts
@@ -35,6 +35,7 @@ export default {
     request_pending_message: 'O seu pedido foi criado e está pendente de aprovação.',
     request_approved_message: 'Este pedido foi approvado e está sendo processado.',
     request_rejected_message: 'Este pedido foi rejeitado.',
+    request_completed_message: 'Este pedido foi concluído.',
     user_status_active: 'Ativo',
     user_status_inactive: 'Inativo',
     add_new_identity: 'Adicionar nova identidade',
@@ -97,7 +98,7 @@ export default {
       verify_instructions:
         'Para verificar a atualização, abra o terminal e siga as instruções abaixo:',
     },
-    assets: 'Ativos',
+    asset: 'Ativo',
     no_data: 'Nenhum dado disponível.',
     no_matching_results: 'Nenhum resultado encontrado para `{search}`.',
     add_new_label: 'Adicionar novo rótulo: {label}',
@@ -230,6 +231,7 @@ export default {
       amount: 'Quantidade',
       fee: 'Taxa',
       comment: 'Comentário',
+      url: 'URL',
     },
     types: {
       addusergroup: {
@@ -486,6 +488,7 @@ export default {
     not_found: 'Canister não encontrado.',
     not_found_description: 'O canister que está a tentar aceder não existe.',
     ic_settings: 'Configuraçōes do IC',
+    top_up: 'Recarregar',
     start_monitoring: 'Iniciar monitoramento',
     monitor: {
       title: 'Monitorizar ciclos',
@@ -687,6 +690,7 @@ export default {
     wasm: 'Wasm',
     download: 'Baixar',
     arg: 'Arg',
+    access: 'Acesso',
     target: 'Alvo',
     permissions: 'Permissões',
     approval_policies: 'Políticas de Aprovação',
@@ -1086,6 +1090,7 @@ export default {
       systemupgrade: 'Atualizar o sistema',
       change: 'Alterar',
       fund: 'Financiar',
+      callcanister: 'Chamar',
     },
     allow: {
       public: 'Acesso público',
@@ -1136,6 +1141,7 @@ export default {
       fundexternalcanister: 'Financiar canister',
       setdisasterrecovery: 'Recuperação de sistema',
       callexternalcanister: 'Interagir com canister',
+      createexternalcanister: 'Criar canister',
       addasset: 'Adicionar ativo',
       editasset: 'Editar ativo',
       removeasset: 'Remover ativo',

--- a/apps/wallet/tsconfig.json
+++ b/apps/wallet/tsconfig.json
@@ -21,5 +21,6 @@
     }
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "exclude": ["src/locales/**"],
+  "references": [{ "path": "./tsconfig.node.json" }, { "path": "./tsconfig.locales.json" },]
 }

--- a/apps/wallet/tsconfig.locales.json
+++ b/apps/wallet/tsconfig.locales.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "composite": true,
+      "strict": true,
+      "skipLibCheck": true,
+      "resolveJsonModule": true
+    },
+    "include": [
+      "src/locales/**/*.ts"
+    ]
+  }

--- a/apps/wallet/tsconfig.node.json
+++ b/apps/wallet/tsconfig.node.json
@@ -7,5 +7,8 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "build/**/*.ts", "src/locales/*.ts"]
+  "references": [
+    { "path": "./tsconfig.locales.json" }
+  ],
+  "include": ["vite.config.ts", "build/**/*.ts"]
 }

--- a/apps/wallet/tsconfig.node.json
+++ b/apps/wallet/tsconfig.node.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "composite": true,
+    "composite": false,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "build/**/*.ts"]
+  "include": ["vite.config.ts", "build/**/*.ts", "src/locales/*.ts"]
 }


### PR DESCRIPTION
Added a new build plugin that checks the secondary locales if they contain all keys the English locale does. Outputs a warning in dev, fails the build in prod. Also fixed the missing keys.