### PR TITLE
fix(orbit): force platform linux/amd64 in docker build

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -57,8 +57,7 @@ function deterministic_build() {
   local target=$2
 
   # Build the canister
-  docker build --build-arg BUILD_MODE=$BUILD_MODE -t orbit-$project_name --target $target .
-   
+  docker build --build-arg BUILD_MODE=$BUILD_MODE -t orbit-$project_name --target $target . --platform=linux/amd64
 
   # Create a container to extract the generated artifacts
   docker create --name orbit-$project_name-container orbit-$project_name


### PR DESCRIPTION
It appears that without specifying the platform docker uses the wrong image on mac, resulting in missing file error:
```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
```