### PR TITLE
fix(station): Asset request factories now use Request::from_request_creation_input

### DIFF
--- a/core/station/impl/src/factories/requests/add_asset.rs
+++ b/core/station/impl/src/factories/requests/add_asset.rs
@@ -18,20 +18,15 @@ impl Create<station_api::AddAssetOperationInput> for AddAssetRequestCreate {
         input: station_api::CreateRequestInput,
         operation_input: station_api::AddAssetOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::AddAsset(AddAssetOperation {
                 asset_id: None,
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Asset creation".to_string()),
-            input.summary,
+            "Add asset".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/edit_asset.rs
+++ b/core/station/impl/src/factories/requests/edit_asset.rs
@@ -18,19 +18,14 @@ impl Create<station_api::EditAssetOperationInput> for EditAssetRequestCreate {
         input: station_api::CreateRequestInput,
         operation_input: station_api::EditAssetOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::EditAsset(EditAssetOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Edit asset".to_string()),
-            input.summary,
+            "Edit asset".to_string(),
         );
 
         Ok(request)

--- a/core/station/impl/src/factories/requests/remove_asset.rs
+++ b/core/station/impl/src/factories/requests/remove_asset.rs
@@ -18,19 +18,14 @@ impl Create<station_api::RemoveAssetOperationInput> for RemoveAssetRequestCreate
         input: station_api::CreateRequestInput,
         operation_input: station_api::RemoveAssetOperationInput,
     ) -> Result<Request, RequestError> {
-        let request = Request::new(
+        let request = Request::from_request_creation_input(
             request_id,
             requested_by_user,
-            Request::default_expiration_dt_ns(),
+            input,
             RequestOperation::RemoveAsset(RemoveAssetOperation {
                 input: operation_input.into(),
             }),
-            input
-                .execution_plan
-                .map(Into::into)
-                .unwrap_or(RequestExecutionPlan::Immediate),
-            input.title.unwrap_or_else(|| "Remove asset".to_string()),
-            input.summary,
+            "Remove asset".to_string(),
         );
 
         Ok(request)


### PR DESCRIPTION
The asset related request factory implementations used custom request creation code which did not correctly instantiate the requests.