### PR TITLE
fix(wallet): empty reason if no matching approval policy found

### DIFF
--- a/apps/wallet/src/utils/evaluation.utils.ts
+++ b/apps/wallet/src/utils/evaluation.utils.ts
@@ -53,7 +53,7 @@ export function statusReasonsToTextSummary(
   const reasonList = reasons
     .map(reason => i18n.global.t(summaryReasonToI18nKey(reason, finalStatus)))
     .join(', ');
-  const reason = reasonList || "No matching approval policy";
+  const reason = reasonList || 'No matching approval policy';
 
   return `${i18n.global.t(summaryKey, {
     count: reasons.length,

--- a/apps/wallet/src/utils/evaluation.utils.ts
+++ b/apps/wallet/src/utils/evaluation.utils.ts
@@ -53,8 +53,9 @@ export function statusReasonsToTextSummary(
   const reasonList = reasons
     .map(reason => i18n.global.t(summaryReasonToI18nKey(reason, finalStatus)))
     .join(', ');
+  const reason = reasonList || "No matching approval policy";
 
   return `${i18n.global.t(summaryKey, {
     count: reasons.length,
-  })} ${reasonList}.`;
+  })} ${reason}.`;
 }

--- a/apps/wallet/src/utils/evaluation.utils.ts
+++ b/apps/wallet/src/utils/evaluation.utils.ts
@@ -1,6 +1,6 @@
 import { EvaluationStatus, EvaluationSummaryReason } from '~/generated/station/station.did';
-import { unreachable, variantIs } from './helper.utils';
 import { i18n } from '~/plugins/i18n.plugin';
+import { unreachable, variantIs } from './helper.utils';
 
 export function statusToI18nKeyPrefix(status: EvaluationStatus): string {
   if (variantIs(status, 'Approved')) {


### PR DESCRIPTION
This PR fixes the message "Request rejected for the following reasons: ." in case of no matching approval policy found to "Request rejected for the following reasons: No matching approval policy.".