### PR TITLE
chore(ci): bump Rust to 1.87.0

### DIFF
--- a/core/station/impl/results.yml
+++ b/core/station/impl/results.yml
@@ -1,55 +1,55 @@
 benches:
   batch_insert_100_requests:
     total:
-      instructions: 231070696
+      instructions: 220314676
       heap_increase: 0
       stable_memory_increase: 96
     scopes: {}
   find_100_users_from_50k_user_dataset:
     total:
-      instructions: 255101550
+      instructions: 225483018
       heap_increase: 97
       stable_memory_increase: 0
     scopes: {}
   find_500_external_canister_policies_from_50k_dataset:
     total:
-      instructions: 27281440
+      instructions: 22585211
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   heap_size_of_indexed_request_fields_cache_is_lt_300mib:
     total:
-      instructions: 223191635
+      instructions: 167467878
       heap_increase: 85
       stable_memory_increase: 0
     scopes: {}
   list_1k_requests:
     total:
-      instructions: 136257341
+      instructions: 117939823
       heap_increase: 14
       stable_memory_increase: 0
     scopes: {}
   list_external_canisters_with_all_statuses:
     total:
-      instructions: 229849223
+      instructions: 192133415
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   repository_find_1k_requests_from_10k_dataset_default_filters:
     total:
-      instructions: 89527437
+      instructions: 76177472
       heap_increase: 17
       stable_memory_increase: 0
     scopes: {}
   service_filter_5k_requests_from_100k_dataset:
     total:
-      instructions: 683738661
+      instructions: 531817581
       heap_increase: 112
       stable_memory_increase: 16
     scopes: {}
   service_find_all_requests_from_2k_dataset:
     total:
-      instructions: 275031891
+      instructions: 216447371
       heap_increase: 49
       stable_memory_increase: 16
     scopes: {}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -39,9 +39,9 @@ package_version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages
 cargo build --locked --target wasm32-unknown-unknown --release --package $PACKAGE $FEATURES
 
 if [[ "$OSTYPE" == "linux"* || "$RUNNER_OS" == "Linux" ]]; then
-  URL="https://github.com/dfinity/ic-wasm/releases/download/0.6.0/ic-wasm-linux64"
+  URL="https://github.com/dfinity/ic-wasm/releases/download/0.9.3/ic-wasm-linux64"
 elif [[ "$OSTYPE" == "darwin"* || "$RUNNER_OS" == "macOS" ]]; then
-  URL="https://github.com/dfinity/ic-wasm/releases/download/0.6.0/ic-wasm-macos"
+  URL="https://github.com/dfinity/ic-wasm/releases/download/0.9.3/ic-wasm-macos"
 else
   echo "OS not supported: ${OSTYPE:-$RUNNER_OS}"
   exit 1


### PR DESCRIPTION
This PR bumps the Rust compiler version to the latest stable version 1.87.0 and the ic-wasm version to the latest version 0.9.3.

The performance improves quite a bit due to bulk memory operations (requiring the ic-wasm version bump).