### PR TITLE
feat(station): make canister_status endpoint canfund compatible

### DIFF
--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -3198,11 +3198,6 @@ type CanisterSnapshotsResult = variant {
   Err : Error;
 };
 
-type CanisterStatusResult = variant {
-  Ok : CanisterStatusResponse;
-  Err : Error;
-};
-
 type HeaderField = record { text; text };
 
 type HttpRequest = record {
@@ -3313,7 +3308,7 @@ service : (opt SystemInstall) -> {
   // List all user groups of the station.
   list_user_groups : (input : ListUserGroupsInput) -> (ListUserGroupsResult) query;
   // Get canister status of a canister controlled by the station.
-  canister_status : (input : CanisterStatusInput) -> (CanisterStatusResult);
+  canister_status : (input : CanisterStatusInput) -> (CanisterStatusResponse);
   // Get snapshots of a canister controlled by the station.
   canister_snapshots : (input : CanisterSnapshotsInput) -> (CanisterSnapshotsResult);
   // HTTP Protocol interface.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -222,8 +222,6 @@ export interface CanisterStatusResponse {
   'module_hash' : [] | [Uint8Array | number[]],
   'reserved_cycles' : bigint,
 }
-export type CanisterStatusResult = { 'Ok' : CanisterStatusResponse } |
-  { 'Err' : Error };
 export interface Capabilities {
   'name' : string,
   'version' : string,
@@ -1533,7 +1531,10 @@ export interface _SERVICE {
     [CanisterSnapshotsInput],
     CanisterSnapshotsResult
   >,
-  'canister_status' : ActorMethod<[CanisterStatusInput], CanisterStatusResult>,
+  'canister_status' : ActorMethod<
+    [CanisterStatusInput],
+    CanisterStatusResponse
+  >,
   'capabilities' : ActorMethod<[], CapabilitiesResult>,
   'create_request' : ActorMethod<[CreateRequestInput], CreateRequestResult>,
   'fetch_account_balances' : ActorMethod<

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -871,10 +871,6 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'reserved_cycles' : IDL.Nat,
   });
-  const CanisterStatusResult = IDL.Variant({
-    'Ok' : CanisterStatusResponse,
-    'Err' : Error,
-  });
   const StandardData = IDL.Record({
     'supported_operations' : IDL.Vec(IDL.Text),
     'supported_address_formats' : IDL.Vec(IDL.Text),
@@ -1678,7 +1674,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'canister_status' : IDL.Func(
         [CanisterStatusInput],
-        [CanisterStatusResult],
+        [CanisterStatusResponse],
         [],
       ),
     'capabilities' : IDL.Func([], [CapabilitiesResult], ['query']),

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -3198,11 +3198,6 @@ type CanisterSnapshotsResult = variant {
   Err : Error;
 };
 
-type CanisterStatusResult = variant {
-  Ok : CanisterStatusResponse;
-  Err : Error;
-};
-
 type HeaderField = record { text; text };
 
 type HttpRequest = record {
@@ -3313,7 +3308,7 @@ service : (opt SystemInstall) -> {
   // List all user groups of the station.
   list_user_groups : (input : ListUserGroupsInput) -> (ListUserGroupsResult) query;
   // Get canister status of a canister controlled by the station.
-  canister_status : (input : CanisterStatusInput) -> (CanisterStatusResult);
+  canister_status : (input : CanisterStatusInput) -> (CanisterStatusResponse);
   // Get snapshots of a canister controlled by the station.
   canister_snapshots : (input : CanisterSnapshotsInput) -> (CanisterSnapshotsResult);
   // HTTP Protocol interface.

--- a/core/station/impl/src/controllers/external_canister.rs
+++ b/core/station/impl/src/controllers/external_canister.rs
@@ -1,4 +1,5 @@
 use crate::{
+    core::ic_cdk::api::trap,
     core::middlewares::{authorize, call_context},
     models::resource::{ExternalCanisterId, ExternalCanisterResourceAction, Resource},
     services::{ExternalCanisterService, EXTERNAL_CANISTER_SERVICE},
@@ -17,8 +18,11 @@ use std::sync::Arc;
 
 // Canister entrypoints for the controller.
 #[update(name = "canister_status")]
-async fn canister_status(input: CanisterIdRecord) -> ApiResult<CanisterStatusResponse> {
-    CONTROLLER.canister_status(input).await
+async fn canister_status(input: CanisterIdRecord) -> CanisterStatusResponse {
+    CONTROLLER
+        .canister_status(input)
+        .await
+        .unwrap_or_else(|e| trap(&format!("{:?}", e)))
 }
 
 #[update(name = "canister_snapshots")]

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -514,9 +514,8 @@ fn create_external_canister_and_check_status() {
     assert_eq!(status.module_hash, None);
 
     // checking canister status on behalf of the user_a
-
     let canister_id_record = CanisterIdRecord { canister_id };
-    let status: (ApiResult<CanisterStatusResult>,) = update_candid_as(
+    let status: (CanisterStatusResult,) = update_candid_as(
         &env,
         canister_ids.station,
         user_a,
@@ -524,7 +523,22 @@ fn create_external_canister_and_check_status() {
         (canister_id_record.clone(),),
     )
     .unwrap();
-    assert_eq!(status.0.unwrap().module_hash, None);
+    assert_eq!(status.0.module_hash, None);
+
+    // checking canister status on behalf of the user_c which has no permission to call canister_status
+    let user_c = user_test_id(2);
+    let err = update_candid_as::<_, (CanisterStatusResult,)>(
+        &env,
+        canister_ids.station,
+        user_c,
+        "canister_status",
+        (canister_id_record.clone(),),
+    )
+    .unwrap_err();
+    assert!(err.reject_message.contains(&format!(
+        "Unauthorized access to resources: ExternalCanister(Read(Canister({})))",
+        canister_id
+    )));
 }
 
 #[test]


### PR DESCRIPTION
This PR makes the `canister_status` endpoint of the station compatible with canfund by aligning its return value with the return value of the management canister.