### PR TITLE
chore(station,upgrader): do not sync station data to upgrader after every upgrade of upgrader

### DIFF
--- a/core/station/impl/src/factories/requests/mod.rs
+++ b/core/station/impl/src/factories/requests/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     errors::{RequestError, RequestExecuteError},
     models::{Request, RequestOperation},
     services::{
-        permission::PERMISSION_SERVICE, CHANGE_CANISTER_SERVICE, DISASTER_RECOVERY_SERVICE,
-        EXTERNAL_CANISTER_SERVICE, REQUEST_POLICY_SERVICE, SYSTEM_SERVICE,
+        permission::PERMISSION_SERVICE, CHANGE_CANISTER_SERVICE, EXTERNAL_CANISTER_SERVICE,
+        REQUEST_POLICY_SERVICE, SYSTEM_SERVICE,
     },
 };
 use async_trait::async_trait;
@@ -369,14 +369,9 @@ impl RequestFactory {
             RequestOperation::SetDisasterRecovery(operation) => Box::new(
                 set_disaster_recovery::SetDisasterRecoveryRequestExecute::new(request, operation),
             ),
-            RequestOperation::SystemUpgrade(operation) => {
-                Box::new(SystemUpgradeRequestExecute::new(
-                    request,
-                    operation,
-                    Arc::clone(&SYSTEM_SERVICE),
-                    Arc::clone(&DISASTER_RECOVERY_SERVICE),
-                ))
-            }
+            RequestOperation::SystemUpgrade(operation) => Box::new(
+                SystemUpgradeRequestExecute::new(request, operation, Arc::clone(&SYSTEM_SERVICE)),
+            ),
             RequestOperation::ChangeExternalCanister(operation) => {
                 Box::new(ChangeExternalCanisterRequestExecute::new(
                     request,


### PR DESCRIPTION
This PR stops syncing station data to the upgrader after every upgrade of the upgrader. This is safe under the assumption that people don't use a recent station (containing this PR) to upgrade an old upgrader that did not contain any station data and thus syncing station data after an upgrade was necessary.