### PR TITLE
fix(station): harden async batch flows

### DIFF
--- a/core/station/impl/src/jobs/execute_created_transfers.rs
+++ b/core/station/impl/src/jobs/execute_created_transfers.rs
@@ -107,9 +107,8 @@ impl Job {
 
         // wait for all the transfers to be executed
         let results = future::join_all(calls).await;
-        let transfers = transfers.clone();
 
-        for (pos, result) in results.iter().enumerate() {
+        for result in results.into_iter() {
             match result {
                 Ok((transfer, details)) => {
                     let (mut transfer, _account, asset) = transfer.clone();
@@ -153,8 +152,7 @@ impl Job {
                         ));
                     }
                 }
-                Err(e) => {
-                    let mut transfer = transfers[pos].clone();
+                Err((mut transfer, e)) => {
                     transfer.status = TransferStatus::Failed {
                         reason: e.to_string(),
                     };
@@ -187,38 +185,51 @@ impl Job {
     async fn execute_transfer(
         &self,
         transfer: Transfer,
-    ) -> Result<((Transfer, Account, Asset), BlockchainTransactionSubmitted), TransferError> {
+    ) -> Result<
+        ((Transfer, Account, Asset), BlockchainTransactionSubmitted),
+        (Transfer, TransferError),
+    > {
         let account = self
             .account_repository
             .get(&Account::key(transfer.from_account))
-            .ok_or(TransferError::ValidationError {
-                info: format!(
-                    "Transfer account not found for id {}",
-                    Uuid::from_bytes(transfer.from_account).hyphenated()
-                ),
-            })?;
+            .ok_or((
+                transfer.clone(),
+                TransferError::ValidationError {
+                    info: format!(
+                        "Transfer account not found for id {}",
+                        Uuid::from_bytes(transfer.from_account).hyphenated()
+                    ),
+                },
+            ))?;
 
-        let asset = self.asset_repository.get(&transfer.from_asset).ok_or(
+        let asset = self.asset_repository.get(&transfer.from_asset).ok_or((
+            transfer.clone(),
             TransferError::ValidationError {
                 info: format!(
                     "Transfer asset not found for id {}",
                     Uuid::from_bytes(transfer.from_asset).hyphenated()
                 ),
             },
-        )?;
+        ))?;
 
         let blockchain_api = BlockchainApiFactory::build(&asset.blockchain).map_err(|e| {
-            TransferError::ExecutionError {
-                reason: format!("Failed to build blockchain api: {}", e),
-            }
+            (
+                transfer.clone(),
+                TransferError::ExecutionError {
+                    reason: format!("Failed to build blockchain api: {}", e),
+                },
+            )
         })?;
 
         match blockchain_api.submit_transaction(&account, &transfer).await {
             Ok(details) => Ok(((transfer, account, asset), details)),
 
-            Err(error) => Err(TransferError::ExecutionError {
-                reason: error.to_json_string(),
-            })?,
+            Err(error) => Err((
+                transfer,
+                TransferError::ExecutionError {
+                    reason: error.to_json_string(),
+                },
+            ))?,
         }
     }
 }

--- a/core/station/impl/src/jobs/execute_scheduled_requests.rs
+++ b/core/station/impl/src/jobs/execute_scheduled_requests.rs
@@ -8,9 +8,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::future;
-#[cfg(test)]
-use orbit_essentials::cdk::api::call::RejectionCode;
-#[cfg(not(test))]
 use orbit_essentials::cdk::{call, id};
 use orbit_essentials::repository::Repository;
 
@@ -78,15 +75,13 @@ impl Job {
 
         // wait for all the requests to be executed
         let results = future::join_all(calls).await;
-        let requests = requests.clone();
 
         // update the status of the requests
-        for (pos, result) in results.iter().enumerate() {
+        for result in results.into_iter() {
             match result {
                 Ok(()) => (),
-                Err(e) => {
+                Err((request, e)) => {
                     let request_failed_time = next_time();
-                    let request = requests[pos].clone();
                     self.request_service
                         .fail_request(request, e.to_string(), request_failed_time)
                         .await;
@@ -102,15 +97,22 @@ impl Job {
     /// This function will handle the request execution for the given operation type.
     /// In production, the actual request execution is wrapped inside an inter-canister call
     /// to catch traps and report them as `RequestExecuteError::InternalError`.
-    async fn execute_request(&self, request: Request) -> Result<(), RequestExecuteError> {
-        #[cfg(not(test))]
-        let res = call::<_, (_,)>(id(), "try_execute_request", (request.id,)).await;
-        #[cfg(test)]
-        let res: Result<_, (RejectionCode, String)> =
-            Ok((self.request_service.try_execute_request(request.id).await,));
-        match res {
-            Ok(res) => res.0,
-            Err((_code, msg)) => Err(RequestExecuteError::InternalError { reason: msg }),
+    async fn execute_request(
+        &self,
+        request: Request,
+    ) -> Result<(), (Request, RequestExecuteError)> {
+        if cfg!(test) {
+            self.request_service
+                .try_execute_request(request.id)
+                .await
+                .map_err(|e| (request, e))
+        } else {
+            call::<_, (_,)>(id(), "try_execute_request", (request.id,))
+                .await
+                .map(|res| res.0)
+                .map_err(|(_code, msg)| {
+                    (request, RequestExecuteError::InternalError { reason: msg })
+                })
         }
     }
 }


### PR DESCRIPTION
This PR hardens async batch flows to not enumerate the results and index into foreign vectors since those foreign vectors might not be aligned with the result vector (it does not seem to be an issue at the moment, but the current design is error-prone w.r.t. future changes).