### PR TITLE
chore(deps): bump lodash to fix Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "picomatch@>=2.0.0 <2.3.2": "2.3.2",
       "lodash-es@<4.18.0": "^4.18.1",
       "brace-expansion@^1": "1.1.13",
-      "brace-expansion@^2": "2.0.3"
+      "brace-expansion@^2": "2.0.3",
+      "lodash@<4.18.0": "^4.18.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   lodash-es@<4.18.0: ^4.18.1
   brace-expansion@^1: 1.1.13
   brace-expansion@^2: 2.0.3
+  lodash@<4.18.0: ^4.18.1
 
 importers:
 
@@ -4925,8 +4926,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -10430,7 +10431,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       rxjs: 7.8.1
       shell-quote: 1.8.2
       spawn-command: 0.0.2
@@ -12094,7 +12095,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -14297,7 +14298,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- Adds pnpm override for `lodash@<4.18.0` → `^4.18.1`, resolving 2 Dependabot alerts:
  - **`lodash`** — high (#218): code injection via `_.template` imports key names
  - **`lodash`** — medium (#217): prototype pollution via `_.unset` and `_.omit`

## Notes
- Alert #201 (`rustls-webpki` 0.102.8) remains open — constrained by `ic-agent@0.38.2`, requires a major `ic-agent` version upgrade to resolve

## Test plan
- [x] `pnpm install` completes successfully
- [x] Lockfile contains `lodash@4.18.1` (no more `4.17.21`)
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)