### PR TITLE
feat(station,upgrader,control-panel): enable overflow-checks in production canister builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ license = "Apache-2.0"
 lto = true
 opt-level = 'z'
 codegen-units = 1
+overflow-checks = true
 
 [workspace.dependencies]
 anyhow = "1.0.75"


### PR DESCRIPTION
This PR enables overflow-checks in production canister builds: consequently, overflows will result in traps of the corresponding canister method in which the overflow occurs.