### PR TITLE
chore(ci): bump uuid crate

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -83,6 +83,9 @@ jobs:
         run: |
           cargo fmt --all -- --check
           cargo clippy --locked --verbose --tests --benches --workspace -- -D clippy::all
+      - name: 'Check code (wasm32-unknown-unknown)'
+        run: |
+          export RUSTFLAGS="--cfg getrandom_backend=\"custom\""
           cargo clippy --locked --verbose --target wasm32-unknown-unknown -p control-panel -p station -p upgrader -- -D clippy::all
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
  "rand",
@@ -1736,7 +1736,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3148,7 +3160,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3360,7 +3372,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "convert_case",
- "getrandom",
+ "getrandom 0.3.3",
  "hex",
  "ic-cdk 0.17.2",
  "ic-cdk-timers",
@@ -3935,6 +3947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3961,7 +3979,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3994,7 +4012,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.63",
 ]
@@ -4143,7 +4161,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5553,12 +5571,22 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "serde",
+ "uuid-rng-internal",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9376f53b15ed85851c10175b5e45f0af556b4853ff3fe335080b337e3828981e"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -5603,6 +5631,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6041,6 +6078,15 @@ checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
  "bitflags 2.6.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dfx-core = { git = "https://github.com/dfinity/sdk.git", rev = "d65717bd6d0c1722
 flate2 = "1.0"
 convert_case = "0.6"
 futures = "0.3"
-getrandom = { version = "0.2", features = ["custom"] }
+getrandom = { version = "0.3.3" }
 hex = "0.4"
 ic-agent = "0.38"
 ic-asset = { git = "https://github.com/dfinity/sdk.git", rev = "d65717bd6d0c172247c37dd23395c9fb13b2ba20" }
@@ -88,6 +88,6 @@ tempfile = "3.10"
 thiserror = "1.0.48"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1.44.2" }
-uuid = { version = "1.4.1", features = ["serde", "v4"] }
+uuid = { version = "1.16.0", features = ["serde", "v4", "rng-getrandom"] }
 wat = "1.0.52"
 semver = "1.0.23"

--- a/libs/orbit-essentials/Cargo.toml
+++ b/libs/orbit-essentials/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 base64 = { workspace = true }
 candid = { workspace = true }
 convert_case = { workspace = true }
-getrandom = { workspace = true, features = ['custom'] }
+getrandom = { workspace = true }
 hex = { workspace = true }
 ic-cdk = { workspace = true }
 ic-certification = { workspace = true }
@@ -33,7 +33,7 @@ serde_json = { workspace = true }
 serde_bytes = { workspace = true }
 time = { workspace = true, features = ['formatting', 'parsing'] }
 thiserror = { workspace = true }
-uuid = { workspace = true, features = ['serde', 'v4'] }
+uuid = { workspace = true, features = ['serde', 'v4', 'rng-getrandom'] }
 ic-cdk-timers = { workspace = true }
 sha2 = { workspace = true }
 

--- a/libs/orbit-essentials/src/utils/random.rs
+++ b/libs/orbit-essentials/src/utils/random.rs
@@ -27,8 +27,6 @@ unsafe extern "Rust" fn __getrandom_v03_custom(
 ) -> Result<(), getrandom::Error> {
     RNG.with(|rng| {
         let buf = unsafe {
-            // fill the buffer with zeros
-            core::ptr::write_bytes(dest, 0, len);
             // create mutable byte slice
             core::slice::from_raw_parts_mut(dest, len)
         };

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -46,7 +46,7 @@ else
   echo "OS not supported: ${OSTYPE:-$RUNNER_OS}"
   exit 1
 fi
-#curl -sL "${URL}" -o ic-wasm || exit 1
+curl -sL "${URL}" -o ic-wasm || exit 1
 chmod +x ic-wasm
 
 PACKAGE=$(echo $PACKAGE | tr - _)

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -28,7 +28,7 @@ echo "Ensuring rust toolchain is installed"
 rustup show active-toolchain || rustup toolchain install
 
 echo Building package $PACKAGE
-export RUSTFLAGS="--remap-path-prefix $(readlink -f ${SCRIPT_DIR}/..)=/build --remap-path-prefix ${CARGO_HOME}/bin=/cargo/bin --remap-path-prefix ${CARGO_HOME}/git=/cargo/git"
+export RUSTFLAGS="--remap-path-prefix $(readlink -f ${SCRIPT_DIR}/..)=/build --remap-path-prefix ${CARGO_HOME}/bin=/cargo/bin --remap-path-prefix ${CARGO_HOME}/git=/cargo/git --cfg getrandom_backend=\"custom\""
 for l in $(ls ${CARGO_HOME}/registry/src/); do
   export RUSTFLAGS="--remap-path-prefix ${CARGO_HOME}/registry/src/${l}=/cargo/registry/src/github ${RUSTFLAGS}"
 done
@@ -46,7 +46,7 @@ else
   echo "OS not supported: ${OSTYPE:-$RUNNER_OS}"
   exit 1
 fi
-curl -sL "${URL}" -o ic-wasm || exit 1
+#curl -sL "${URL}" -o ic-wasm || exit 1
 chmod +x ic-wasm
 
 PACKAGE=$(echo $PACKAGE | tr - _)


### PR DESCRIPTION
This PR bumps the `uuid` and `getrandom` crates. Because of
```
#[no_mangle]
unsafe extern "Rust" fn __getrandom_v03_custom(
```
multiple versions of the orbit essentials library in the build tree might lead to linking errors.