### PR TITLE
feat(station): update monitoring strategy

### DIFF
--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -916,11 +916,11 @@ mod install_canister_handlers {
     pub fn init_cycle_monitor(upgrader_id: Principal, cycle_obtain_strategy: &CycleObtainStrategy) {
         let fund_strategy = MonitorExternalCanisterStrategy::BelowEstimatedRuntime(
             MonitoringExternalCanisterEstimatedRuntimeInput {
-                min_runtime_secs: 14 * 24 * 60 * 60,  // 14 days
+                min_runtime_secs: 60 * 24 * 60 * 60,  // 60 days
                 fund_runtime_secs: 30 * 24 * 60 * 60, // 30 days
-                max_runtime_cycles_fund: 1_000_000_000_000,
-                fallback_min_cycles: 400_000_000_000,
-                fallback_fund_cycles: 200_000_000_000,
+                max_runtime_cycles_fund: 2_000_000_000_000,
+                fallback_min_cycles: 600_000_000_000,
+                fallback_fund_cycles: 300_000_000_000,
             },
         );
 

--- a/tests/integration/src/cycles_monitor_tests.rs
+++ b/tests/integration/src/cycles_monitor_tests.rs
@@ -238,9 +238,10 @@ fn can_mint_cycles_to_top_up_self() {
     assert!(post_account_balance < pre_account_balance);
     assert!(post_cycle_balance > pre_cycle_balance);
 
-    // assert that while we lose some cycles during the process, it'll be roughly what we expect
+    // assert that while we lose some cycles during the process, it'll be roughly what we expect,
+    // which is currently set to `fallback_fund_cycles=300_000_000_000`
     assert!(
-        post_cycle_balance - pre_cycle_balance > 199_000_000_000
-            && post_cycle_balance - pre_cycle_balance < 200_000_000_000
+        post_cycle_balance - pre_cycle_balance > 299_000_000_000
+            && post_cycle_balance - pre_cycle_balance < 300_000_000_000
     );
 }


### PR DESCRIPTION
Ensures that if there is a source for cycles (e.g. ICP account), that the station and upgrader will be funded to a threshold that allows them to have the necessary amount of cycles for reservation for costly operations such as canister upgrades.