### PR TITLE
chore(station): perform request validation before execution

### DIFF
--- a/core/station/impl/src/errors/request_execute.rs
+++ b/core/station/impl/src/errors/request_execute.rs
@@ -12,6 +12,9 @@ pub enum RequestExecuteError {
     /// Request can't be executed because it was not approved.
     #[error(r#"Request can't be executed because it was not approved."#)]
     NotApproved,
+    /// The request has failed validation.
+    #[error(r#"The request has failed validation."#)]
+    ValidationError { info: String },
     /// Request execution failed due to internal error: {reason}.
     #[error(r#"Request execution failed due to internal error: `{reason}`."#)]
     InternalError { reason: String },

--- a/core/station/impl/src/models/request.rs
+++ b/core/station/impl/src/models/request.rs
@@ -359,7 +359,21 @@ impl ModelValidator<RequestError> for Request {
         validate_title(&self.title)?;
         validate_summary(&self.summary)?;
         validate_requested_by(&self.requested_by)?;
-        validate_expiration_dt(&self.expiration_dt)?;
+
+        let must_not_be_expired = match self.status {
+            RequestStatus::Created => true,
+            RequestStatus::Approved
+            | RequestStatus::Rejected
+            | RequestStatus::Scheduled { .. }
+            | RequestStatus::Cancelled { .. }
+            | RequestStatus::Processing { .. }
+            | RequestStatus::Completed { .. }
+            | RequestStatus::Failed { .. } => false,
+        };
+        if must_not_be_expired {
+            validate_expiration_dt(&self.expiration_dt)?;
+        }
+
         validate_execution_plan(&self.execution_plan)?;
         validate_status(&self.status)?;
         validate_request_operation_foreign_keys(&self.operation)?;

--- a/core/station/impl/src/models/request.rs
+++ b/core/station/impl/src/models/request.rs
@@ -372,9 +372,9 @@ impl ModelValidator<RequestError> for Request {
         };
         if must_not_be_expired {
             validate_expiration_dt(&self.expiration_dt)?;
+            validate_execution_plan(&self.execution_plan)?;
         }
 
-        validate_execution_plan(&self.execution_plan)?;
         validate_status(&self.status)?;
         validate_request_operation_foreign_keys(&self.operation)?;
 

--- a/core/station/impl/src/services/request.rs
+++ b/core/station/impl/src/services/request.rs
@@ -502,6 +502,18 @@ impl RequestService {
                     reason: e.to_string(),
                 })?;
 
+        if let Err(err) = request.validate() {
+            match err {
+                RequestError::ValidationError { info } => {
+                    return Err(RequestExecuteError::ValidationError { info });
+                }
+                _ => {
+                    let reason = format!("Unexpected validation result: {:?}", err);
+                    return Err(RequestExecuteError::InternalError { reason });
+                }
+            }
+        }
+
         if !matches!(request.status, RequestStatus::Processing { .. }) {
             let reason = format!(
                 "The request {} is not processing and thus cannot be executed.",

--- a/tests/integration/src/system_upgrade_tests.rs
+++ b/tests/integration/src/system_upgrade_tests.rs
@@ -383,12 +383,9 @@ fn delayed_system_upgrade() {
 
     loop {
         request = get_request(&env, WALLET_ADMIN_USER, canister_ids.station, request);
-        match request.status {
-            RequestStatusDTO::Scheduled { ref scheduled_at } => {
-                assert!(rfc3339_to_timestamp(scheduled_at) >= expected_scheduled_at);
-                break;
-            }
-            _ => (),
+        if let RequestStatusDTO::Scheduled { ref scheduled_at } = request.status {
+            assert!(rfc3339_to_timestamp(scheduled_at) >= expected_scheduled_at);
+            break;
         };
         env.advance_time(Duration::from_secs(1));
         env.tick();


### PR DESCRIPTION
This PR repeats request validation before execution to cover cases when the request becomes invalid while accepting votes.