### PR TITLE
fix(station): restrict access to system canister info

### DIFF
--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -7,6 +7,16 @@ use candid::{CandidType, Deserialize, Nat, Principal};
 use orbit_essentials::cmc::SubnetSelection;
 use orbit_essentials::types::WasmModuleExtraChunks;
 
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct CanisterSnapshotsInput {
+    pub canister_id: Principal,
+}
+
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
+pub struct CanisterStatusInput {
+    pub canister_id: Principal,
+}
+
 // Taken from https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Default)]
 pub enum LogVisibility {

--- a/core/station/impl/src/controllers/external_canister.rs
+++ b/core/station/impl/src/controllers/external_canister.rs
@@ -78,7 +78,7 @@ impl ExternalCanisterController {
             .await
     }
 
-    #[with_middleware(guard = authorize(&call_context(), &[Resource::ExternalCanister(ExternalCanisterResourceAction::Read(ExternalCanisterId::Canister(input.canister_id)))]))]
+    #[with_middleware(guard = authorize(&call_context(), &[Resource::from(&input)]))]
     async fn canister_snapshots(&self, input: CanisterSnapshotsInput) -> ApiResult<Vec<Snapshot>> {
         self.canister_service
             .canister_snapshots(input.canister_id)

--- a/core/station/impl/src/controllers/mod.rs
+++ b/core/station/impl/src/controllers/mod.rs
@@ -56,9 +56,7 @@ mod tests {
     #[test]
     fn check_candid_interface() {
         use candid_parser::utils::{service_equal, CandidSource};
-        use orbit_essentials::cdk::api::management_canister::main::{
-            CanisterIdRecord, CanisterStatusResponse,
-        };
+        use orbit_essentials::cdk::api::management_canister::main::CanisterStatusResponse;
 
         candid::export_service!();
         let new_interface = __export_service();

--- a/core/station/impl/src/core/init.rs
+++ b/core/station/impl/src/core/init.rs
@@ -18,17 +18,17 @@ lazy_static! {
             Allow::authenticated(),
             Resource::System(SystemResourceAction::Capabilities),
         ),
-        // Admins can read the system info which includes the canister's version, cycles, etc.
+        // reading the system info which includes the canister's version, cycles, etc.
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::SystemInfo),
         ),
-        // Admins can manage the system info (e.g. change the canister's name)
+        // managing the system info (e.g. change the canister's name)
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::ManageSystemInfo),
         ),
-        // Admins can upgrade the canister
+        // upgrading the canister
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::Upgrade),

--- a/core/station/impl/src/core/init.rs
+++ b/core/station/impl/src/core/init.rs
@@ -18,17 +18,17 @@ lazy_static! {
             Allow::authenticated(),
             Resource::System(SystemResourceAction::Capabilities),
         ),
-        // reading the system info which includes the canister's version, cycles, etc.
+        // all authenticated users can read the system info which includes the canister's version, cycles, etc.
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::SystemInfo),
         ),
-        // managing the system info (e.g. change the canister's name)
+        // all authenticated users can request to manage the system info (e.g. change the canister's name)
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::ManageSystemInfo),
         ),
-        // upgrading the canister
+        // all authenticated users can request to upgrade the canister
         (
             Allow::authenticated(),
             Resource::System(SystemResourceAction::Upgrade),

--- a/core/station/impl/src/mappers/authorization.rs
+++ b/core/station/impl/src/mappers/authorization.rs
@@ -385,7 +385,7 @@ impl From<&station_api::CreateRequestInput> for Resource {
 impl From<&CanisterSnapshotsInput> for Resource {
     fn from(input: &CanisterSnapshotsInput) -> Self {
         let canister_id = input.canister_id;
-        if let Ok(()) = EnsureExternalCanister::is_external_canister(canister_id) {
+        if EnsureExternalCanister::is_external_canister(canister_id) {
             Resource::ExternalCanister(ExternalCanisterResourceAction::Read(
                 ExternalCanisterId::Canister(canister_id),
             ))
@@ -398,7 +398,7 @@ impl From<&CanisterSnapshotsInput> for Resource {
 impl From<&CanisterStatusInput> for Resource {
     fn from(input: &CanisterStatusInput) -> Self {
         let canister_id = input.canister_id;
-        if let Ok(()) = EnsureExternalCanister::is_external_canister(canister_id) {
+        if EnsureExternalCanister::is_external_canister(canister_id) {
             Resource::ExternalCanister(ExternalCanisterResourceAction::Read(
                 ExternalCanisterId::Canister(canister_id),
             ))

--- a/core/station/impl/src/mappers/authorization.rs
+++ b/core/station/impl/src/mappers/authorization.rs
@@ -1,6 +1,6 @@
 use super::HelperMapper;
 use crate::{
-    core::{ic_cdk::api::trap, CallContext},
+    core::{ic_cdk::api::trap, validation::EnsureExternalCanister, CallContext},
     models::{
         resource::{
             AccountResourceAction, CallExternalCanisterResourceTarget,
@@ -15,7 +15,9 @@ use crate::{
 };
 use orbit_essentials::repository::Repository;
 use orbit_essentials::types::UUID;
-use station_api::{RequestOperationInput, UserPrivilege};
+use station_api::{
+    CanisterSnapshotsInput, CanisterStatusInput, RequestOperationInput, UserPrivilege,
+};
 
 pub const USER_PRIVILEGES: [UserPrivilege; 23] = [
     UserPrivilege::Capabilities,
@@ -376,6 +378,32 @@ impl From<&station_api::CreateRequestInput> for Resource {
                         .as_bytes(),
                 )))
             }
+        }
+    }
+}
+
+impl From<&CanisterSnapshotsInput> for Resource {
+    fn from(input: &CanisterSnapshotsInput) -> Self {
+        let canister_id = input.canister_id;
+        if let Ok(()) = EnsureExternalCanister::is_external_canister(canister_id) {
+            Resource::ExternalCanister(ExternalCanisterResourceAction::Read(
+                ExternalCanisterId::Canister(canister_id),
+            ))
+        } else {
+            Resource::System(SystemResourceAction::SystemInfo)
+        }
+    }
+}
+
+impl From<&CanisterStatusInput> for Resource {
+    fn from(input: &CanisterStatusInput) -> Self {
+        let canister_id = input.canister_id;
+        if let Ok(()) = EnsureExternalCanister::is_external_canister(canister_id) {
+            Resource::ExternalCanister(ExternalCanisterResourceAction::Read(
+                ExternalCanisterId::Canister(canister_id),
+            ))
+        } else {
+            Resource::System(SystemResourceAction::SystemInfo)
         }
     }
 }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -767,7 +767,7 @@ impl CanisterMethod {
 
 impl ModelValidator<ValidationError> for CanisterMethod {
     fn validate(&self) -> ModelValidatorResult<ValidationError> {
-        EnsureExternalCanister::is_external_canister(self.canister_id)?;
+        EnsureExternalCanister::ensure_external_canister(self.canister_id)?;
 
         Ok(())
     }

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -420,11 +420,9 @@ impl ExternalCanisterService {
     /// The station needs to be a controller of the target canister.
     pub async fn canister_status(
         &self,
-        input: CanisterIdRecord,
+        canister_id: Principal,
     ) -> ServiceResult<CanisterStatusResponse> {
-        let canister_status_arg = CanisterIdRecord {
-            canister_id: input.canister_id,
-        };
+        let canister_status_arg = CanisterIdRecord { canister_id };
 
         let canister_status_response = mgmt::canister_status(canister_status_arg)
             .await
@@ -439,13 +437,8 @@ impl ExternalCanisterService {
     /// Calls the management canister to get the snapshots of the canister with the given id.
     ///
     /// The station needs to be a controller of the target canister.
-    pub async fn canister_snapshots(
-        &self,
-        input: CanisterIdRecord,
-    ) -> ServiceResult<Vec<Snapshot>> {
-        let canister_snapshots_arg = CanisterIdRecord {
-            canister_id: input.canister_id,
-        };
+    pub async fn canister_snapshots(&self, canister_id: Principal) -> ServiceResult<Vec<Snapshot>> {
+        let canister_snapshots_arg = CanisterIdRecord { canister_id };
 
         let canister_snapshots_response = mgmt::list_canister_snapshots(canister_snapshots_arg)
             .await

--- a/core/station/impl/src/services/external_canister.rs
+++ b/core/station/impl/src/services/external_canister.rs
@@ -458,7 +458,7 @@ impl ExternalCanisterService {
         arg: Option<Vec<u8>>,
         cycles: Option<u64>,
     ) -> ServiceResult<Vec<u8>, ExternalCanisterError> {
-        EnsureExternalCanister::is_external_canister(canister_id)?;
+        EnsureExternalCanister::ensure_external_canister(canister_id)?;
 
         call_raw(
             canister_id,
@@ -504,7 +504,7 @@ impl ExternalCanisterService {
                 external_canister
             }
             CreateExternalCanisterOperationKind::AddExisting(opts) => {
-                EnsureExternalCanister::is_external_canister(opts.canister_id)?;
+                EnsureExternalCanister::ensure_external_canister(opts.canister_id)?;
                 self.check_unique_canister_id(&opts.canister_id, None)?;
 
                 let external_canister =

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -1712,11 +1712,8 @@ fn read_system_canister_info() {
     )
     .unwrap();
 
-    // create new user identities and add them to the station
+    // checking canister snapshots/status of the upgrader on behalf of an unauthenticated user fails
     let user = user_test_id(0);
-    add_user(&env, user, vec![], canister_ids.station);
-
-    // checking canister snapshots/status of the upgrader on behalf of the user fails
     let err = update_candid_as::<_, (ApiResult<Vec<Snapshot>>,)>(
         &env,
         canister_ids.station,
@@ -1725,9 +1722,7 @@ fn read_system_canister_info() {
         (canister_id_record.clone(),),
     )
     .unwrap_err();
-    assert!(err
-        .reject_message
-        .contains("Resource::System(SystemResourceAction::SystemInfo)"));
+    assert!(err.reject_message.contains("System(SystemInfo)"));
     let err = update_candid_as::<_, (CanisterStatusResult,)>(
         &env,
         canister_ids.station,
@@ -1736,7 +1731,5 @@ fn read_system_canister_info() {
         (canister_id_record.clone(),),
     )
     .unwrap_err();
-    assert!(err
-        .reject_message
-        .contains("Resource::System(SystemResourceAction::SystemInfo)"));
+    assert!(err.reject_message.contains("System(SystemInfo)"));
 }


### PR DESCRIPTION
This PR restricts access to reading canister snapshots/status for system canisters by using the permission `Resource::System(SystemResourceAction::SystemInfo)` instead of external canister permissions which are not appropriate for system canisters.