### PR TITLE
refactor(scripts): use dfx --system-canisters instead of manual NNS setup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -166,10 +166,6 @@ jobs:
         uses: dfinity/setup-dfx@main
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
-      - name: 'Install cbor2'
-        run: pip install cbor2
-      - name: 'Install crc32'
-        run: sudo apt install -y libarchive-zip-perl
       - name: 'Install Dependencies'
         run: |
           pnpm install --frozen-lockfile
@@ -192,7 +188,7 @@ jobs:
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
       - name: 'Start PocketIC'
-        run: dfx start --clean --pocketic --host 127.0.0.1:4943 --background
+        run: dfx start --clean --system-canisters --host 127.0.0.1:4943 --background
       - name: 'Perform local deployment'
         run: ./orbit --init
       - name: 'Test local deployment'
@@ -204,12 +200,6 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
-      - name: 'Setup Python'
-        uses: actions/setup-python@v5
-      - name: 'Install cbor2'
-        run: pip install cbor2
-      - name: 'Install crc32'
-        run: sudo apt install -y libarchive-zip-perl
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
       - name: 'Run sccache-cache'
@@ -217,7 +207,7 @@ jobs:
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
       - name: 'Start local replica'
-        run: dfx start --clean --host 127.0.0.1:4943 --background
+        run: dfx start --clean --system-canisters --host 127.0.0.1:4943 --background
       - name: 'Perform local deployment'
         run: ./orbit --init
       - name: 'Test local deployment'
@@ -245,7 +235,7 @@ jobs:
       - name: 'Install dfx'
         uses: dfinity/setup-dfx@main
       - name: 'Start local replica'
-        run: dfx start --clean --pocketic --host 127.0.0.1:4943 --background
+        run: dfx start --clean --system-canisters --host 127.0.0.1:4943 --background
       - name: 'Test prod deployment script'
         run: |
           echo y | ./scripts/deploy.sh --local # install

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Start PocketIC with system canisters (ICP ledger, ICP index, CMC, Internet Ident
 dfx start --clean --system-canisters --host 127.0.0.1:4943
 ```
 
-Note that the local replica should be stopped using `dfx stop` rather than by CTRL^C.
+Note that PocketIC should be stopped using `dfx stop` rather than by CTRL^C.
 
 Then the following steps can be used to setup the Orbit canister ecosystem for local development.
 

--- a/README.md
+++ b/README.md
@@ -89,21 +89,13 @@ Please make sure you have the following installed:
 
 ### Building the Code
 
-Start a local replica listening on port 4943:
+Start PocketIC with system canisters (ICP ledger, ICP index, CMC, Internet Identity) listening on port 4943:
 
 ```
-dfx start --clean --pocketic --host 127.0.0.1:4943
+dfx start --clean --system-canisters --host 127.0.0.1:4943
 ```
 
 Note that the local replica should be stopped using `dfx stop` rather than by CTRL^C.
-
-If you want to resume your local replica after `dfx stop`, then you need to install the Python package `cbor2`,
-have the binary `crc32` to compute CRC32 checksums on your executable path,
-and use the following command for the first time:
-
-```
-dfx start --clean --host 127.0.0.1:4943
-```
 
 Then the following steps can be used to setup the Orbit canister ecosystem for local development.
 

--- a/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
+++ b/apps/wallet/src/generated/control-panel/control_panel.did.d.ts
@@ -2,185 +2,895 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+/**
+ * The input for adding a registry entry.
+ */
 export interface AddRegistryEntryInput { 'entry' : RegistryEntryInput }
+/**
+ * The response of adding a registry entry.
+ */
 export interface AddRegistryEntryResponse { 'entry' : RegistryEntry }
-export type AddRegistryEntryResult = { 'Ok' : AddRegistryEntryResponse } |
-  { 'Err' : ApiError };
+/**
+ * The result of adding a registry entry.
+ */
+export type AddRegistryEntryResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : AddRegistryEntryResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * Generic error type added to responses that can fail.
+ */
 export interface ApiError {
+  /**
+   * Error code, added as a string to allow for custom error codes.
+   */
   'code' : string,
+  /**
+   * Error message to be displayed to the user.
+   */
   'message' : [] | [string],
+  /**
+   * Error details to be displayed to the user.
+   */
   'details' : [] | [Array<[string, string]>],
 }
+/**
+ * The artifact type.
+ */
 export interface Artifact {
+  /**
+   * The id of the artifact.
+   */
   'id' : UUID,
+  /**
+   * The sha256 hash of the artifact.
+   */
   'hash' : Sha256Hex,
+  /**
+   * The blob of the artifact.
+   */
   'artifact' : Uint8Array | number[],
+  /**
+   * The size of the artifact in bytes.
+   */
   'size' : bigint,
+  /**
+   * The timestamp when the artifact was created.
+   */
   'created_at' : TimestampRFC3339,
 }
+/**
+ * The successful result of checking if the caller can deploy a station canister.
+ * Returns the remaining number of station canisters the caller can still deploy
+ * or a reason why the caller cannot deploy a station canister
+ * (bad subscription status or exceeded quota).
+ */
 export type CanDeployStationResponse = {
     'NotAllowed' : UserSubscriptionStatus
   } |
   { 'Allowed' : bigint } |
   { 'QuotaExceeded' : null };
-export type CanDeployStationResult = { 'Ok' : CanDeployStationResponse } |
-  { 'Err' : ApiError };
-export interface DeleteRegistryEntryInput { 'id' : UUID }
-export interface DeleteRegistryEntryResponse { 'entry' : RegistryEntry }
-export type DeleteRegistryEntryResult = { 'Ok' : DeleteRegistryEntryResponse } |
-  { 'Err' : ApiError };
+/**
+ * The result of checking if the caller can deploy a station canister.
+ */
+export type CanDeployStationResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : CanDeployStationResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The input for deleting a registry entry.
+ */
+export interface DeleteRegistryEntryInput {
+  /**
+   * The id of the registry entry.
+   */
+  'id' : UUID,
+}
+/**
+ * The response of deleting a registry entry.
+ */
+export interface DeleteRegistryEntryResponse {
+  /**
+   * The registry entry that was deleted.
+   */
+  'entry' : RegistryEntry,
+}
+/**
+ * The result of deleting a registry entry.
+ */
+export type DeleteRegistryEntryResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : DeleteRegistryEntryResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The input for deploying a station admin user.
+ * 
+ * Used to associate a user with a station canister as an admin when initializing the station.
+ */
 export interface DeployStationAdminUserInput {
+  /**
+   * The username to associate with the station canister as an admin.
+   */
   'username' : string,
+  /**
+   * The principal of the user to associate with the station canister as an admin.
+   */
   'identity' : Principal,
 }
+/**
+ * The input for deploying a station canister.
+ */
 export interface DeployStationInput {
+  /**
+   * The station name to use.
+   */
   'name' : string,
+  /**
+   * The subnet to which the station should be deployed.
+   * 
+   * By default, the station is deployed to the same subnet as the control panel.
+   */
   'subnet_selection' : [] | [SubnetSelection],
+  /**
+   * The initial admin users for the station.
+   */
   'admins' : Array<DeployStationAdminUserInput>,
-  'associate_with_caller' : [] | [{ 'labels' : Array<string> }],
+  /**
+   * Wether to associate the deployed station to the caller's stations.
+   * 
+   * By default, the station is only added to the caller's stations if the caller is in the provided admins list.
+   */
+  'associate_with_caller' : [] | [
+    {
+      /**
+       * The labels to associate with the station for the caller.
+       */
+      'labels' : Array<string>,
+    }
+  ],
 }
-export type DeployStationResult = { 'Ok' : { 'canister_id' : StationID } } |
-  { 'Err' : ApiError };
+/**
+ * The result of deploying a station canister for the caller.
+ */
+export type DeployStationResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : {
+      /**
+       * The station canister id.
+       */
+      'canister_id' : StationID,
+    }
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The input for editing a registry entry.
+ */
 export interface EditRegistryEntryInput {
+  /**
+   * The id of the registry entry.
+   */
   'id' : UUID,
+  /**
+   * The updated registry entry.
+   */
   'entry' : RegistryEntryUpdateInput,
 }
+/**
+ * The response of editing a registry entry.
+ */
 export interface EditRegistryEntryResponse { 'entry' : RegistryEntry }
-export type EditRegistryEntryResult = { 'Ok' : EditRegistryEntryResponse } |
-  { 'Err' : ApiError };
-export interface GetArtifactInput { 'artifact_id' : UUID }
+/**
+ * The result of editing a registry entry.
+ */
+export type EditRegistryEntryResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : EditRegistryEntryResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The get artifact input.
+ */
+export interface GetArtifactInput {
+  /**
+   * The id of the artifact.
+   */
+  'artifact_id' : UUID,
+}
+/**
+ * The get artifact response.
+ */
 export interface GetArtifactResponse { 'artifact' : Artifact }
-export type GetArtifactResult = { 'Ok' : GetArtifactResponse } |
-  { 'Err' : ApiError };
-export interface GetRegistryEntryInput { 'id' : UUID }
-export interface GetRegistryEntryResponse { 'entry' : RegistryEntry }
-export type GetRegistryEntryResult = { 'Ok' : GetRegistryEntryResponse } |
-  { 'Err' : ApiError };
-export type GetUserResult = { 'Ok' : { 'user' : User } } |
-  { 'Err' : ApiError };
+/**
+ * The get artifact result.
+ */
+export type GetArtifactResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : GetArtifactResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The input for getting a registry entry.
+ */
+export interface GetRegistryEntryInput {
+  /**
+   * The id of the registry entry.
+   */
+  'id' : UUID,
+}
+/**
+ * The get registry entry response.
+ */
+export interface GetRegistryEntryResponse {
+  /**
+   * The registry entry that matches the provided id.
+   */
+  'entry' : RegistryEntry,
+}
+/**
+ * The get registry entry result.
+ */
+export type GetRegistryEntryResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : GetRegistryEntryResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The result of getting the user information.
+ */
+export type GetUserResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : {
+      /**
+       * The caller user information.
+       */
+      'user' : User,
+    }
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The HTTP request header field.
+ */
 export type HeaderField = [string, string];
+/**
+ * The HTTP request.
+ */
 export interface HttpRequest {
+  /**
+   * The URL of the request (e.g. https://example.com).
+   */
   'url' : string,
+  /**
+   * The HTTP method of the request (e.g. GET, POST, PUT).
+   */
   'method' : string,
+  /**
+   * The body of the request.
+   */
   'body' : Uint8Array | number[],
+  /**
+   * The headers of the request.
+   */
   'headers' : Array<HeaderField>,
 }
+/**
+ * The HTTP response.
+ */
 export interface HttpResponse {
+  /**
+   * The body of the response.
+   */
   'body' : Uint8Array | number[],
+  /**
+   * The headers of the response.
+   */
   'headers' : Array<HeaderField>,
+  /**
+   * The status code of the response (e.g. 200, 404, 500).
+   */
   'status_code' : number,
 }
+/**
+ * The input for listing stations.
+ */
 export interface ListUserStationsInput {
+  /**
+   * The labels to filter the stations by.
+   * 
+   * All stations that have at least one of the provided labels will be returned, if no labels
+   * are provided all stations will be returned.
+   * 
+   * The match is case insensitive.
+   */
   'filter_by_labels' : [] | [Array<string>],
 }
+/**
+ * The result of listing user stations.
+ */
 export type ListUserStationsResult = {
-    'Ok' : { 'stations' : Array<UserStation> }
+    /**
+     * The list of stations.
+     */
+    'Ok' : {
+      /**
+       * The list of stations.
+       */
+      'stations' : Array<UserStation>,
+    }
   } |
-  { 'Err' : ApiError };
-export type ManageUserStationsInput = { 'Add' : Array<UserStation> } |
-  { 'Remove' : Array<StationID> } |
-  { 'Update' : Array<{ 'station' : UserStation, 'index' : [] | [bigint] }> };
-export type ManageUserStationsResult = { 'Ok' : null } |
-  { 'Err' : ApiError };
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The action to perform on the stations associated with the user.
+ * 
+ * This can be used to add, remove, update the stations associated with the user.
+ */
+export type ManageUserStationsInput = {
+    /**
+     * Add a the specified stations to the user, if the station already exists it will be updated.
+     */
+    'Add' : Array<UserStation>
+  } |
+  {
+    /**
+     * Remove the specified stations from the user, if the station does not exist it will be ignored.
+     */
+    'Remove' : Array<StationID>
+  } |
+  {
+    /**
+     * Update the specified stations associated with the user.
+     */
+    'Update' : Array<
+      {
+        /**
+         * The stations to update, if the station does not exist it will be ignored.
+         */
+        'station' : UserStation,
+        /**
+         * The new index of the station, if the index is out of bounds it will set to the closest bound.
+         */
+        'index' : [] | [bigint],
+      }
+    >
+  };
+/**
+ * The result of managing the user stations.
+ */
+export type ManageUserStationsResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : null
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * A metadata record that contains a key and a value.
+ */
 export interface Metadata { 'key' : string, 'value' : string }
+/**
+ * The input for finding the next wasm module version.
+ */
 export interface NextWasmModuleVersionInput {
+  /**
+   * The name of the registry entry.
+   */
   'name' : string,
+  /**
+   * The current version of the registry entry.
+   */
   'current_version' : string,
 }
+/**
+ * The response of finding the next wasm module version.
+ */
 export interface NextWasmModuleVersionResponse {
+  /**
+   * The registry entry that is the next version of the provided entry.
+   */
   'entry' : [] | [RegistryEntry],
 }
+/**
+ * The result of finding the next wasm module version.
+ */
 export type NextWasmModuleVersionResult = {
+    /**
+     * Successfull operation result.
+     */
     'Ok' : NextWasmModuleVersionResponse
   } |
-  { 'Err' : ApiError };
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
 export interface PaginationInput {
+  /**
+   * The offset to use for pagination.
+   */
   'offset' : [] | [bigint],
+  /**
+   * The maximum number of items to retrieve.
+   * 
+   * If not set, the default limit will be used.
+   */
   'limit' : [] | [number],
 }
-export interface RegisterUserInput { 'station' : [] | [UserStation] }
-export type RegisterUserResult = { 'Ok' : { 'user' : User } } |
-  { 'Err' : ApiError };
+/**
+ * The input for registering an user.
+ */
+export interface RegisterUserInput {
+  /**
+   * A station canister to use for this user.
+   */
+  'station' : [] | [UserStation],
+}
+/**
+ * The result of registering an user.
+ */
+export type RegisterUserResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : {
+      /**
+       * The caller newly created user information.
+       */
+      'user' : User,
+    }
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * An entry record, which contains information and the value stored in the registry.
+ */
 export interface RegistryEntry {
+  /**
+   * The UUID that identifies the entry in the registry.
+   */
   'id' : UUID,
+  /**
+   * The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+   * across all the entries in the registry.
+   * 
+   * Restrictions:
+   * 
+   * - Categories must be between 2 and 32 characters long.
+   * - There can be up to 10 categories per entry.
+   */
   'categories' : Array<string>,
+  /**
+   * The timestamp when the entry was last updated.
+   */
   'updated_at' : [] | [TimestampRFC3339],
+  /**
+   * The content of the entry in the registry.
+   */
   'value' : RegistryEntryValue,
+  /**
+   * The metadata of the entry in the registry.
+   * 
+   * This is a key-value map that can be used to store additional information about the entry,
+   * such as the author, license, repository, docs, etc.
+   * 
+   * Restrictions:
+   * 
+   * - The key must be between 1 and 32 characters long.
+   * - The value must be between 1 and 512 characters long.
+   * - There can be up to 10 metadata entries per entry in the registry.
+   */
   'metadata' : Array<Metadata>,
+  /**
+   * The name of the entry, which is used to identify it (e.g. station). Names that start with `@` are considered
+   * to be namespaced, and the namespace is the part of the name that comes before the `/`. Within each namespace
+   * the name should refer to the same type of entry, but many entries can exist with the same name.
+   * 
+   * e.g. if the namespace is "@orbit" and the name is "station", then all the entries will refer to a wasm module.
+   * 
+   * Restrictions:
+   * 
+   * - Names that start with `@` are considered namespaced.
+   * - Names that start with `@` must have a namespace and a name separated by a `/`.
+   * - Names must be between 2 and 48 characters long.
+   * - Namespaces must be between 2 and 32 characters long.
+   * - Names that are not namespaced, are put in the default namespace `@default`.
+   */
   'name' : string,
+  /**
+   * The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+   * 
+   * Tags are grouped within the same `namespace/name` (e.g. "@orbit/station").
+   * 
+   * Restrictions:
+   * 
+   * - Tags must be between 2 and 32 characters long.
+   * - There can be up to 10 tags per entry.
+   */
   'tags' : Array<string>,
+  /**
+   * The description of the entry, which is a human-readable description of the entry.
+   * 
+   * Restrictions:
+   * 
+   * - Descriptions must be between 24 and 512 characters long.
+   */
   'description' : string,
+  /**
+   * The timestamp when the entry was created.
+   */
   'created_at' : TimestampRFC3339,
 }
+/**
+ * The registry entry input.
+ */
 export interface RegistryEntryInput {
+  /**
+   * The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+   * across all the entries in the registry.
+   */
   'categories' : Array<string>,
+  /**
+   * The content of the entry in the registry.
+   */
   'value' : RegistryEntryValueInput,
+  /**
+   * The metadata of the entry in the registry.
+   */
   'metadata' : Array<Metadata>,
+  /**
+   * The name of the entry, which is used to identify it (e.g. station).
+   */
   'name' : string,
+  /**
+   * The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+   */
   'tags' : Array<string>,
+  /**
+   * The description of the entry, which is a human-readable description of the entry.
+   */
   'description' : string,
 }
-export type RegistryEntrySortBy = { 'Version' : SortDirection } |
-  { 'CreatedAt' : SortDirection };
+/**
+ * The registry entry sort options.
+ */
+export type RegistryEntrySortBy = {
+    /**
+     * Sort by the version of the registry entry, if applicable.
+     */
+    'Version' : SortDirection
+  } |
+  {
+    /**
+     * Sort by the timestamp when the registry entry was created.
+     */
+    'CreatedAt' : SortDirection
+  };
+/**
+ * The registry entry update input.
+ */
 export interface RegistryEntryUpdateInput {
+  /**
+   * The category is used to associate the entry with a specific category (e.g. "chain-fusion")
+   * across all the entries in the registry.
+   */
   'categories' : [] | [Array<string>],
+  /**
+   * The content of the entry in the registry.
+   */
   'value' : [] | [RegistryEntryValueInput],
+  /**
+   * The metadata of the entry in the registry.
+   */
   'metadata' : [] | [Array<Metadata>],
+  /**
+   * The tags are used to tag the entry with specific search terms (e.g. "latest", "stable").
+   */
   'tags' : [] | [Array<string>],
+  /**
+   * The description of the entry, which is a human-readable description of the entry.
+   */
   'description' : [] | [string],
 }
+/**
+ * The registry entry value.
+ */
 export type RegistryEntryValue = {
     'WasmModule' : WasmModuleRegistryEntryValue
   };
+/**
+ * The registry entry value input.
+ */
 export type RegistryEntryValueInput = {
     'WasmModule' : WasmModuleRegistryEntryValueInput
   };
+/**
+ * The registry entry value kind.
+ */
 export type RegistryEntryValueKind = { 'WasmModule' : null };
-export type RemoveUserResult = { 'Ok' : { 'user' : User } } |
-  { 'Err' : ApiError };
-export type SearchRegistryFilterKind = { 'Kind' : RegistryEntryValueKind } |
-  { 'Name' : string } |
-  { 'Namespace' : string };
+/**
+ * The result of removing the user associated with the caller.
+ */
+export type RemoveUserResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : {
+      /**
+       * The caller user that was removed.
+       */
+      'user' : User,
+    }
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The search registry filter options.
+ */
+export type SearchRegistryFilterKind = {
+    /**
+     * The kind of registry entry to find.
+     */
+    'Kind' : RegistryEntryValueKind
+  } |
+  {
+    /**
+     * The name of the registry entry to find, if the namespace is not provided the default namespace is used.
+     */
+    'Name' : string
+  } |
+  {
+    /**
+     * The namespace of the registry entry to find.
+     */
+    'Namespace' : string
+  };
+/**
+ * The input for searching the registry.
+ */
 export interface SearchRegistryInput {
+  /**
+   * Sort the entries in the registry.
+   */
   'sort_by' : [] | [RegistryEntrySortBy],
+  /**
+   * The pagination options to use for the search.
+   */
   'pagination' : [] | [PaginationInput],
+  /**
+   * Filters are used sequentially and are combined with an AND operation to filter the entries in the registry.
+   */
   'filter_by' : Array<SearchRegistryFilterKind>,
 }
+/**
+ * The search registry response.
+ */
 export interface SearchRegistryResponse {
+  /**
+   * The total number of entries that match the search criteria.
+   */
   'total' : bigint,
+  /**
+   * The list of registry entries that match the search criteria.
+   */
   'entries' : Array<RegistryEntry>,
+  /**
+   * The next offset to use for pagination.
+   */
   'next_offset' : [] | [bigint],
 }
-export type SearchRegistryResult = { 'Ok' : SearchRegistryResponse } |
-  { 'Err' : ApiError };
-export type SetUserActiveResult = { 'Ok' : null } |
-  { 'Err' : ApiError };
+/**
+ * The search registry result.
+ */
+export type SearchRegistryResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : SearchRegistryResponse
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The result of setting the user active.
+ */
+export type SetUserActiveResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : null
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The sha256 hash.
+ */
 export type Sha256Hex = string;
 export type SortDirection = { 'Asc' : null } |
   { 'Desc' : null };
+/**
+ * The canister id of a station.
+ */
 export type StationID = Principal;
 export interface SubnetFilter { 'subnet_type' : [] | [string] }
-export type SubnetSelection = { 'Filter' : SubnetFilter } |
-  { 'Subnet' : { 'subnet' : Principal } };
+export type SubnetSelection = {
+    /**
+     * Choose a random subnet that fulfills the specified properties
+     */
+    'Filter' : SubnetFilter
+  } |
+  {
+    /**
+     * Choose a specific subnet
+     */
+    'Subnet' : { 'subnet' : Principal }
+  };
+/**
+ * The timestamp type used in the canister.
+ */
 export type TimestampRFC3339 = string;
+/**
+ * A UUID used to identify items.
+ */
 export type UUID = string;
+/**
+ * The canister modules required for the control panel.
+ */
 export interface UploadCanisterModulesInput {
+  /**
+   * Optional extra chunks of the station canister wasm module.
+   */
   'station_wasm_module_extra_chunks' : [] | [[] | [WasmModuleExtraChunks]],
+  /**
+   * The station wasm module to use.
+   */
   'station_wasm_module' : [] | [Uint8Array | number[]],
+  /**
+   * The upgrader wasm module to use for the station canister.
+   */
   'upgrader_wasm_module' : [] | [Uint8Array | number[]],
 }
-export type UploadUploadCanisterModulesInputResult = { 'Ok' : null } |
-  { 'Err' : ApiError };
+/**
+ * The result of uploading canister modules.
+ */
+export type UploadUploadCanisterModulesInputResult = {
+    /**
+     * Successfull operation result.
+     */
+    'Ok' : null
+  } |
+  {
+    /**
+     * The error that occurred during the operation.
+     */
+    'Err' : ApiError
+  };
+/**
+ * The user user information.
+ */
 export interface User {
+  /**
+   * The last time the user was active in the system.
+   */
   'last_active' : TimestampRFC3339,
+  /**
+   * The waiting list subscription status.
+   */
   'subscription_status' : UserSubscriptionStatus,
+  /**
+   * The identity associated with the user.
+   */
   'identity' : Principal,
 }
+/**
+ * The id of an user.
+ */
 export type UserId = UUID;
+/**
+ * The principal that is associated with an user.
+ */
 export type UserIdentityID = Principal;
+/**
+ * The station information associated with the user.
+ */
 export interface UserStation {
+  /**
+   * The name of the station.
+   */
   'name' : string,
+  /**
+   * The labels associated with the station.
+   * 
+   * This can be used to store user preferences or other information related to the station such as the station type.
+   * 
+   * Maximum of 10 labels per station and 64 characters per label.
+   */
   'labels' : Array<string>,
+  /**
+   * The id associated with the station.
+   */
   'canister_id' : StationID,
 }
 export type UserSubscriptionStatus = { 'Unsubscribed' : null } |
@@ -188,64 +898,179 @@ export type UserSubscriptionStatus = { 'Unsubscribed' : null } |
   { 'Denylisted' : null } |
   { 'Pending' : null };
 export interface WasmModuleExtraChunks {
+  /**
+   * The hash of the assembled wasm module.
+   */
   'wasm_module_hash' : Uint8Array | number[],
+  /**
+   * The asset canister from which the chunks are to be retrieved.
+   */
   'store_canister' : Principal,
+  /**
+   * The name of the asset containing extra chunks in the asset canister.
+   */
   'extra_chunks_key' : string,
 }
+/**
+ * The dependency of a wasm module.
+ */
 export interface WasmModuleRegistryEntryDependency {
+  /**
+   * The name of the dependency.
+   */
   'name' : string,
+  /**
+   * The version of the wasm module.
+   */
   'version' : string,
 }
+/**
+ * The wasm module registry value, which is the content of the wasm module and its version.
+ */
 export interface WasmModuleRegistryEntryValue {
+  /**
+   * Optional extra chunks of the wasm module that are stored in an asset canister referenced in the record `WasmModuleExtraChunks`.
+   */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
+  /**
+   * The version of the wasm module.
+   * 
+   * Restrictions:
+   * 
+   * - Versions must be between 1 and 32 characters long.
+   */
   'version' : string,
+  /**
+   * The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+   * 
+   * This registry ids should only reference registry entries that are of type `WasmModule`, others will be ignored.
+   */
   'dependencies' : Array<WasmModuleRegistryEntryDependency>,
+  /**
+   * The id of the wasm module that is stored in the artifact repository.
+   */
   'wasm_artifact_id' : UUID,
 }
+/**
+ * The wasm module registry value input, which is the content of the wasm module and its version.
+ */
 export interface WasmModuleRegistryEntryValueInput {
+  /**
+   * The wasm module that should be stored in the artifact repository.
+   */
   'wasm_module' : Uint8Array | number[],
+  /**
+   * Optional extra chunks of the wasm module that are stored in an asset canister referenced in the record `WasmModuleExtraChunks`.
+   */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
+  /**
+   * The version of the wasm module.
+   */
   'version' : string,
+  /**
+   * The dependencies of the wasm module, which are other wasm modules that this wasm module depends on.
+   */
   'dependencies' : Array<WasmModuleRegistryEntryDependency>,
 }
+/**
+ * The control panel service definition.
+ */
 export interface _SERVICE {
+  /**
+   * Add a new entry to the registry.
+   * 
+   * The caller must have the necessary permissions to add an entry to the registry.
+   */
   'add_registry_entry' : ActorMethod<
     [AddRegistryEntryInput],
     AddRegistryEntryResult
   >,
+  /**
+   * Checks if the caller can deploy a new station canister.
+   */
   'can_deploy_station' : ActorMethod<[], CanDeployStationResult>,
+  /**
+   * Deletes an existing entry from the registry.
+   */
   'delete_registry_entry' : ActorMethod<
     [DeleteRegistryEntryInput],
     DeleteRegistryEntryResult
   >,
+  /**
+   * Delete user associated with the caller.
+   */
   'delete_user' : ActorMethod<[], RemoveUserResult>,
+  /**
+   * Deploys a new station canister for the caller.
+   */
   'deploy_station' : ActorMethod<[DeployStationInput], DeployStationResult>,
+  /**
+   * Edit an existing entry in the registry.
+   * A registry entry can only be edited if it references the same kind of value.
+   * 
+   * The caller must have the necessary permissions to edit an entry in the registry.
+   */
   'edit_registry_entry' : ActorMethod<
     [EditRegistryEntryInput],
     EditRegistryEntryResult
   >,
+  /**
+   * Enables the caller to get an artifact by its id.
+   */
   'get_artifact' : ActorMethod<[GetArtifactInput], GetArtifactResult>,
+  /**
+   * Get the registry entry by its id.
+   */
   'get_registry_entry' : ActorMethod<
     [GetRegistryEntryInput],
     GetRegistryEntryResult
   >,
+  /**
+   * Get the user information for the caller.
+   */
   'get_user' : ActorMethod<[], GetUserResult>,
+  /**
+   * HTTP Protocol interface.
+   */
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  /**
+   * List all the stations associated with the caller.
+   */
   'list_user_stations' : ActorMethod<
     [ListUserStationsInput],
     ListUserStationsResult
   >,
+  /**
+   * Manage the stations associated with the caller.
+   */
   'manage_user_stations' : ActorMethod<
     [ManageUserStationsInput],
     ManageUserStationsResult
   >,
+  /**
+   * Find the next wasm module version for the provided module name and current version.
+   * 
+   * If no next version is found, the result will be `None`.
+   */
   'next_wasm_module_version' : ActorMethod<
     [NextWasmModuleVersionInput],
     NextWasmModuleVersionResult
   >,
+  /**
+   * Create a new user for the caller.
+   */
   'register_user' : ActorMethod<[RegisterUserInput], RegisterUserResult>,
+  /**
+   * Search the registry for entries.
+   */
   'search_registry' : ActorMethod<[SearchRegistryInput], SearchRegistryResult>,
+  /**
+   * Set the last active time for the user associated with the caller.
+   */
   'set_user_active' : ActorMethod<[], SetUserActiveResult>,
+  /**
+   * Uploads the canister modules for the station and upgrader canisters.
+   */
   'upload_canister_modules' : ActorMethod<
     [UploadCanisterModulesInput],
     UploadUploadCanisterModulesInputResult

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -2,144 +2,504 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+/**
+ * A record type that can be used to represent a account in the canister.
+ */
 export interface Account {
+  /**
+   * The internal account id.
+   */
   'id' : UUID,
+  /**
+   * The configs approval policy for the account.
+   * 
+   * The configs approval policy defines the rule that must be met for the account to have its configs updated.
+   */
   'configs_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * Metadata associated with the account (e.g. `{"contract": "0x1234", "symbol": "ANY"}`).
+   */
   'metadata' : Array<AccountMetadata>,
+  /**
+   * A friendly name for the account.
+   */
   'name' : string,
+  /**
+   * The list of assets supported by this account.
+   */
   'assets' : Array<AccountAsset>,
+  /**
+   * The list of addresses associated with the account.
+   */
   'addresses' : Array<AccountAddress>,
+  /**
+   * The transfer approval policy for the account.
+   * 
+   * The transfer approval policy defines the rule that must be met for a transfer to be approved.
+   */
   'transfer_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * The time at which the account was created or last modified (e.g. "2021-01-01T00:00:00Z").
+   */
   'last_modification_timestamp' : TimestampRFC3339,
 }
-export interface AccountAddress { 'address' : string, 'format' : string }
+/**
+ * Record type to describe an address of an account.
+ */
+export interface AccountAddress {
+  /**
+   * The address.
+   */
+  'address' : string,
+  /**
+   * The format of the address, eg. icp_account_identifier.
+   */
+  'format' : string,
+}
+/**
+ * Record type to describe an asset of an account.
+ */
 export interface AccountAsset {
+  /**
+   * The balance of the asset.
+   */
   'balance' : [] | [AccountBalance],
+  /**
+   * The asset id.
+   */
   'asset_id' : UUID,
 }
 export interface AccountBalance {
+  /**
+   * The account id.
+   */
   'account_id' : UUID,
+  /**
+   * The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
+   */
   'decimals' : number,
+  /**
+   * The balance of the account.
+   */
   'balance' : bigint,
+  /**
+   * The time at which the balance was last updated.
+   */
   'last_update_timestamp' : TimestampRFC3339,
+  /**
+   * The state of balance query:
+   * - `fresh`: The balance was recently updated and is considered fresh.
+   * - `stale`: The balance may be out of date.
+   * - `stale_refreshing`: The balance may be out of date but it is being refreshed in the background.
+   */
   'query_state' : string,
+  /**
+   * The asset id.
+   */
   'asset_id' : UUID,
 }
+/**
+ * A record type that can be used to represent a account balance.
+ */
 export interface AccountBalanceInfo {
+  /**
+   * The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
+   */
   'decimals' : number,
+  /**
+   * Balance of the account.
+   */
   'balance' : bigint,
+  /**
+   * The time at which the balance was last updated.
+   */
   'last_update_timestamp' : TimestampRFC3339,
 }
+/**
+ * A record type that can be used to represent the privileges of a caller for a given account.
+ */
 export interface AccountCallerPrivileges {
+  /**
+   * The account id that the caller has privileges for.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can request transfers from the account.
+   */
   'can_transfer' : boolean,
+  /**
+   * Whether or not the caller can edit the account.
+   */
   'can_edit' : boolean,
 }
-export interface AccountMetadata { 'key' : string, 'value' : string }
+/**
+ * Account can have additional information attached to them,
+ * this type can be used to represent the additional info.
+ */
+export interface AccountMetadata {
+  /**
+   * The key of the additional info (e.g. "contract")
+   */
+  'key' : string,
+  /**
+   * The value of the additional info (e.g. "0x1234")
+   */
+  'value' : string,
+}
+/**
+ * The actions that are available for accounts.
+ */
 export type AccountResourceAction = { 'List' : null } |
   { 'Read' : ResourceId } |
   { 'Create' : null } |
   { 'Transfer' : ResourceId } |
   { 'Update' : ResourceId };
+/**
+ * The seed used to derive the addresses of the account.
+ */
 export type AccountSeed = Uint8Array | number[];
 export interface AddAccountOperation {
+  /**
+   * The account, only available after the request is executed.
+   */
   'account' : [] | [Account],
+  /**
+   * The input to the request to add the account.
+   */
   'input' : AddAccountOperationInput,
 }
+/**
+ * Input type for adding an account through a request.
+ */
 export interface AddAccountOperationInput {
+  /**
+   * The approval policy for updates to the account.
+   */
   'configs_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * Who can read the account information.
+   */
   'read_permission' : Allow,
+  /**
+   * Who can request updates to the account.
+   */
   'configs_permission' : Allow,
+  /**
+   * Metadata associated with the account (e.g. `{"contract": "0x1234", "symbol": "ANY"}`).
+   */
   'metadata' : Array<AccountMetadata>,
+  /**
+   * A friendly name for the account (e.g. "My Account").
+   */
   'name' : string,
+  /**
+   * The assets to add to the account.
+   */
   'assets' : Array<UUID>,
+  /**
+   * The approval policy for transfers from the account.
+   */
   'transfer_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * Who can request transfers from the account.
+   */
   'transfer_permission' : Allow,
 }
 export interface AddAddressBookEntryOperation {
+  /**
+   * The address book entry, only available after the request is executed.
+   */
   'address_book_entry' : [] | [AddressBookEntry],
+  /**
+   * The input to the request to add the address book entry.
+   */
   'input' : AddAddressBookEntryOperationInput,
 }
+/**
+ * Input type for creating a new address book entry through a request.
+ */
 export interface AddAddressBookEntryOperationInput {
+  /**
+   * Metadata associated with the address book entry (e.g. `{"kyc": "true"}`).
+   */
   'metadata' : Array<AddressBookMetadata>,
+  /**
+   * The labels associated with the address book entry (e.g. `["exchange", "kyc"]`).
+   */
   'labels' : Array<string>,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : string,
+  /**
+   * The actual address.
+   */
   'address' : string,
+  /**
+   * The format of the address, eg. icp_account_identifier
+   */
   'address_format' : string,
+  /**
+   * The owner of the address.
+   */
   'address_owner' : string,
 }
 export interface AddAssetOperation {
+  /**
+   * The result of adding an asset.
+   */
   'asset' : [] | [Asset],
+  /**
+   * The input to the request to add an asset.
+   */
   'input' : AddAssetOperationInput,
 }
+/**
+ * The input type for adding an asset.
+ */
 export interface AddAssetOperationInput {
+  /**
+   * The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
+   */
   'decimals' : number,
+  /**
+   * The asset standard that is supported (e.g. `erc20`, etc.), canonically represented as a lowercase string
+   * with spaces replaced with underscores.
+   */
   'standards' : Array<string>,
+  /**
+   * The asset metadata (e.g. `{"logo": "https://example.com/logo.png"}`).
+   */
   'metadata' : Array<AssetMetadata>,
+  /**
+   * The asset name (e.g. `Internet Computer`, `Bitcoin`, `Ethereum`, etc.)
+   */
   'name' : string,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : string,
+  /**
+   * The asset symbol, e.g. "ICP" or "BTC".
+   */
   'symbol' : AssetSymbol,
 }
+/**
+ * The operation type for adding a new named rule.
+ */
 export interface AddNamedRuleOperation {
+  /**
+   * The result of adding a named rule.
+   */
   'named_rule' : [] | [NamedRule],
+  /**
+   * The input to the request to add a named rule.
+   */
   'input' : AddNamedRuleOperationInput,
 }
+/**
+ * The input type for creating a named rule.
+ */
 export interface AddNamedRuleOperationInput {
+  /**
+   * The rule name.
+   */
   'name' : string,
+  /**
+   * The rule value.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The rule description.
+   */
   'description' : [] | [string],
 }
 export interface AddRequestPolicyOperation {
+  /**
+   * The input to the request to add a request policy.
+   */
   'input' : AddRequestPolicyOperationInput,
+  /**
+   * The request policy that was created by the request (only available after the request is executed).
+   */
   'policy_id' : [] | [UUID],
 }
 export interface AddRequestPolicyOperationInput {
+  /**
+   * The rule to use for the request evaluation.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The request specifier that identifies the request to add a policy for.
+   */
   'specifier' : RequestSpecifier,
 }
 export interface AddUserGroupOperation {
+  /**
+   * The user group that was added, only available after the request is executed.
+   */
   'user_group' : [] | [UserGroup],
+  /**
+   * The input to the request to add the user group.
+   */
   'input' : AddUserGroupOperationInput,
 }
-export interface AddUserGroupOperationInput { 'name' : string }
+export interface AddUserGroupOperationInput {
+  /**
+   * The name of the group.
+   */
+  'name' : string,
+}
 export interface AddUserOperation {
+  /**
+   * The user that was added, only available after the request is executed.
+   */
   'user' : [] | [User],
+  /**
+   * The input to the request to add the user.
+   */
   'input' : AddUserOperationInput,
 }
 export interface AddUserOperationInput {
+  /**
+   * The status of the user (e.g. `Active`).
+   * 
+   * The user must be active to be able to practically use the station.
+   */
   'status' : UserStatus,
+  /**
+   * The list of groups the user belongs to.
+   * 
+   * Users can be tagged with groups that can be used to control access to the station
+   * (e.g. the UUID of the finance group).
+   */
   'groups' : Array<UUID>,
+  /**
+   * The user name (e.g. "John Doe").
+   */
   'name' : string,
+  /**
+   * The principals associated with the user.
+   */
   'identities' : Array<Principal>,
 }
+/**
+ * A record type that can be used to represent an address book entry in the canister.
+ */
 export interface AddressBookEntry {
+  /**
+   * The internal address book entry id.
+   */
   'id' : UUID,
+  /**
+   * Metadata associated with the address book entry (e.g. `{"kyc": "true"}`).
+   */
   'metadata' : Array<AddressBookMetadata>,
+  /**
+   * The list of labels associated with the address book entry (e.g. `["kyc", "approved"]`).
+   */
   'labels' : Array<string>,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : string,
+  /**
+   * The actual address.
+   */
   'address' : string,
+  /**
+   * The time at which the address book entry was created or last modified (e.g. "2021-01-01T00:00:00Z").
+   */
   'last_modification_timestamp' : string,
+  /**
+   * The address format (e.g. "icp_account_identifier").
+   */
   'address_format' : string,
+  /**
+   * The address owner.
+   */
   'address_owner' : string,
 }
+/**
+ * A record type that can be used to represent the privileges of a caller for a given address book entry.
+ */
 export interface AddressBookEntryCallerPrivileges {
+  /**
+   * The address book entry id.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can delete the address book entry.
+   */
   'can_delete' : boolean,
+  /**
+   * Whether or not the caller can edit the address book entry.
+   */
   'can_edit' : boolean,
 }
-export interface AddressBookMetadata { 'key' : string, 'value' : string }
+/**
+ * Address book entries can have additional information attached to them,
+ * this type can be used to represent the additional info.
+ */
+export interface AddressBookMetadata {
+  /**
+   * The key of the additional info (e.g. "kyc")
+   */
+  'key' : string,
+  /**
+   * The value of the additional info (e.g. "true")
+   */
+  'value' : string,
+}
+/**
+ * The allow rules for who can access the resource.
+ */
 export interface Allow {
+  /**
+   * Only the specified user groups can access the resource.
+   */
   'user_groups' : Array<UUID>,
+  /**
+   * Required authentication level for accessing the resource.
+   */
   'auth_scope' : AuthScope,
+  /**
+   * Only the specified users can access the resource.
+   */
   'users' : Array<UUID>,
 }
+/**
+ * A record type that can be used to represent an asset in the station.
+ */
 export interface Asset {
+  /**
+   * The internal asset id.
+   */
   'id' : UUID,
+  /**
+   * The number of decimals used by the asset (e.g. `8` for `BTC`, `18` for `ETH`, etc.).
+   */
   'decimals' : number,
+  /**
+   * The asset standard that is supported (e.g. `erc20`, etc.), canonically represented as a lowercase string
+   * with spaces replaced with underscores.
+   */
   'standards' : Array<string>,
+  /**
+   * The asset metadata (e.g. `{"logo": "https://example.com/logo.png"}`).
+   */
   'metadata' : Array<AssetMetadata>,
+  /**
+   * The asset name (e.g. `Internet Computer`, `Bitcoin`, `Ethereum`, etc.)
+   */
   'name' : string,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : string,
+  /**
+   * The asset symbol, e.g. "ICP" or "BTC".
+   */
   'symbol' : AssetSymbol,
 }
 export interface AssetCallerPrivileges {
@@ -147,50 +507,188 @@ export interface AssetCallerPrivileges {
   'can_delete' : boolean,
   'can_edit' : boolean,
 }
-export interface AssetMetadata { 'key' : string, 'value' : string }
+/**
+ * Assets can have additional information attached to them,
+ * this type can be used to represent the additional info.
+ */
+export interface AssetMetadata {
+  /**
+   * The key of the additional info (e.g. "logo")
+   */
+  'key' : string,
+  /**
+   * The value of the additional info (e.g. "https://example.com/logo.png")
+   */
+  'value' : string,
+}
+/**
+ * The asset symbol, e.g. "ICP" or "BTC".
+ */
 export type AssetSymbol = string;
-export type AuthScope = { 'Authenticated' : null } |
-  { 'Public' : null } |
-  { 'Restricted' : null };
+/**
+ * The authorization scope the caller must have, used to specify the required scope for accessing a resource.
+ */
+export type AuthScope = {
+    /**
+     * Requires to be an authenticated user to access the resource.
+     */
+    'Authenticated' : null
+  } |
+  {
+    /**
+     * Allows access to the resource without requiring any authentication.
+     */
+    'Public' : null
+  } |
+  {
+    /**
+     * Requires the caller to have direct access to the resource through user groups or user ids.
+     */
+    'Restricted' : null
+  };
+/**
+ * A basic user record that can be used to represent a user in the station.
+ */
 export interface BasicUser {
+  /**
+   * The UUID of the user (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
   'id' : UUID,
+  /**
+   * The status of the user (e.g. `Active`).
+   */
   'status' : UserStatus,
+  /**
+   * The user name (e.g. "John Doe").
+   */
   'name' : string,
 }
 export interface CallExternalCanisterOperation {
+  /**
+   * This field is not populated in list responses, only when using `get_request` and
+   * setting `with_full_info` to `opt true` to avoid going over the response size limit.
+   */
   'arg' : [] | [Uint8Array | number[]],
+  /**
+   * see `CallExternalCanisterOperationInput`
+   */
   'execution_method' : CanisterMethod,
+  /**
+   * see `CallExternalCanisterOperationInput`
+   */
   'validation_method' : [] | [CanisterMethod],
+  /**
+   * The checksum of the argument blob passed to both the validation and execution method.
+   * Defaults to `null` if no argument blob is provided.
+   */
   'arg_checksum' : [] | [Sha256Hash],
+  /**
+   * The amount of cycles attached to the call of the execution method.
+   */
   'execution_method_cycles' : [] | [bigint],
+  /**
+   * A human-readable rendering of the argument blob procuded by the validation method.
+   */
   'arg_rendering' : [] | [string],
+  /**
+   * The reply blob produced by a successful call of the execution method,
+   * i.e., when the request is `Completed`.
+   */
   'execution_method_reply' : [] | [Uint8Array | number[]],
 }
 export interface CallExternalCanisterOperationInput {
+  /**
+   * The argument blob passed to both the validation and execution method.
+   * Defaults to the candid encoding of '()' if omitted.
+   */
   'arg' : [] | [Uint8Array | number[]],
+  /**
+   * The canister method that is called after the request becomes `Approved`
+   * passing the validated argument blob.
+   */
   'execution_method' : CanisterMethod,
+  /**
+   * The canister method validating the argument blob:
+   * - on validation success, returns a human-readable rendering of the argument blob
+   * and then the request becomes `Created`;
+   * - on validation error, returns a textual diagnostic message
+   * and then the request creation fails with a validation error
+   * containing the textual diagnostic message.
+   * Formally, the return type of the validation method must be
+   * ```
+   * variant {
+   * Ok : text;
+   * Err : text;
+   * }
+   * ```
+   * If omitted (`validation_method = null`), no validation of the argument blob is performed
+   * and no human-readable rendering of the argument blob is provided.
+   */
   'validation_method' : [] | [CanisterMethod],
+  /**
+   * The amount of cycles attached to the call of the execution method.
+   */
   'execution_method_cycles' : [] | [bigint],
 }
+/**
+ * The validation and execution method targets of a `CallExternalCanister` request.
+ */
 export interface CallExternalCanisterResourceTarget {
   'execution_method' : ExecutionMethodResourceTarget,
   'validation_method' : ValidationMethodResourceTarget,
 }
+/**
+ * The input type for canceling a request.
+ */
 export interface CancelRequestInput {
+  /**
+   * The request id to cancel.
+   */
   'request_id' : UUID,
+  /**
+   * The reason for canceling the request.
+   */
   'reason' : [] | [string],
 }
-export type CancelRequestResult = { 'Ok' : { 'request' : Request } } |
+/**
+ * The result type for canceling a request.
+ */
+export type CancelRequestResult = {
+    'Ok' : {
+      /**
+       * The request that was canceled.
+       */
+      'request' : Request,
+    }
+  } |
   { 'Err' : Error };
+/**
+ * The pair that is used to represent the execution and validation method.
+ */
 export interface CanisterExecutionAndValidationMethodPair {
+  /**
+   * The method that the caller can call on the external canister.
+   * 
+   * The `*` method name is used to represent that the caller can call any method on the canister.
+   */
   'execution_method' : string,
+  /**
+   * The validation method that is used to validate the request and
+   * render the argument.
+   */
   'validation_method' : ValidationMethodResourceTarget,
 }
 export type CanisterInstallMode = { 'reinstall' : null } |
   { 'upgrade' : null } |
   { 'install' : null };
 export interface CanisterMethod {
+  /**
+   * The canister to call.
+   */
   'canister_id' : Principal,
+  /**
+   * The method to call on the canister.
+   */
   'method_name' : string,
 }
 export interface CanisterSnapshotsInput { 'canister_id' : Principal }
@@ -221,58 +719,233 @@ export interface CanisterStatusResponse {
   'module_hash' : [] | [Uint8Array | number[]],
   'reserved_cycles' : bigint,
 }
+/**
+ * A record type that is used to show the current capabilities of the station.
+ */
 export interface Capabilities {
+  /**
+   * The name of the station.
+   */
   'name' : string,
+  /**
+   * Version of the station.
+   */
   'version' : string,
+  /**
+   * The list of supported assets.
+   */
   'supported_assets' : Array<Asset>,
+  /**
+   * The list of supported blockchains and standards.
+   */
   'supported_blockchains' : Array<SupportedBlockchain>,
 }
-export type CapabilitiesResult = { 'Ok' : { 'capabilities' : Capabilities } } |
-  { 'Err' : Error };
+/**
+ * Result type for getting the current config.
+ */
+export type CapabilitiesResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The config.
+       */
+      'capabilities' : Capabilities,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Type for instructions to update the address book entry's metadata.
+ */
 export type ChangeAddressBookMetadata = {
+    /**
+     * Override values of existing metadata with the specified keys
+     * and add new metadata if no metadata can be found with the specified keys.
+     */
     'OverrideSpecifiedBy' : Array<AddressBookMetadata>
   } |
-  { 'RemoveKeys' : Array<string> } |
-  { 'ReplaceAllBy' : Array<AddressBookMetadata> };
-export type ChangeAssets = { 'ReplaceWith' : { 'assets' : Array<UUID> } } |
-  { 'Change' : { 'add_assets' : Array<UUID>, 'remove_assets' : Array<UUID> } };
+  {
+    /**
+     * Remove metadata with the specified keys.
+     */
+    'RemoveKeys' : Array<string>
+  } |
+  {
+    /**
+     * Replace all existing metadata by the specified metadata.
+     */
+    'ReplaceAllBy' : Array<AddressBookMetadata>
+  };
+/**
+ * Mutate the list of assets.
+ */
+export type ChangeAssets = {
+    /**
+     * Replace all current assets with the specified list.
+     */
+    'ReplaceWith' : { 'assets' : Array<UUID> }
+  } |
+  {
+    /**
+     * Change the list of assets by adding and removing assets.
+     */
+    'Change' : { 'add_assets' : Array<UUID>, 'remove_assets' : Array<UUID> }
+  };
+/**
+ * Type for instructions to update the external canister's metadata.
+ */
 export type ChangeExternalCanisterMetadata = {
+    /**
+     * Override values of existing metadata with the specified keys
+     * and add new metadata if no metadata can be found with the specified keys.
+     */
     'OverrideSpecifiedBy' : Array<ExternalCanisterMetadata>
   } |
-  { 'RemoveKeys' : Array<string> } |
-  { 'ReplaceAllBy' : Array<ExternalCanisterMetadata> };
+  {
+    /**
+     * Remove metadata with the specified keys.
+     */
+    'RemoveKeys' : Array<string>
+  } |
+  {
+    /**
+     * Replace all existing metadata by the specified metadata.
+     */
+    'ReplaceAllBy' : Array<ExternalCanisterMetadata>
+  };
 export interface ChangeExternalCanisterOperation {
+  /**
+   * The canister installation mode.
+   */
   'mode' : CanisterInstallMode,
+  /**
+   * The canister to install.
+   */
   'canister_id' : Principal,
+  /**
+   * The checksum of the wasm module.
+   */
   'module_checksum' : Sha256Hash,
+  /**
+   * The checksum of the arg blob.
+   */
   'arg_checksum' : [] | [Sha256Hash],
 }
 export interface ChangeExternalCanisterOperationInput {
+  /**
+   * The initial argument passed to the new wasm module.
+   */
   'arg' : [] | [Uint8Array | number[]],
+  /**
+   * Additional wasm module chunks to append to the wasm module.
+   */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
+  /**
+   * The canister installation mode.
+   */
   'mode' : CanisterInstallMode,
+  /**
+   * The canister to install.
+   */
   'canister_id' : Principal,
+  /**
+   * The wasm module to install.
+   */
   'module' : Uint8Array | number[],
 }
-export type ChangeMetadata = { 'OverrideSpecifiedBy' : Array<AssetMetadata> } |
-  { 'RemoveKeys' : Array<string> } |
-  { 'ReplaceAllBy' : Array<AssetMetadata> };
+/**
+ * Type for instructions to update the address book entry's metadata.
+ */
+export type ChangeMetadata = {
+    /**
+     * Override values of existing metadata with the specified keys
+     * and add new metadata if no metadata can be found with the specified keys.
+     */
+    'OverrideSpecifiedBy' : Array<AssetMetadata>
+  } |
+  {
+    /**
+     * Remove metadata with the specified keys.
+     */
+    'RemoveKeys' : Array<string>
+  } |
+  {
+    /**
+     * Replace all existing metadata by the specified metadata.
+     */
+    'ReplaceAllBy' : Array<AssetMetadata>
+  };
 export type ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
 export interface ConfigureExternalCanisterOperationInput {
+  /**
+   * The kind of operation to perform.
+   */
   'kind' : ConfigureExternalCanisterOperationKind,
+  /**
+   * The canister to update.
+   */
   'canister_id' : Principal,
 }
-export type ConfigureExternalCanisterOperationKind = { 'SoftDelete' : null } |
-  { 'Settings' : ConfigureExternalCanisterSettingsInput } |
-  { 'Delete' : null } |
-  { 'NativeSettings' : DefiniteCanisterSettingsInput };
+/**
+ * The input type for configuring an external canister in the station.
+ */
+export type ConfigureExternalCanisterOperationKind = {
+    /**
+     * Remove the canister from the Station only.
+     */
+    'SoftDelete' : null
+  } |
+  {
+    /**
+     * The settings to configure for the external canister.
+     */
+    'Settings' : ConfigureExternalCanisterSettingsInput
+  } |
+  {
+    /**
+     * Remove the canister from the Station and the IC.
+     * 
+     * Caution: This operation is irreversible.
+     */
+    'Delete' : null
+  } |
+  {
+    /**
+     * The Internet Computer canister settings to configure for the external canister.
+     */
+    'NativeSettings' : DefiniteCanisterSettingsInput
+  };
 export interface ConfigureExternalCanisterSettingsInput {
+  /**
+   * What operations are allowed on the canister.
+   */
   'permissions' : [] | [ExternalCanisterPermissionsUpdateInput],
   'name' : [] | [string],
+  /**
+   * The labels of the external canister.
+   */
   'labels' : [] | [Array<string>],
+  /**
+   * The description of the external canister.
+   */
   'description' : [] | [string],
+  /**
+   * The request policies for the canister.
+   */
   'request_policies' : [] | [ExternalCanisterRequestPoliciesUpdateInput],
+  /**
+   * The state of the external canister.
+   */
   'state' : [] | [ExternalCanisterState],
+  /**
+   * The metadata of the external canister.
+   */
   'change_metadata' : [] | [ChangeExternalCanisterMetadata],
 }
 export interface CreateExternalCanisterOperation {
@@ -280,58 +953,196 @@ export interface CreateExternalCanisterOperation {
   'input' : CreateExternalCanisterOperationInput,
 }
 export interface CreateExternalCanisterOperationInput {
+  /**
+   * What operations are allowed on the canister.
+   */
   'permissions' : ExternalCanisterPermissionsCreateInput,
+  /**
+   * The metadata of the external canister.
+   */
   'metadata' : [] | [Array<ExternalCanisterMetadata>],
+  /**
+   * The kind of create operation to perform.
+   */
   'kind' : CreateExternalCanisterOperationKind,
+  /**
+   * The name of the external canister.
+   */
   'name' : string,
+  /**
+   * The labels of the external canister.
+   */
   'labels' : [] | [Array<string>],
+  /**
+   * The description of the external canister.
+   */
   'description' : [] | [string],
+  /**
+   * The request policies for the canister.
+   */
   'request_policies' : ExternalCanisterRequestPoliciesCreateInput,
 }
 export type CreateExternalCanisterOperationKind = {
+    /**
+     * An existing canister is added to the station.
+     */
     'AddExisting' : CreateExternalCanisterOperationKindAddExisting
   } |
-  { 'CreateNew' : CreateExternalCanisterOperationKindCreateNew };
+  {
+    /**
+     * A new canister is created.
+     */
+    'CreateNew' : CreateExternalCanisterOperationKindCreateNew
+  };
 export interface CreateExternalCanisterOperationKindAddExisting {
+  /**
+   * The canister id to use.
+   */
   'canister_id' : Principal,
 }
 export interface CreateExternalCanisterOperationKindCreateNew {
+  /**
+   * The initial cycles to allocate to the canister.
+   * 
+   * If not set, only the minimal amount of cycles required to create the
+   * canister will be allocated.
+   */
   'initial_cycles' : [] | [bigint],
+  /**
+   * The subnet on which the canister should be created.
+   * 
+   * By default, the canister is created on the same subnet as the station.
+   */
   'subnet_selection' : [] | [SubnetSelection],
 }
+/**
+ * The input type for creating a request.
+ */
 export interface CreateRequestInput {
+  /**
+   * The request title (e.g. "Payment to John").
+   */
   'title' : [] | [string],
+  /**
+   * The time at which the request will execute if approved.
+   */
   'execution_plan' : [] | [RequestExecutionSchedule],
+  /**
+   * The time at which the request will expire if still pending.
+   */
   'expiration_dt' : [] | [TimestampRFC3339],
+  /**
+   * The optional deduplication key used to ensure request uniqueness.
+   */
   'deduplication_key' : [] | [string],
+  /**
+   * The list of tags for the request.
+   */
   'tags' : [] | [Array<string>],
+  /**
+   * The request summary (e.g. "This request will transfer 100 ICP to the account 0x1234").
+   */
   'summary' : [] | [string],
+  /**
+   * The operation that was requested.
+   */
   'operation' : RequestOperationInput,
 }
+/**
+ * The result type for creating a request.
+ */
 export type CreateRequestResult = {
     'Ok' : {
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : RequestCallerPrivileges,
+      /**
+       * The request that was created.
+       */
       'request' : Request,
+      /**
+       * The additional info about the request.
+       */
       'additional_info' : RequestAdditionalInfo,
     }
   } |
-  { 'Err' : Error };
-export type CycleObtainStrategy = { 'Disabled' : null } |
   {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Strategy defining how the station canister tops up its own cycles.
+ */
+export type CycleObtainStrategy = {
+    /**
+     * Do not obtain cycles for Orbit.
+     */
+    'Disabled' : null
+  } |
+  {
+    /**
+     * Use the CMC to mint cycles from ICP held in an Orbit account.
+     */
     'MintFromNativeToken' : {
+      /**
+       * The Orbit account ID to use for minting cycles.
+       */
       'account_id' : UUID,
+      /**
+       * The Orbit account name.
+       */
       'account_name' : [] | [string],
     }
   } |
   {
+    /**
+     * Use the Cycles Ledger balance to obtain cycles.
+     */
     'WithdrawFromCyclesLedger' : {
+      /**
+       * The Orbit account ID to use for obtaining cycles.
+       */
       'account_id' : UUID,
+      /**
+       * The Orbit account name.
+       */
       'account_name' : [] | [string],
     }
   };
-export type CycleObtainStrategyInput = { 'Disabled' : null } |
-  { 'MintFromNativeToken' : { 'account_id' : UUID } } |
-  { 'WithdrawFromCyclesLedger' : { 'account_id' : UUID } };
+/**
+ * Strategy defining how the station canister tops up its own cycles.
+ */
+export type CycleObtainStrategyInput = {
+    /**
+     * Do not obtain cycles for Orbit.
+     */
+    'Disabled' : null
+  } |
+  {
+    /**
+     * Use the CMC to mint cycles from ICP held in an Orbit account.
+     */
+    'MintFromNativeToken' : {
+      /**
+       * The Orbit account ID to use for minting cycles.
+       */
+      'account_id' : UUID,
+    }
+  } |
+  {
+    /**
+     * Use the Cycles Ledger balance to obtain cycles.
+     */
+    'WithdrawFromCyclesLedger' : {
+      /**
+       * The Orbit account ID to use for obtaining cycles.
+       */
+      'account_id' : UUID,
+    }
+  };
 export interface DefiniteCanisterSettings {
   'freezing_threshold' : bigint,
   'controllers' : Array<Principal>,
@@ -350,91 +1161,293 @@ export interface DefiniteCanisterSettingsInput {
   'memory_allocation' : [] | [bigint],
   'compute_allocation' : [] | [bigint],
 }
+/**
+ * The disaster recovery committee extended with the user group name.
+ */
 export interface DisasterRecovery {
+  /**
+   * The name of the disaster recovery committee user group.
+   */
   'user_group_name' : [] | [string],
+  /**
+   * The disaster recovery committee.
+   */
   'committee' : DisasterRecoveryCommittee,
 }
 export interface DisasterRecoveryCommittee {
+  /**
+   * The user group id of the committee.
+   */
   'user_group_id' : UUID,
+  /**
+   * The quorum required for the committee to approve a disaster recovery operation.
+   */
   'quorum' : number,
 }
-export interface DisplayUser { 'id' : UUID, 'name' : string }
-export interface EditAccountOperation { 'input' : EditAccountOperationInput }
+/**
+ * A minimal user record that is meant to aid displaying users on the client.
+ */
+export interface DisplayUser {
+  /**
+   * The UUID of the user (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
+  'id' : UUID,
+  /**
+   * The user name (e.g. "John Doe").
+   */
+  'name' : string,
+}
+export interface EditAccountOperation {
+  /**
+   * The input to the request to edit the account.
+   */
+  'input' : EditAccountOperationInput,
+}
+/**
+ * Input type for editing an account through a request.
+ */
 export interface EditAccountOperationInput {
+  /**
+   * The account id that will be edited.
+   */
   'account_id' : UUID,
+  /**
+   * The request policy for what it takes to execute a configuration change.
+   */
   'configs_request_policy' : [] | [RequestPolicyRuleInput],
+  /**
+   * Who can read the account information.
+   */
   'read_permission' : [] | [Allow],
+  /**
+   * Who can request configuration changes to the account.
+   */
   'configs_permission' : [] | [Allow],
+  /**
+   * A friendly name for the account (e.g. "My Account").
+   */
   'name' : [] | [string],
+  /**
+   * Mutate the list of assets.
+   */
   'change_assets' : [] | [ChangeAssets],
+  /**
+   * The request policy for what it takes to execute a transfer.
+   */
   'transfer_request_policy' : [] | [RequestPolicyRuleInput],
+  /**
+   * Who can request transfers from the account.
+   */
   'transfer_permission' : [] | [Allow],
 }
 export interface EditAddressBookEntryOperation {
+  /**
+   * The input to the request to edit the address book entry.
+   */
   'input' : EditAddressBookEntryOperationInput,
 }
+/**
+ * Input type for updating an address book entry through a request.
+ */
 export interface EditAddressBookEntryOperationInput {
+  /**
+   * The updated list of labels associated with the address book entry.
+   */
   'labels' : [] | [Array<string>],
+  /**
+   * Instructions to update the address book entry's metadata.
+   */
   'change_metadata' : [] | [ChangeAddressBookMetadata],
+  /**
+   * The id of the address book entry.
+   */
   'address_book_entry_id' : UUID,
+  /**
+   * The new owner of the address.
+   */
   'address_owner' : [] | [string],
 }
-export interface EditAssetOperation { 'input' : EditAssetOperationInput }
+export interface EditAssetOperation {
+  /**
+   * The input to the request to edit an asset.
+   */
+  'input' : EditAssetOperationInput,
+}
+/**
+ * The input type for editing an asset.
+ */
 export interface EditAssetOperationInput {
+  /**
+   * The asset standard that is supported (e.g. `erc20`, etc.), canonically represented as a lowercase string
+   * with spaces replaced with underscores.
+   */
   'standards' : [] | [Array<string>],
+  /**
+   * The name of the asset.
+   */
   'name' : [] | [string],
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : [] | [string],
+  /**
+   * The metadata to change.
+   */
   'change_metadata' : [] | [ChangeMetadata],
+  /**
+   * The asset id to edit.
+   */
   'asset_id' : UUID,
+  /**
+   * The asset symbol, e.g. "ICP" or "BTC".
+   */
   'symbol' : [] | [AssetSymbol],
 }
+/**
+ * The operation type for editing an existing named rule.
+ */
 export interface EditNamedRuleOperation {
+  /**
+   * The input to the request to edit a named rule.
+   */
   'input' : EditNamedRuleOperationInput,
 }
+/**
+ * The input type for editing a named rule.
+ */
 export interface EditNamedRuleOperationInput {
+  /**
+   * The rule name.
+   */
   'name' : [] | [string],
+  /**
+   * The rule value.
+   */
   'rule' : [] | [RequestPolicyRule],
+  /**
+   * The optional rule description.
+   */
   'description' : [] | [[] | [string]],
+  /**
+   * The named rule id to edit.
+   */
   'named_rule_id' : UUID,
 }
 export interface EditPermissionOperation {
+  /**
+   * The input to the request to edit an permission.
+   */
   'input' : EditPermissionOperationInput,
 }
 export interface EditPermissionOperationInput {
+  /**
+   * The updated resource that this policy will apply to.
+   */
   'resource' : Resource,
+  /**
+   * The updated list of user groups that have access to the resource.
+   */
   'user_groups' : [] | [Array<UUID>],
+  /**
+   * The updated authorization scope for the resource.
+   */
   'auth_scope' : [] | [AuthScope],
+  /**
+   * The updated list of users that have access to the resource.
+   */
   'users' : [] | [Array<UUID>],
 }
 export interface EditRequestPolicyOperation {
+  /**
+   * The input to the request to edit a request policy.
+   */
   'input' : EditRequestPolicyOperationInput,
 }
 export interface EditRequestPolicyOperationInput {
+  /**
+   * The updated rule to use for the request evaluation.
+   */
   'rule' : [] | [RequestPolicyRule],
+  /**
+   * The updated request specifier that identifies the request to add a policy for.
+   */
   'specifier' : [] | [RequestSpecifier],
+  /**
+   * The request policy id that will be edited.
+   */
   'policy_id' : UUID,
 }
 export interface EditUserGroupOperation {
+  /**
+   * The input to the request to edit the user group.
+   */
   'input' : EditUserGroupOperationInput,
 }
 export interface EditUserGroupOperationInput {
+  /**
+   * The name of the group.
+   */
   'name' : string,
+  /**
+   * The id of the group to edit.
+   */
   'user_group_id' : UUID,
 }
-export interface EditUserOperation { 'input' : EditUserOperationInput }
+export interface EditUserOperation {
+  /**
+   * The input to the request to edit the user.
+   */
+  'input' : EditUserOperationInput,
+}
 export interface EditUserOperationInput {
+  /**
+   * The id of the user to edit.
+   */
   'id' : UUID,
+  /**
+   * The status of the user (e.g. `Active`).
+   */
   'status' : [] | [UserStatus],
+  /**
+   * The list of groups the user belongs to.
+   * 
+   * Users can be tagged with groups that can be used to control access to the station
+   * (e.g. "UUID of the finance group").
+   */
   'groups' : [] | [Array<UUID>],
+  /**
+   * Cancel all pending (request status `Created`) requests for this user.
+   */
   'cancel_pending_requests' : [] | [boolean],
+  /**
+   * The user name (e.g. "John Doe").
+   */
   'name' : [] | [string],
+  /**
+   * The principals associated with the user.
+   */
   'identities' : [] | [Array<Principal>],
 }
+/**
+ * Generic error type added to responses that can fail.
+ */
 export interface Error {
+  /**
+   * Error code, added as a string to allow for custom error codes.
+   */
   'code' : string,
+  /**
+   * Error message to be displayed to the user.
+   */
   'message' : [] | [string],
+  /**
+   * Error details to be displayed to the user.
+   */
   'details' : [] | [Array<[string, string]>],
 }
+/**
+ * Defines the evaluation data of a request policy rule.
+ */
 export type EvaluatedRequestPolicyRule = { 'Not' : RequestPolicyRuleResult } |
   {
     'Quorum' : {
@@ -455,64 +1468,214 @@ export type EvaluatedRequestPolicyRule = { 'Not' : RequestPolicyRuleResult } |
   { 'AllOf' : Array<RequestPolicyRuleResult> } |
   { 'AnyOf' : Array<RequestPolicyRuleResult> } |
   { 'AllowListedByMetadata' : { 'metadata' : AddressBookMetadata } };
+/**
+ * Defines the high level result of evaluating a request policy rule.
+ */
 export type EvaluationStatus = { 'Approved' : null } |
   { 'Rejected' : null } |
   { 'Pending' : null };
+/**
+ * List of reasons why a request can be approved or rejected.
+ */
 export type EvaluationSummaryReason = { 'AllowList' : null } |
   { 'AllowListMetadata' : null } |
   { 'AutoApproved' : null } |
   { 'ApprovalQuorum' : null };
+/**
+ * The execution method targets of a `CallExternalCanister` request.
+ */
 export type ExecutionMethodResourceTarget = { 'Any' : null } |
   { 'ExecutionMethod' : CanisterMethod };
+/**
+ * An external canister that the station can interact with.
+ */
 export interface ExternalCanister {
+  /**
+   * The id of the resource in the station.
+   */
   'id' : UUID,
+  /**
+   * The permissions that are set for who can interact with the canister.
+   */
   'permissions' : ExternalCanisterPermissions,
+  /**
+   * The time at which the canister was last modified, if available.
+   */
   'modified_at' : [] | [TimestampRFC3339],
+  /**
+   * The metadata that is associated with the canister.
+   */
   'metadata' : Array<ExternalCanisterMetadata>,
+  /**
+   * The name of the canister.
+   */
   'name' : string,
+  /**
+   * The labels that can be used to categorize the canister.
+   */
   'labels' : Array<string>,
+  /**
+   * The principal id of the canister.
+   */
   'canister_id' : Principal,
+  /**
+   * A description that can be used to describe the canister.
+   */
   'description' : [] | [string],
+  /**
+   * The time at which the canister was created.
+   */
   'created_at' : TimestampRFC3339,
+  /**
+   * The request policies that are associated with the canister.
+   */
   'request_policies' : ExternalCanisterRequestPolicies,
+  /**
+   * The current state of the record (e.g. `Active`).
+   */
   'state' : ExternalCanisterState,
+  /**
+   * Monitoring configuration for the canister.
+   */
   'monitoring' : [] | [MonitorExternalCanisterStartInput],
 }
+/**
+ * The permission for making calls to a specific or any external canister method.
+ */
 export interface ExternalCanisterCallPermission {
+  /**
+   * The execution method that the caller can use,
+   * if `*` is used the caller can use any method.
+   */
   'execution_method' : string,
+  /**
+   * Allowed users and user groups for the operation.
+   */
   'allow' : Allow,
+  /**
+   * The validation method that is used to validate the request and
+   * render the argument.
+   */
   'validation_method' : ValidationMethodResourceTarget,
 }
+/**
+ * The request policy rule for the canister call operation.
+ */
 export interface ExternalCanisterCallRequestPolicyRule {
+  /**
+   * The method name that the rule is for,
+   * if `*` is used the rule applies to all methods.
+   */
   'execution_method' : string,
+  /**
+   * The request policy rule for the canister call operation.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The validation method that is used to match the policy against
+   * the permission of the resource.
+   */
   'validation_method' : ValidationMethodResourceTarget,
+  /**
+   * The id of the request policy rule.
+   */
   'policy_id' : UUID,
 }
+/**
+ * The request policy rule for the canister call operation.
+ */
 export interface ExternalCanisterCallRequestPolicyRuleInput {
+  /**
+   * The method name that the rule is for,
+   * if `*` is used the rule applies to all methods.
+   */
   'execution_method' : string,
+  /**
+   * The request policy rule for the canister call operation.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The validation method that is used to match the policy against
+   * the permission of the resource.
+   */
   'validation_method' : ValidationMethodResourceTarget,
+  /**
+   * The id of the request policy rule.
+   * 
+   * If not provided a new entry will be created.
+   */
   'policy_id' : [] | [UUID],
 }
+/**
+ * The caller privileges for the external canister methods.
+ */
 export interface ExternalCanisterCallerMethodsPrivileges {
+  /**
+   * The method that the caller can call on the external canister.
+   * 
+   * The `*` method name is used to represent that the caller can
+   * call any method on the canister.
+   */
   'execution_method' : string,
+  /**
+   * The validation method that is used to validate the request and
+   * render the argument.
+   */
   'validation_method' : ValidationMethodResourceTarget,
 }
+/**
+ * The caller privileges for the external canister.
+ */
 export interface ExternalCanisterCallerPrivileges {
+  /**
+   * The external canister entry id.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can edit the external canister.
+   */
   'can_change' : boolean,
+  /**
+   * The canister id.
+   */
   'canister_id' : Principal,
+  /**
+   * The list of methods that the caller can call on the external canister.
+   */
   'can_call' : Array<ExternalCanisterCallerMethodsPrivileges>,
+  /**
+   * Whether or not the caller can fund the external canister.
+   */
   'can_fund' : boolean,
 }
+/**
+ * The input type for setting call permissions of an existing external canister.
+ */
 export type ExternalCanisterChangeCallPermissionsInput = {
+    /**
+     * Override the call permissions from the specified execution methods.
+     */
     'OverrideSpecifiedByExecutionMethods' : Array<
       {
+        /**
+         * The method that the caller can call on the external canister.
+         * 
+         * The `*` method name is used to represent that the caller can call any method on the canister.
+         */
         'execution_method' : string,
+        /**
+         * The permissions associated with the execution method, if the list is empty all call permissions of the
+         * execution method will be removed.
+         */
         'permissions' : Array<
           {
+            /**
+             * Allowed users and user groups for the operation.
+             */
             'allow' : Allow,
+            /**
+             * The validation method that is used to validate the request and render the argument.
+             */
             'validation_method' : ValidationMethodResourceTarget,
           }
         >,
@@ -520,25 +1683,68 @@ export type ExternalCanisterChangeCallPermissionsInput = {
     >
   } |
   {
+    /**
+     * Override the permissions for the specified execution and validation method pairs.
+     */
     'OverrideSpecifiedByExecutionValidationMethodPairs' : Array<
       {
+        /**
+         * If allow is not provided the call permission will be removed for the specified execution
+         * and validation method pair.
+         */
         'allow' : [] | [Allow],
+        /**
+         * The method configuration that is used to represent the execution and validation method pair.
+         */
         'method_configuration' : CanisterExecutionAndValidationMethodPair,
       }
     >
   } |
-  { 'ReplaceAllBy' : Array<ExternalCanisterCallPermission> };
+  {
+    /**
+     * Replaces all the call permissions with the provided list, if the list is empty
+     * all the call permissions will be removed.
+     */
+    'ReplaceAllBy' : Array<ExternalCanisterCallPermission>
+  };
 export type ExternalCanisterChangeCallRequestPoliciesInput = {
+    /**
+     * Remove call request policies by the provided ids.
+     */
     'RemoveByPolicyIds' : Array<UUID>
   } |
   {
+    /**
+     * Override the request policies for the specified execution methods.
+     */
     'OverrideSpecifiedByExecutionMethods' : Array<
       {
+        /**
+         * The method that the caller can call on the external canister.
+         * 
+         * The `*` method name is used to represent that the caller can call any method on the canister.
+         */
         'execution_method' : string,
+        /**
+         * The request policies associated with the execution method, if the list is empty all the policies of
+         * the execution method will be removed.
+         */
         'policies' : Array<
           {
+            /**
+             * The request policy rule for the canister call operation.
+             */
             'rule' : RequestPolicyRule,
+            /**
+             * The validation method that is used to match the policy against
+             * the permission of the resource.
+             */
             'validation_method' : ValidationMethodResourceTarget,
+            /**
+             * The id of the request policy rule.
+             * 
+             * If not provided a new entry will be created.
+             */
             'policy_id' : [] | [UUID],
           }
         >,
@@ -546,48 +1752,162 @@ export type ExternalCanisterChangeCallRequestPoliciesInput = {
     >
   } |
   {
+    /**
+     * Override the request policies for the specified execution and validation method pairs.
+     */
     'OverrideSpecifiedByExecutionValidationMethodPairs' : Array<
       {
+        /**
+         * The method configuration that is used to represent the execution and validation method pair.
+         */
         'method_configuration' : CanisterExecutionAndValidationMethodPair,
+        /**
+         * The request policies to use for the method configuration, if the list is empty all the policies of
+         * the execution and validation method pair will be removed.
+         */
         'policies' : Array<ExternalCanisterChangeRequestPolicyRuleInput>,
       }
     >
   } |
-  { 'ReplaceAllBy' : Array<ExternalCanisterCallRequestPolicyRuleInput> };
+  {
+    /**
+     * Replaces all the call request policies with the provided list.
+     */
+    'ReplaceAllBy' : Array<ExternalCanisterCallRequestPolicyRuleInput>
+  };
+/**
+ * The request policy rule for the canister change operation.
+ */
 export interface ExternalCanisterChangeRequestPolicyRule {
+  /**
+   * The request policy rule for the canister change operation.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The id of the request policy rule.
+   */
   'policy_id' : UUID,
 }
+/**
+ * The request policy rule for the canister change operation.
+ */
 export interface ExternalCanisterChangeRequestPolicyRuleInput {
+  /**
+   * The request policy rule for the canister change operation.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The id of the request policy rule.
+   * 
+   * If not provided a new entry will be created.
+   */
   'policy_id' : [] | [UUID],
 }
+/**
+ * The target canister to interact with.
+ */
 export type ExternalCanisterId = { 'Any' : null } |
   { 'Canister' : Principal };
-export interface ExternalCanisterMetadata { 'key' : string, 'value' : string }
+/**
+ * ExternalCanister can have additional information attached to them,
+ * this type can be used to represent the additional info.
+ */
+export interface ExternalCanisterMetadata {
+  /**
+   * The key of the additional info (e.g. "app_id")
+   */
+  'key' : string,
+  /**
+   * The value of the additional info (e.g. "2ec270f1-7663-4d51-b70f-9339486b6d6d")
+   */
+  'value' : string,
+}
+/**
+ * The permissions set for the external canister.
+ */
 export interface ExternalCanisterPermissions {
+  /**
+   * The permissions for the calling methods on the canister.
+   */
   'calls' : Array<ExternalCanisterCallPermission>,
+  /**
+   * Who can read information about the canister (e.g. canister status),
+   * changes to this permission can be made by the `change` permission.
+   */
   'read' : Allow,
+  /**
+   * Who can make changes to the canister, includes:
+   * - changing the permissions
+   * - install operations
+   */
   'change' : Allow,
 }
+/**
+ * The create input type for setting the permissions for the external canister.
+ */
 export type ExternalCanisterPermissionsCreateInput = ExternalCanisterPermissions;
+/**
+ * The input type for setting the permissions for the external canister.
+ */
 export interface ExternalCanisterPermissionsUpdateInput {
+  /**
+   * The permissions for calling methods on the canister.
+   */
   'calls' : [] | [ExternalCanisterChangeCallPermissionsInput],
+  /**
+   * Who can read information about the canister (e.g. canister status),
+   * changes to this permission can be made by the `change` permission.
+   */
   'read' : [] | [Allow],
+  /**
+   * Who can make changes to the canister, includes:
+   * - changing the permissions
+   * - install operations
+   */
   'change' : [] | [Allow],
 }
+/**
+ * The request policy rules for the external canister.
+ */
 export interface ExternalCanisterRequestPolicies {
+  /**
+   * The request policy rules for the calling methods on the canister.
+   */
   'calls' : Array<ExternalCanisterCallRequestPolicyRule>,
+  /**
+   * The request policy rules for the canister change operation.
+   */
   'change' : Array<ExternalCanisterChangeRequestPolicyRule>,
 }
+/**
+ * The input type for setting the request policies for a new external canister.
+ */
 export interface ExternalCanisterRequestPoliciesCreateInput {
+  /**
+   * The request policy rules for the calling methods on the canister.
+   */
   'calls' : Array<ExternalCanisterCallRequestPolicyRuleInput>,
+  /**
+   * The request policy rules for the canister change operation.
+   */
   'change' : Array<ExternalCanisterChangeRequestPolicyRuleInput>,
 }
+/**
+ * The input type for setting the request policies for an existing external canister.
+ */
 export interface ExternalCanisterRequestPoliciesUpdateInput {
+  /**
+   * The request policy rules for the calling methods on the canister.
+   */
   'calls' : [] | [ExternalCanisterChangeCallRequestPoliciesInput],
+  /**
+   * The request policy rules for the canister change operation.
+   */
   'change' : [] | [Array<ExternalCanisterChangeRequestPolicyRuleInput>],
 }
+/**
+ * The actions that are available for external canisters.
+ */
 export type ExternalCanisterResourceAction = {
     'Call' : CallExternalCanisterResourceTarget
   } |
@@ -596,119 +1916,499 @@ export type ExternalCanisterResourceAction = {
   { 'Read' : ExternalCanisterId } |
   { 'Create' : null } |
   { 'Change' : ExternalCanisterId };
-export type ExternalCanisterState = { 'Active' : null } |
-  { 'Archived' : null };
-export interface FetchAccountBalancesInput { 'account_ids' : Array<UUID> }
-export type FetchAccountBalancesResult = {
-    'Ok' : { 'balances' : Array<[] | [AccountBalance]> }
+/**
+ * The state of the external canister.
+ */
+export type ExternalCanisterState = {
+    /**
+     * The record is active and can be interacted with.
+     */
+    'Active' : null
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The record is archived and can no longer be interacted with.
+     */
+    'Archived' : null
+  };
+/**
+ * Input type for getting a account balance.
+ */
+export interface FetchAccountBalancesInput {
+  /**
+   * The account ids to retrieve.
+   */
+  'account_ids' : Array<UUID>,
+}
+/**
+ * Result type for getting a account.
+ */
+export type FetchAccountBalancesResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The account balance that was retrieved.
+       */
+      'balances' : Array<[] | [AccountBalance]>,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The request operation for funding an external canister from the station.
+ */
 export type FundExternalCanisterOperation = FundExternalCanisterOperationInput;
+/**
+ * The input type for funding an external canister in the station.
+ */
 export interface FundExternalCanisterOperationInput {
+  /**
+   * The kind of funding operation to perform.
+   */
   'kind' : FundExternalCanisterOperationKind,
+  /**
+   * The external canister to fund.
+   */
   'canister_id' : Principal,
 }
+/**
+ * The operation kind for funding an external canister in the station.
+ */
 export type FundExternalCanisterOperationKind = {
+    /**
+     * The amount of cycles to send to the canister.
+     */
     'Send' : FundExternalCanisterSendCyclesInput
   };
-export interface FundExternalCanisterSendCyclesInput { 'cycles' : bigint }
-export interface GetAccountInput { 'account_id' : UUID }
+/**
+ * The input type for specifying the cycles to send to an external canister.
+ */
+export interface FundExternalCanisterSendCyclesInput {
+  /**
+   * The amount of cycles to send to the canister.
+   */
+  'cycles' : bigint,
+}
+/**
+ * Input type for getting a account.
+ */
+export interface GetAccountInput {
+  /**
+   * The account id to retrieve.
+   */
+  'account_id' : UUID,
+}
+/**
+ * Result type for getting a account.
+ */
 export type GetAccountResult = {
-    'Ok' : { 'privileges' : AccountCallerPrivileges, 'account' : Account }
-  } |
-  { 'Err' : Error };
-export interface GetAddressBookEntryInput { 'address_book_entry_id' : UUID }
-export type GetAddressBookEntryResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The privileges of the caller for the account.
+       */
+      'privileges' : AccountCallerPrivileges,
+      /**
+       * The account that was retrieved.
+       */
+      'account' : Account,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for getting a single address book entry.
+ */
+export interface GetAddressBookEntryInput {
+  /**
+   * The address book entry id to retrieve.
+   */
+  'address_book_entry_id' : UUID,
+}
+/**
+ * Result type for getting an address book entry.
+ */
+export type GetAddressBookEntryResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The privileges of the caller for the address book entry.
+       */
       'privileges' : AddressBookEntryCallerPrivileges,
+      /**
+       * The address book entry that was retrieved.
+       */
       'address_book_entry' : AddressBookEntry,
     }
   } |
-  { 'Err' : Error };
-export interface GetAssetInput { 'asset_id' : UUID }
-export type GetAssetResult = {
-    'Ok' : { 'privileges' : AssetCallerPrivileges, 'asset' : Asset }
-  } |
-  { 'Err' : Error };
-export interface GetExternalCanisterFiltersInput {
-  'with_labels' : [] | [boolean],
-  'with_name' : [] | [{ 'prefix' : [] | [string] }],
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for getting an asset.
+ */
+export interface GetAssetInput {
+  /**
+   * The asset id to retrieve.
+   */
+  'asset_id' : UUID,
 }
+/**
+ * The result type for getting an asset.
+ */
+export type GetAssetResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The caller privileges for the asset.
+       */
+      'privileges' : AssetCallerPrivileges,
+      /**
+       * The asset that was retrieved.
+       */
+      'asset' : Asset,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for getting the available filters for the external canisters.
+ */
+export interface GetExternalCanisterFiltersInput {
+  /**
+   * Include the labels of the external canisters in the result.
+   */
+  'with_labels' : [] | [boolean],
+  /**
+   * Include the names of the external canisters in the result.
+   */
+  'with_name' : [] | [
+    {
+      /**
+       * The prefix to use for filtering the names.
+       * 
+       * If the prefix is not provided, any name will be returned.
+       */
+      'prefix' : [] | [string],
+    }
+  ],
+}
+/**
+ * The result type for the filtering of external canisters.
+ */
 export type GetExternalCanisterFiltersResult = {
     'Ok' : {
+      /**
+       * The list of labels that are used by the external canisters.
+       */
       'labels' : [] | [Array<string>],
+      /**
+       * The list of names that are used by the external canisters
+       * and their canister id.
+       */
       'names' : [] | [Array<{ 'name' : string, 'canister_id' : Principal }>],
     }
   } |
   { 'Err' : Error };
-export interface GetExternalCanisterInput { 'canister_id' : Principal }
+/**
+ * Input type for getting a external canister.
+ */
+export interface GetExternalCanisterInput {
+  /**
+   * The principal id of the external canister.
+   */
+  'canister_id' : Principal,
+}
 export type GetExternalCanisterResult = {
     'Ok' : {
+      /**
+       * The caller privileges for the external canister.
+       */
       'privileges' : ExternalCanisterCallerPrivileges,
+      /**
+       * The external canister that was retrieved.
+       */
       'canister' : ExternalCanister,
     }
   } |
   { 'Err' : Error };
-export interface GetNamedRuleInput { 'named_rule_id' : UUID }
+/**
+ * Input type for getting a named rule.
+ */
+export interface GetNamedRuleInput {
+  /**
+   * The named rule to retrieve by the id.
+   */
+  'named_rule_id' : UUID,
+}
+/**
+ * Result type for retrieving a named rule.
+ */
 export type GetNamedRuleResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The privileges of the caller for the named rule.
+       */
       'privileges' : NamedRuleCallerPrivileges,
+      /**
+       * The named rule that was retrieved.
+       */
       'named_rule' : NamedRule,
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for getting the list of requests based on the given filters.
+ */
 export interface GetNextApprovableRequestInput {
+  /**
+   * Get the next request from a list sorted by the given field.
+   */
   'sort_by' : [] | [ListRequestsSortBy],
+  /**
+   * Exclude requests the user indicated to skip.
+   */
   'excluded_request_ids' : Array<UUID>,
+  /**
+   * The type of the request (e.g. "transfer").
+   */
   'operation_types' : [] | [Array<ListRequestsOperationType>],
 }
+/**
+ * Result type for retrieving a request.
+ */
 export type GetNextApprovableRequestResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : [] | [GetRequestResultData]
   } |
-  { 'Err' : Error };
-export interface GetPermissionInput { 'resource' : Resource }
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+export interface GetPermissionInput {
+  /**
+   * The resource to retrieve the permission for.
+   */
+  'resource' : Resource,
+}
 export type GetPermissionResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The permission that was retrieved.
+       */
       'permission' : Permission,
+      /**
+       * The privileges of the caller for the permission.
+       */
       'privileges' : PermissionCallerPrivileges,
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for getting a request.
+ */
 export interface GetRequestInput {
+  /**
+   * The request id to retrieve.
+   */
   'request_id' : UUID,
+  /**
+   * Fill in all the additional info about the request operation, request types such as `CallExternalCanisterOperation`
+   * will include the request argument, this can be a large amount of data and could potentially exceed the response
+   * size limit.
+   * 
+   * If not provided, this field defaults to `false` and the additional info is not included in the response.
+   */
   'with_full_info' : [] | [boolean],
 }
-export interface GetRequestPolicyInput { 'id' : UUID }
+export interface GetRequestPolicyInput {
+  /**
+   * The id of the request policy to retrieve.
+   */
+  'id' : UUID,
+}
 export type GetRequestPolicyResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The privileges of the caller for the request policy.
+       */
       'privileges' : RequestPolicyCallerPrivileges,
+      /**
+       * The request policy that was retrieved.
+       */
       'policy' : RequestPolicy,
     }
   } |
-  { 'Err' : Error };
-export type GetRequestResult = { 'Ok' : GetRequestResultData } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Result type for retrieving a request.
+ */
+export type GetRequestResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : GetRequestResultData
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
 export interface GetRequestResultData {
+  /**
+   * The privileges of the caller.
+   */
   'privileges' : RequestCallerPrivileges,
+  /**
+   * The request that was requested.
+   */
   'request' : Request,
+  /**
+   * The additional info about the request.
+   */
   'additional_info' : RequestAdditionalInfo,
 }
-export interface GetTransfersInput { 'transfer_ids' : Array<UUID> }
-export type GetTransfersResult = { 'Ok' : { 'transfers' : Array<Transfer> } } |
-  { 'Err' : Error };
-export interface GetUserGroupInput { 'user_group_id' : UUID }
-export type GetUserGroupResult = {
+export interface GetTransfersInput {
+  /**
+   * The list of transfer ids to retrieve.
+   */
+  'transfer_ids' : Array<UUID>,
+}
+export type GetTransfersResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The transfer that was retrieved.
+       */
+      'transfers' : Array<Transfer>,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for getting a user group.
+ */
+export interface GetUserGroupInput {
+  /**
+   * The group id to retrieve.
+   */
+  'user_group_id' : UUID,
+}
+/**
+ * Result type for getting a user group.
+ */
+export type GetUserGroupResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The caller privileges for the user group.
+       */
       'privileges' : UserGroupCallerPrivileges,
+      /**
+       * The group that was retrieved.
+       */
       'user_group' : UserGroup,
     }
   } |
-  { 'Err' : Error };
-export interface GetUserInput { 'user_id' : UUID }
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for retrieving a user.
+ */
+export interface GetUserInput {
+  /**
+   * The user id to retrieve (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
+  'user_id' : UUID,
+}
+/**
+ * Result type for retrieving a user.
+ */
 export type GetUserResult = {
-    'Ok' : { 'privileges' : UserCallerPrivileges, 'user' : User }
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The caller privileges for the user.
+       */
+      'privileges' : UserCallerPrivileges,
+      /**
+       * The user that was retrieved.
+       */
+      'user' : User,
+    }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
 export type HeaderField = [string, string];
 export type HealthStatus = { 'Healthy' : null } |
   { 'Uninitialized' : null };
@@ -723,587 +2423,2413 @@ export interface HttpResponse {
   'headers' : Array<HeaderField>,
   'status_code' : number,
 }
+/**
+ * The initial accounts to create when initializing the canister for the first time, e.g., after disaster recovery.
+ */
 export interface InitAccountInput {
+  /**
+   * The UUID of the account, if not provided a new UUID will be generated.
+   */
   'id' : [] | [UUID],
+  /**
+   * Metadata associated with the account (e.g. `{"contract": "0x1234", "symbol": "ANY"}`).
+   */
   'metadata' : Array<AccountMetadata>,
+  /**
+   * A friendly name for the account (e.g. "My Account").
+   */
   'name' : string,
+  /**
+   * The asset standard for this account (e.g. `native`, `erc20`, etc.).
+   */
   'assets' : Array<UUID>,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'seed' : AccountSeed,
 }
+/**
+ * The permissions for the account.
+ */
 export interface InitAccountPermissionsInput {
+  /**
+   * The approval policy for updates to the account.
+   */
   'configs_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * Who can read the account information.
+   */
   'read_permission' : Allow,
+  /**
+   * Who can request updates to the account.
+   */
   'configs_permission' : Allow,
+  /**
+   * The approval policy for transfers from the account.
+   */
   'transfer_request_policy' : [] | [RequestPolicyRule],
+  /**
+   * Who can request transfers from the account.
+   */
   'transfer_permission' : Allow,
 }
+/**
+ * The initial account to create when initializing the canister for the first time.
+ */
 export interface InitAccountWithPermissionsInput {
+  /**
+   * The permissions for the account.
+   */
   'permissions' : InitAccountPermissionsInput,
+  /**
+   * The initial account to create.
+   */
   'account_init' : InitAccountInput,
 }
+/**
+ * The initial assets to create when initializing the canister for the first time, e.g., after disaster recovery.
+ */
 export interface InitAssetInput {
+  /**
+   * The UUID of the asset, if not provided a new UUID will be generated.
+   */
   'id' : [] | [UUID],
+  /**
+   * The number of decimals used to format the asset balance.
+   */
   'decimals' : number,
+  /**
+   * The standards this asset supports.
+   */
   'standards' : Array<string>,
+  /**
+   * Metadata associated with the asset.
+   */
   'metadata' : Array<AssetMetadata>,
+  /**
+   * The name of the asset.
+   */
   'name' : string,
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : string,
+  /**
+   * The asset symbol, e.g. "ICP" or "BTC".
+   */
   'symbol' : string,
 }
+/**
+ * The init type for adding a named rule when initializing the canister for the first time.
+ */
 export interface InitNamedRuleInput {
+  /**
+   * The id of the named rule, if not provided a new UUID will be generated.
+   */
   'id' : [] | [UUID],
+  /**
+   * The name of the named rule.
+   */
   'name' : string,
+  /**
+   * The rule to use for the named rule.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The description of the named rule.
+   */
   'description' : [] | [string],
 }
-export interface InitPermissionInput { 'resource' : Resource, 'allow' : Allow }
+/**
+ * The init type for initializing the permissions when first creating the canister.
+ */
+export interface InitPermissionInput {
+  /**
+   * The resource that the permission is for.
+   */
+  'resource' : Resource,
+  /**
+   * The allow rules for who can access the resource.
+   */
+  'allow' : Allow,
+}
+/**
+ * The init type for adding a request approval policy when initializing the canister for the first time.
+ */
 export interface InitRequestPolicyInput {
+  /**
+   * The id of the request policy, if not provided a new UUID will be generated.
+   */
   'id' : [] | [UUID],
+  /**
+   * The rule to use for the request approval evaluation (e.g. "quorum").
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The request specifier that identifies what operation this policy is for (e.g. "transfer").
+   */
   'specifier' : RequestSpecifier,
 }
-export interface InitUserGroupInput { 'id' : [] | [UUID], 'name' : string }
-export interface InitUserInput {
+/**
+ * The input type for creating a user group when initializing the canister for the first time.
+ */
+export interface InitUserGroupInput {
+  /**
+   * The id of the user group, if not provided a new UUID will be generated.
+   */
   'id' : [] | [UUID],
-  'status' : UserStatus,
-  'groups' : [] | [Array<UUID>],
+  /**
+   * The name of the user group, must be unique.
+   */
   'name' : string,
+}
+/**
+ * The users to create when initializing the canister for the first time.
+ */
+export interface InitUserInput {
+  /**
+   * The id of the user, if not provided a new UUID will be generated.
+   */
+  'id' : [] | [UUID],
+  /**
+   * The status of the user (e.g. `Active`).
+   */
+  'status' : UserStatus,
+  /**
+   * The user groups to associate with the user (optional).
+   * If not provided it defaults to the [`Admin`,`Operator`] groups if default user groups are created,
+   * i.e., when the field `initial_config` in `SystemInit` has the form of `WithAllDefaults` or `WithDefaultPolicies`.
+   */
+  'groups' : [] | [Array<UUID>],
+  /**
+   * The name of the user.
+   */
+  'name' : string,
+  /**
+   * The identities of the user.
+   */
   'identities' : Array<UserIdentityInput>,
 }
+/**
+ * The initial configuration for the station.
+ * 
+ * Unless the `Complete` variant is used, the station will be initialized with default user
+ * groups, named rules (aka. approval rules), request policies, permissions, and assets.
+ * 
+ * The default user groups for the station will be:
+ * - `Admin` with the UUID "00000000-0000-4000-8000-000000000000"
+ * - `Operator` with the UUID "00000000-0000-4000-8000-000000000001"
+ * 
+ * The default named rules for the station will be:
+ * - `Admin approval` with a specified admin quorum
+ * - `Operator approval` with a specified operator and admin quorum
+ * 
+ */
 export type InitialConfig = {
+    /**
+     * Initialize the station with default user groups, named rules, policies, permissions.
+     */
     'WithDefaultPolicies' : {
+      /**
+       * The initial assets to create.
+       */
       'assets' : Array<InitAssetInput>,
+      /**
+       * The initial admin quorum in the admin level approval rule.
+       */
       'admin_quorum' : number,
+      /**
+       * The initial accounts to create.
+       */
       'accounts' : Array<InitAccountInput>,
+      /**
+       * The initial users to create.
+       */
       'users' : Array<InitUserInput>,
+      /**
+       * The initial operator quorum in the operator level approval rule.
+       */
       'operator_quorum' : number,
     }
   } |
   {
+    /**
+     * Initialize the station with default user groups, named rules, policies, permissions, and assets.
+     * This does not create an initial account.
+     */
     'WithAllDefaults' : {
+      /**
+       * The initial admin quorum in the admin level approval rule.
+       */
       'admin_quorum' : number,
+      /**
+       * The initial users to create.
+       */
       'users' : Array<InitUserInput>,
+      /**
+       * The initial operator quorum in the operator level approval rule.
+       */
       'operator_quorum' : number,
     }
   } |
   {
+    /**
+     * Initialize the station with all custom entries.
+     */
     'Complete' : {
+      /**
+       * The initial permissions to create.
+       */
       'permissions' : Array<InitPermissionInput>,
+      /**
+       * The initial assets to create.
+       */
       'assets' : Array<InitAssetInput>,
+      /**
+       * The initial request policies to create.
+       */
       'request_policies' : Array<InitRequestPolicyInput>,
+      /**
+       * The initial user groups to create.
+       */
       'user_groups' : Array<InitUserGroupInput>,
+      /**
+       * The initial accounts to create.
+       */
       'accounts' : Array<InitAccountWithPermissionsInput>,
+      /**
+       * The initial disaster recovery committee to create.
+       */
       'disaster_recovery_committee' : [] | [DisasterRecoveryCommittee],
+      /**
+       * The initial users to create.
+       */
       'users' : Array<InitUserInput>,
+      /**
+       * The initial named rules to create.
+       */
       'named_rules' : Array<InitNamedRuleInput>,
     }
   };
 export interface ListAccountTransfersInput {
+  /**
+   * The account id to retrieve.
+   */
   'account_id' : UUID,
+  /**
+   * The transfer status in text format (e.g. "pending", "approved", etc.).
+   */
   'status' : [] | [TransferStatusType],
+  /**
+   * Until which date to retrieve the transfers.
+   */
   'to_dt' : [] | [TimestampRFC3339],
+  /**
+   * From which date to retrieve the transfers.
+   */
   'from_dt' : [] | [TimestampRFC3339],
 }
 export type ListAccountTransfersResult = {
-    'Ok' : { 'transfers' : Array<TransferListItem> }
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The list of transfers.
+       */
+      'transfers' : Array<TransferListItem>,
+    }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * A record type that can be used search for accounts.
+ */
 export interface ListAccountsInput {
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
+  /**
+   * The name of the account to search for.
+   */
   'search_term' : [] | [string],
 }
+/**
+ * Result type for listing all accounts.
+ */
 export type ListAccountsResult = {
     'Ok' : {
+      /**
+       * The total number of users.
+       */
       'total' : bigint,
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : Array<AccountCallerPrivileges>,
+      /**
+       * The list of accounts.
+       */
       'accounts' : Array<Account>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
   { 'Err' : Error };
+/**
+ * Input type for listing address book entries for a given blockchain standard.
+ */
 export interface ListAddressBookEntriesInput {
+  /**
+   * The address boo entry ids to retrieve.
+   */
   'ids' : [] | [Array<UUID>],
+  /**
+   * The address formats to search for.
+   */
   'address_formats' : [] | [Array<string>],
+  /**
+   * The labels to search for, if provided only address book entries with the given labels will be returned.
+   */
   'labels' : [] | [Array<string>],
+  /**
+   * The blockchain identifier (e.g., `ethereum`, `bitcoin`, `icp`, etc.)
+   */
   'blockchain' : [] | [string],
+  /**
+   * The address to search for.
+   */
   'addresses' : [] | [Array<string>],
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
+  /**
+   * The term to use for filtering the address book entries.
+   */
   'search_term' : [] | [string],
 }
+/**
+ * Result type for listing address book entries for a given blockchain standard.
+ */
 export type ListAddressBookEntriesResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of address book entries for the given blockchain standard.
+       */
       'total' : bigint,
+      /**
+       * The privileges of the caller for the address book entries.
+       */
       'privileges' : Array<AddressBookEntryCallerPrivileges>,
+      /**
+       * The list of retrieved address book entries.
+       */
       'address_book_entries' : Array<AddressBookEntry>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
-  { 'Err' : Error };
-export interface ListAssetsInput { 'paginate' : [] | [PaginationInput] }
-export type ListAssetsResult = {
-    'Ok' : {
-      'total' : bigint,
-      'privileges' : Array<AssetCallerPrivileges>,
-      'assets' : Array<Asset>,
-      'next_offset' : [] | [bigint],
-    }
-  } |
-  { 'Err' : Error };
-export interface ListExternalCanistersInput {
-  'sort_by' : [] | [ListExternalCanistersSortInput],
-  'states' : [] | [Array<ExternalCanisterState>],
-  'canister_ids' : [] | [Array<Principal>],
-  'labels' : [] | [Array<string>],
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for listing assets.
+ */
+export interface ListAssetsInput {
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
 }
+/**
+ * The result type for listing assets.
+ */
+export type ListAssetsResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The total number of assets.
+       */
+      'total' : bigint,
+      /**
+       * The caller privileges for the assets.
+       */
+      'privileges' : Array<AssetCallerPrivileges>,
+      /**
+       * The list of assets.
+       */
+      'assets' : Array<Asset>,
+      /**
+       * The offset to use for the next page.
+       */
+      'next_offset' : [] | [bigint],
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for listing external canisters with the given filters.
+ */
+export interface ListExternalCanistersInput {
+  /**
+   * The sort parameters.
+   */
+  'sort_by' : [] | [ListExternalCanistersSortInput],
+  /**
+   * The current state of the external canisters to use for filtering (e.g. `Active`, `Archived`).
+   */
+  'states' : [] | [Array<ExternalCanisterState>],
+  /**
+   * The principal id of the external canister to search for.
+   */
+  'canister_ids' : [] | [Array<Principal>],
+  /**
+   * The labels to use for filtering the external canisters.
+   */
+  'labels' : [] | [Array<string>],
+  /**
+   * The pagination parameters.
+   */
+  'paginate' : [] | [PaginationInput],
+}
+/**
+ * Result type for listing external canisters.
+ */
 export type ListExternalCanistersResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of external canisters.
+       */
       'total' : bigint,
+      /**
+       * The caller privileges for the external canisters.
+       */
       'privileges' : Array<ExternalCanisterCallerPrivileges>,
+      /**
+       * The list of external canisters.
+       */
       'canisters' : Array<ExternalCanister>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
-  { 'Err' : Error };
-export type ListExternalCanistersSortInput = { 'Name' : SortByDirection };
-export interface ListNamedRulesInput { 'paginate' : [] | [PaginationInput] }
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for sorting the results of listing external canisters.
+ */
+export type ListExternalCanistersSortInput = {
+    /**
+     * Sort by the name of the external canister.
+     */
+    'Name' : SortByDirection
+  };
+/**
+ * Input type for listing named rules.
+ */
+export interface ListNamedRulesInput {
+  /**
+   * The pagination parameters.
+   */
+  'paginate' : [] | [PaginationInput],
+}
+/**
+ * Result type for listing named rules.
+ */
 export type ListNamedRulesResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of named rules.
+       */
       'total' : bigint,
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : Array<NamedRuleCallerPrivileges>,
+      /**
+       * The list of named rules.
+       */
       'named_rules' : Array<NamedRule>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for getting the list of notifications associated with the caller.
+ */
 export interface ListNotificationsInput {
+  /**
+   * Show only notifications with the given status.
+   */
   'status' : [] | [NotificationStatus],
+  /**
+   * Until which created time to retrieve the notifications.
+   */
   'to_dt' : [] | [TimestampRFC3339],
+  /**
+   * From which created time to retrieve the notifications.
+   */
   'from_dt' : [] | [TimestampRFC3339],
+  /**
+   * The type of the notification (e.g. "system-message").
+   */
   'notification_type' : [] | [NotificationTypeInput],
 }
+/**
+ * The result type for getting the list of notifications.
+ */
 export type ListNotificationsResult = {
-    'Ok' : { 'notifications' : Array<Notification> }
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The list of notifications ordered by creation time (newest first).
+       */
+      'notifications' : Array<Notification>,
+    }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for listing permissions with the given pagination parameters.
+ */
 export interface ListPermissionsInput {
+  /**
+   * The resources to retrieve the permissions for.
+   */
   'resources' : [] | [Array<Resource>],
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
 }
+/**
+ * Result type for listing permissions.
+ */
 export type ListPermissionsResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The list of permissions.
+       */
       'permissions' : Array<Permission>,
+      /**
+       * The total number of permissions.
+       */
       'total' : bigint,
+      /**
+       * The caller privileges for the permissions.
+       */
       'privileges' : Array<PermissionCallerPrivileges>,
+      /**
+       * The user groups that are associated with returned permissions.
+       */
       'user_groups' : Array<UserGroup>,
+      /**
+       * The users that are associated with returned permissions.
+       */
       'users' : Array<BasicUser>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * Input type for listing request policies with the given pagination parameters.
+ */
 export type ListRequestPoliciesInput = PaginationInput;
+/**
+ * Result type for listing request policies.
+ */
 export type ListRequestPoliciesResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of request policies.
+       */
       'total' : bigint,
+      /**
+       * The caller privileges for the request policies.
+       */
       'privileges' : Array<RequestPolicyCallerPrivileges>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
+      /**
+       * The list of request policies.
+       */
       'policies' : Array<RequestPolicy>,
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type for getting the list of requests based on the given filters.
+ */
 export interface ListRequestsInput {
+  /**
+   * The sorting parameters.
+   */
   'sort_by' : [] | [ListRequestsSortBy],
+  /**
+   * Return only requests with one of these deduplication keys.
+   */
   'deduplication_keys' : [] | [Array<string>],
+  /**
+   * Return the full evaluation results for the requests.
+   */
   'with_evaluation_results' : boolean,
+  /**
+   * From which expiration time to retrieve the requests.
+   */
   'expiration_from_dt' : [] | [TimestampRFC3339],
+  /**
+   * The tags to search. Return only requests which have at least one matching tag.
+   */
   'tags' : [] | [Array<string>],
+  /**
+   * Until which created time to retrieve the requests.
+   */
   'created_to_dt' : [] | [TimestampRFC3339],
+  /**
+   * Show only requests with the given status.
+   */
   'statuses' : [] | [Array<RequestStatusCode>],
+  /**
+   * Show only requests that the specified users have submitted an approval decision for.
+   */
   'approver_ids' : [] | [Array<UUID>],
+  /**
+   * Until which expiration time to retrieve the requests.
+   */
   'expiration_to_dt' : [] | [TimestampRFC3339],
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
+  /**
+   * Show only requests made by the given users.
+   */
   'requester_ids' : [] | [Array<UUID>],
+  /**
+   * The type of the request (e.g. "transfer").
+   */
   'operation_types' : [] | [Array<ListRequestsOperationType>],
+  /**
+   * Return only requests the the user can submit an approval decision for.
+   */
   'only_approvable' : boolean,
+  /**
+   * From which created time to retrieve the requests.
+   */
   'created_from_dt' : [] | [TimestampRFC3339],
 }
-export type ListRequestsOperationType = { 'RemoveAsset' : null } |
-  { 'AddUserGroup' : null } |
-  { 'EditPermission' : null } |
-  { 'SnapshotExternalCanister' : [] | [Principal] } |
-  { 'PruneExternalCanister' : [] | [Principal] } |
-  { 'EditNamedRule' : null } |
-  { 'ConfigureExternalCanister' : [] | [Principal] } |
-  { 'ChangeExternalCanister' : [] | [Principal] } |
-  { 'MonitorExternalCanister' : [] | [Principal] } |
-  { 'AddUser' : null } |
-  { 'EditAsset' : null } |
-  { 'EditUserGroup' : null } |
-  { 'SetDisasterRecovery' : null } |
-  { 'EditRequestPolicy' : null } |
-  { 'RemoveRequestPolicy' : null } |
-  { 'AddAsset' : null } |
-  { 'SystemUpgrade' : null } |
-  { 'RemoveAddressBookEntry' : null } |
-  { 'SystemRestore' : null } |
-  { 'CreateExternalCanister' : null } |
-  { 'EditAddressBookEntry' : null } |
-  { 'FundExternalCanister' : [] | [Principal] } |
-  { 'EditUser' : null } |
-  { 'ManageSystemInfo' : null } |
-  { 'Transfer' : [] | [UUID] } |
-  { 'EditAccount' : null } |
-  { 'AddAddressBookEntry' : null } |
-  { 'AddRequestPolicy' : null } |
-  { 'RemoveNamedRule' : null } |
-  { 'RemoveUserGroup' : null } |
-  { 'CallExternalCanister' : [] | [Principal] } |
-  { 'AddNamedRule' : null } |
-  { 'RestoreExternalCanister' : [] | [Principal] } |
-  { 'AddAccount' : null };
+export type ListRequestsOperationType = {
+    /**
+     * An operation for removing an asset.
+     */
+    'RemoveAsset' : null
+  } |
+  {
+    /**
+     * An operation for adding a new user group.
+     */
+    'AddUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for editing an permission.
+     */
+    'EditPermission' : null
+  } |
+  {
+    /**
+     * An operation for snapshotting an external canister.
+     */
+    'SnapshotExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for pruning an external canister.
+     */
+    'PruneExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for editing a named rule.
+     */
+    'EditNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for configuring an external canister.
+     */
+    'ConfigureExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for changing a external canister with an optionally specified canister ID.
+     */
+    'ChangeExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for monitoring cycles of an external canister.
+     */
+    'MonitorExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for adding a new user.
+     */
+    'AddUser' : null
+  } |
+  {
+    /**
+     * An operation for editing an asset.
+     */
+    'EditAsset' : null
+  } |
+  {
+    /**
+     * An operation for editing an existing user group.
+     */
+    'EditUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for setting disaster recovery config.
+     */
+    'SetDisasterRecovery' : null
+  } |
+  {
+    /**
+     * An operation for editing a request policy.
+     */
+    'EditRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for removing a request policy.
+     */
+    'RemoveRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for adding an asset.
+     */
+    'AddAsset' : null
+  } |
+  {
+    /**
+     * An operation for performing a system upgrade on the station or upgrader.
+     */
+    'SystemUpgrade' : null
+  } |
+  {
+    /**
+     * An operation for removing an address book entry.
+     */
+    'RemoveAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for restoring the station or upgrader from a snapshot.
+     */
+    'SystemRestore' : null
+  } |
+  {
+    /**
+     * An operation for creating a external canister.
+     */
+    'CreateExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for updating an address book entry.
+     */
+    'EditAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for sending cycles to an external canister.
+     */
+    'FundExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for editing an existing user.
+     */
+    'EditUser' : null
+  } |
+  {
+    /**
+     * An operation for managing system info.
+     */
+    'ManageSystemInfo' : null
+  } |
+  {
+    /**
+     * A new transfer of funds from a given account.
+     */
+    'Transfer' : [] | [UUID]
+  } |
+  {
+    /**
+     * An operation for updating information of an account.
+     */
+    'EditAccount' : null
+  } |
+  {
+    /**
+     * An operation for creating a new address book entry.
+     */
+    'AddAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for adding a request policy.
+     */
+    'AddRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for removing a named rule.
+     */
+    'RemoveNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for removing an existing user group.
+     */
+    'RemoveUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for calling an external canister with an optionally specified canister ID.
+     */
+    'CallExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for adding a named rule.
+     */
+    'AddNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for restoring an external canister from a snapshot.
+     */
+    'RestoreExternalCanister' : [] | [Principal]
+  } |
+  {
+    /**
+     * An operation for creating a new account.
+     */
+    'AddAccount' : null
+  };
+/**
+ * The result type for getting the list of requests.
+ */
 export type ListRequestsResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of requests.
+       */
       'total' : bigint,
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : Array<RequestCallerPrivileges>,
+      /**
+       * The list of requests.
+       */
       'requests' : Array<Request>,
+      /**
+       * The next offset to use for pagination.
+       */
       'next_offset' : [] | [bigint],
+      /**
+       * The additional info about the requests.
+       */
       'additional_info' : Array<RequestAdditionalInfo>,
     }
   } |
-  { 'Err' : Error };
-export type ListRequestsSortBy = { 'ExpirationDt' : SortByDirection } |
-  { 'LastModificationDt' : SortByDirection } |
-  { 'CreatedAt' : SortByDirection };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
+/**
+ * The input type that can be used to sort the list of requests by a given field.
+ */
+export type ListRequestsSortBy = {
+    /**
+     * Sort by the request expiration time.
+     */
+    'ExpirationDt' : SortByDirection
+  } |
+  {
+    /**
+     * Sort by the request last modification time.
+     */
+    'LastModificationDt' : SortByDirection
+  } |
+  {
+    /**
+     * Sort by the request creation time.
+     */
+    'CreatedAt' : SortByDirection
+  };
 export interface ListUserGroupsInput {
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
+  /**
+   * The term to use for filtering the user groups.
+   */
   'search_term' : [] | [string],
 }
+/**
+ * Result type for listing all user groups.
+ */
 export type ListUserGroupsResult = {
     'Ok' : {
+      /**
+       * The total number of user groups.
+       */
       'total' : bigint,
+      /**
+       * The caller privileges for the user groups.
+       */
       'privileges' : Array<UserGroupCallerPrivileges>,
+      /**
+       * The list of groups.
+       */
       'user_groups' : Array<UserGroup>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
   { 'Err' : Error };
+/**
+ * Input type for listing users of the station.
+ */
 export interface ListUsersInput {
+  /**
+   * The groups to use for filtering the users.
+   */
   'groups' : [] | [Array<UUID>],
+  /**
+   * The statuses to use for filtering the users.
+   */
   'statuses' : [] | [Array<UserStatus>],
+  /**
+   * The pagination parameters.
+   */
   'paginate' : [] | [PaginationInput],
+  /**
+   * The search term to use for filtering the users.
+   */
   'search_term' : [] | [string],
 }
+/**
+ * Result type for listing users of the station.
+ */
 export type ListUsersResult = {
+    /**
+     * The result data for a successful execution.
+     */
     'Ok' : {
+      /**
+       * The total number of users.
+       */
       'total' : bigint,
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : Array<UserCallerPrivileges>,
+      /**
+       * The list of users.
+       */
       'users' : Array<User>,
+      /**
+       * The offset to use for the next page.
+       */
       'next_offset' : [] | [bigint],
     }
   } |
-  { 'Err' : Error };
+  {
+    /**
+     * The error that occurred (e.g. the user does not have the necessary permissions).
+     */
+    'Err' : Error
+  };
 export type LogVisibility = { 'controllers' : null } |
   { 'public' : null } |
   { 'allowed_viewers' : Array<Principal> };
+/**
+ * An operation for managing the system information.
+ */
 export interface ManageSystemInfoOperation {
+  /**
+   * The input to the request to manage the system information.
+   */
   'input' : ManageSystemInfoOperationInput,
 }
+/**
+ * Input type for managing the system information.
+ */
 export interface ManageSystemInfoOperationInput {
+  /**
+   * The name of the station.
+   */
   'name' : [] | [string],
+  /**
+   * The strategy to use to for the station to top itself up with cycles.
+   */
   'cycle_obtain_strategy' : [] | [CycleObtainStrategyInput],
+  /**
+   * The maximum number of upgrader backup snapshots to keep.
+   */
   'max_upgrader_backup_snapshots' : [] | [bigint],
+  /**
+   * The maximum number of station backup snapshots to keep.
+   */
   'max_station_backup_snapshots' : [] | [bigint],
 }
 export type MarkNotificationReadResult = { 'Ok' : null } |
   { 'Err' : Error };
 export interface MarkNotificationsReadInput {
+  /**
+   * The notifications to mark as read.
+   */
   'notification_ids' : Array<UUID>,
+  /**
+   * If true, all notifications will be marked as read.
+   */
   'read' : boolean,
 }
 export type MeResult = {
-    'Ok' : { 'me' : User, 'privileges' : Array<UserPrivilege> }
+    'Ok' : {
+      /**
+       * The user that is associated with the caller.
+       */
+      'me' : User,
+      /**
+       * The list of privileges associated with the user.
+       */
+      'privileges' : Array<UserPrivilege>,
+    }
   } |
   { 'Err' : Error };
+/**
+ * The request operation for monitoring an external canister from the station.
+ */
 export type MonitorExternalCanisterOperation = MonitorExternalCanisterOperationInput;
+/**
+ * The input type for monitoring an external canister in the station.
+ */
 export interface MonitorExternalCanisterOperationInput {
+  /**
+   * The kind of funding operation to perform.
+   */
   'kind' : MonitorExternalCanisterOperationKind,
+  /**
+   * The external canister to monitor.
+   */
   'canister_id' : Principal,
 }
+/**
+ * The operation kind for monitoring an external canister in the station.
+ */
 export type MonitorExternalCanisterOperationKind = {
     'Start' : MonitorExternalCanisterStartInput
   } |
   { 'Stop' : null };
+/**
+ * The input type for specifying the strategy for monitoring an external canister.
+ */
 export interface MonitorExternalCanisterStartInput {
+  /**
+   * The strategy for obtaining cycles for the funding operation.
+   */
   'cycle_obtain_strategy' : [] | [CycleObtainStrategyInput],
+  /**
+   * The strategy for funding the canister.
+   */
   'funding_strategy' : MonitorExternalCanisterStrategyInput,
 }
-export type MonitorExternalCanisterStrategyInput = { 'Always' : bigint } |
-  { 'BelowThreshold' : MonitoringExternalCanisterCyclesThresholdInput } |
-  { 'BelowEstimatedRuntime' : MonitoringExternalCanisterEstimatedRuntimeInput };
+/**
+ * The input type for specifying the strategy for monitoring an external canister.
+ */
+export type MonitorExternalCanisterStrategyInput = {
+    /**
+     * Fund the canister at a fixed interval with the specified amount of cycles.
+     */
+    'Always' : bigint
+  } |
+  {
+    /**
+     * Fund the canister when the balance is below the threshold.
+     */
+    'BelowThreshold' : MonitoringExternalCanisterCyclesThresholdInput
+  } |
+  {
+    /**
+     * Fund the canister based on the estimated run time in seconds.
+     */
+    'BelowEstimatedRuntime' : MonitoringExternalCanisterEstimatedRuntimeInput
+  };
 export interface MonitoringExternalCanisterCyclesThresholdInput {
+  /**
+   * / The cycles to fund the canister with when the threshold is triggered.
+   */
   'fund_cycles' : bigint,
+  /**
+   * / The min cycles threshold to trigger the funding operation.
+   */
   'min_cycles' : bigint,
 }
 export interface MonitoringExternalCanisterEstimatedRuntimeInput {
+  /**
+   * / The runtime seconds to add to the estimated runtime.
+   */
   'fund_runtime_secs' : bigint,
+  /**
+   * / The fallback min cycles to trigger the funding operation when the estimated runtime is not available,
+   * / or the cycles balance is below the threshold.
+   */
   'fallback_min_cycles' : bigint,
+  /**
+   * / The estimated min runtime in seconds to trigger the funding operation.
+   */
   'min_runtime_secs' : bigint,
+  /**
+   * / The fallback cycles to fund the canister with when the estimated runtime is not available,
+   * / or the cycles balance is below the threshold.
+   */
   'fallback_fund_cycles' : bigint,
+  /**
+   * / The maximum cycles to fund the canister with, only used when the estimated runtime is available.
+   */
   'max_runtime_cycles_fund' : bigint,
 }
+/**
+ * The named rule type.
+ * 
+ * A named rule is a reusable configuration that can be applied to many approval policies.
+ */
 export interface NamedRule {
+  /**
+   * The rule id.
+   */
   'id' : UUID,
+  /**
+   * The rule name.
+   */
   'name' : string,
+  /**
+   * The rule value.
+   */
   'rule' : RequestPolicyRule,
+  /**
+   * The rule description.
+   */
   'description' : [] | [string],
 }
+/**
+ * A record type that can be used to represent the caller privileges for a given named rule.
+ */
 export interface NamedRuleCallerPrivileges {
+  /**
+   * The named rule id.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can delete the resource.
+   */
   'can_delete' : boolean,
+  /**
+   * Whether or not the caller can edit the resource.
+   */
   'can_edit' : boolean,
 }
-export interface Network { 'id' : NetworkId, 'name' : string }
+/**
+ * The blockchain network to used in a transaction.
+ */
+export interface Network {
+  /**
+   * The network id, represented by the blockchain symbol and network name (e.g. "icp:mainnet").
+   */
+  'id' : NetworkId,
+  /**
+   * The name of the network (e.g. "Mainnet").
+   */
+  'name' : string,
+}
+/**
+ * The network id, represented by the blockchain symbol and network name (e.g. "icp:mainnet").
+ */
 export type NetworkId = string;
+/**
+ * A record type that can be used to represent a notification.
+ */
 export interface Notification {
+  /**
+   * The notification id which is a UUID (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
   'id' : UUID,
+  /**
+   * The notification status.
+   */
   'status' : NotificationStatus,
+  /**
+   * The notification title in a single locale.
+   */
   'title' : string,
+  /**
+   * The time at which the notification was created.
+   */
   'created_at' : TimestampRFC3339,
+  /**
+   * The type of the notification.
+   */
   'notification_type' : NotificationType,
+  /**
+   * The notification message in a single locale.
+   */
   'message' : [] | [string],
+  /**
+   * The user that the notification is for.
+   */
   'target_user_id' : UUID,
 }
+/**
+ * The actions that are available for notifications.
+ */
 export type NotificationResourceAction = { 'List' : null } |
   { 'Update' : ResourceId };
-export type NotificationStatus = { 'Read' : null } |
-  { 'Sent' : null };
+/**
+ * Defines the various states that a notification can be in.
+ */
+export type NotificationStatus = {
+    /**
+     * The notification has been read by the user.
+     */
+    'Read' : null
+  } |
+  {
+    /**
+     * The notification has been sent.
+     */
+    'Sent' : null
+  };
+/**
+ * Represents the different types of notifications within the system.
+ */
 export type NotificationType = {
+    /**
+     * Notification for the creation of a new request.
+     * This should be used to alert users when a new request that requires their attention has been created.
+     */
     'RequestCreated' : {
+      /**
+       * Account id is available for relevant request types.
+       */
       'account_id' : [] | [UUID],
+      /**
+       * The request id that was created.
+       */
       'request_id' : UUID,
+      /**
+       * The type of the request (e.g. "transfer").
+       */
       'operation_type' : RequestOperationType,
+      /**
+       * User id is available for relevant request types.
+       */
       'user_id' : [] | [UUID],
     }
   } |
   {
+    /**
+     * Notification for the rejection of a request.
+     * This should be used to alert the requester when a request has been rejected.
+     */
     'RequestRejected' : {
+      /**
+       * The request id that was created.
+       */
       'request_id' : UUID,
+      /**
+       * List of reasons why the request was rejected.
+       */
       'reasons' : [] | [Array<EvaluationSummaryReason>],
+      /**
+       * The type of the request (e.g. "transfer").
+       */
       'operation_type' : RequestOperationType,
     }
   } |
-  { 'SystemMessage' : null } |
   {
+    /**
+     * Notification for system-wide messages.
+     * This can be used for announcements, scheduled maintenance reminders, or other important system messages.
+     */
+    'SystemMessage' : null
+  } |
+  {
+    /**
+     * Notification for the failure of a request.
+     * This should be used to alert the requester when a request has failed to be executed.
+     */
     'RequestFailed' : {
+      /**
+       * The request id that was created.
+       */
       'request_id' : UUID,
+      /**
+       * The type of the request (e.g. "transfer").
+       */
       'operation_type' : RequestOperationType,
+      /**
+       * Details about the failure.
+       */
       'reason' : [] | [string],
     }
   };
 export type NotificationTypeInput = { 'RequestCreated' : null } |
   { 'SystemMessage' : null };
-export interface NotifyFailedStationUpgradeInput { 'reason' : string }
+export interface NotifyFailedStationUpgradeInput {
+  /**
+   * the failure reason
+   */
+  'reason' : string,
+}
 export type NotifyFailedStationUpgradeResult = { 'Ok' : null } |
   { 'Err' : Error };
 export interface PaginationInput {
+  /**
+   * The offset to use for pagination.
+   */
   'offset' : [] | [bigint],
+  /**
+   * The maximum number of items to retrieve.
+   * 
+   * If not set, the default limit will be used.
+   */
   'limit' : [] | [number],
 }
-export interface Permission { 'resource' : Resource, 'allow' : Allow }
-export interface PermissionCallerPrivileges {
+/**
+ * The permission, used to specify the rules for users when interacting with resources.
+ */
+export interface Permission {
+  /**
+   * The resource that the permission is for.
+   */
   'resource' : Resource,
+  /**
+   * The allowed users and user groups for the resource.
+   */
+  'allow' : Allow,
+}
+/**
+ * A record type that can be used to represent the caller privileges for a given permission.
+ */
+export interface PermissionCallerPrivileges {
+  /**
+   * The resource that the caller has privileges for.
+   */
+  'resource' : Resource,
+  /**
+   * Whether or not the caller can edit the resource.
+   */
   'can_edit' : boolean,
 }
+/**
+ * The actions that are available for permissions.
+ */
 export type PermissionResourceAction = { 'Read' : null } |
   { 'Update' : null };
 export interface PruneExternalCanisterOperation {
   'input' : PruneExternalCanisterOperationInput,
 }
 export interface PruneExternalCanisterOperationInput {
+  /**
+   * The canister to prune.
+   */
   'canister_id' : Principal,
+  /**
+   * The resource to prune.
+   */
   'prune' : { 'snapshot' : string } |
     { 'state' : null } |
     { 'chunk_store' : null },
 }
-export interface Quorum { 'min_approved' : number, 'approvers' : UserSpecifier }
-export interface QuorumPercentage {
+/**
+ * A record type that can be used to represent the minimum quorum of users that are required to approve a rule.
+ */
+export interface Quorum {
+  /**
+   * The minimum number of user approvals required for the rule to be approved.
+   */
   'min_approved' : number,
+  /**
+   * The users that can approve the request.
+   */
+  'approvers' : UserSpecifier,
+}
+/**
+ * A record type that can be used to represent a percentage of users that are required to approve a rule.
+ */
+export interface QuorumPercentage {
+  /**
+   * The required user approvals for the rule to be approved.
+   */
+  'min_approved' : number,
+  /**
+   * The users that are required to approve the request.
+   */
   'approvers' : UserSpecifier,
 }
 export interface RemoveAddressBookEntryOperation {
+  /**
+   * The input to the request to remove the address book entry.
+   */
   'input' : RemoveAddressBookEntryOperationInput,
 }
+/**
+ * Input type for removing an address book entry through a request.
+ */
 export interface RemoveAddressBookEntryOperationInput {
+  /**
+   * The id of the address book entry.
+   */
   'address_book_entry_id' : UUID,
 }
-export interface RemoveAssetOperation { 'input' : RemoveAssetOperationInput }
-export interface RemoveAssetOperationInput { 'asset_id' : UUID }
+export interface RemoveAssetOperation {
+  /**
+   * The input to the request to remove an asset.
+   */
+  'input' : RemoveAssetOperationInput,
+}
+/**
+ * The input type for removing an asset.
+ */
+export interface RemoveAssetOperationInput {
+  /**
+   * The asset id to remove.
+   */
+  'asset_id' : UUID,
+}
+/**
+ * The operation type for removing a named rule.
+ */
 export interface RemoveNamedRuleOperation {
+  /**
+   * The input to the request to remove a named rule.
+   */
   'input' : RemoveNamedRuleOperationInput,
 }
-export interface RemoveNamedRuleOperationInput { 'named_rule_id' : UUID }
+/**
+ * The input type for deleting a named rule.
+ */
+export interface RemoveNamedRuleOperationInput {
+  /**
+   * The named rule id to remove.
+   */
+  'named_rule_id' : UUID,
+}
 export interface RemoveRequestPolicyOperation {
+  /**
+   * The input to the request to remove a request policy.
+   */
   'input' : RemoveRequestPolicyOperationInput,
 }
-export interface RemoveRequestPolicyOperationInput { 'policy_id' : UUID }
+export interface RemoveRequestPolicyOperationInput {
+  /**
+   * The request policy id that will be removed.
+   */
+  'policy_id' : UUID,
+}
 export interface RemoveUserGroupOperation {
+  /**
+   * The input to the request to remove the user group.
+   */
   'input' : RemoveUserGroupOperationInput,
 }
-export interface RemoveUserGroupOperationInput { 'user_group_id' : UUID }
+export interface RemoveUserGroupOperationInput {
+  /**
+   * The id of the group to remove.
+   */
+  'user_group_id' : UUID,
+}
+/**
+ * A record type that can be used to represent a requested operation in the station.
+ */
 export interface Request {
+  /**
+   * The request id which is a UUID (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
   'id' : UUID,
+  /**
+   * The request approval status.
+   */
   'status' : RequestStatus,
+  /**
+   * The request title.
+   */
   'title' : string,
+  /**
+   * The time at which the request should be executed if approved.
+   */
   'execution_plan' : RequestExecutionSchedule,
+  /**
+   * The time at which the request will expire.
+   */
   'expiration_dt' : TimestampRFC3339,
+  /**
+   * The optional deduplication key used to ensure request uniqueness.
+   */
   'deduplication_key' : [] | [string],
+  /**
+   * The tags that were provided during request creation.
+   */
   'tags' : Array<string>,
+  /**
+   * The time at which the request was created.
+   */
   'created_at' : TimestampRFC3339,
+  /**
+   * The user that created the request.
+   */
   'requested_by' : UUID,
+  /**
+   * The request summary (e.g. "This request will transfer 100 ICP to the account 0x1234").
+   */
   'summary' : [] | [string],
+  /**
+   * The operation that was requested.
+   */
   'operation' : RequestOperation,
+  /**
+   * The list of user approvals on the request.
+   */
   'approvals' : Array<RequestApproval>,
 }
+/**
+ * A record type that can be used to represent additional information about a request.
+ */
 export interface RequestAdditionalInfo {
+  /**
+   * The request id.
+   */
   'id' : UUID,
+  /**
+   * The evaluation result of all matching policies for the request.
+   */
   'evaluation_result' : [] | [RequestEvaluationResult],
+  /**
+   * The requester name (e.g. "John Doe").
+   */
   'requester_name' : string,
+  /**
+   * Display information for the approvers.
+   */
   'approvers' : Array<DisplayUser>,
 }
+/**
+ * A record type that is used to represent a user approval decision on a request.
+ */
 export interface RequestApproval {
+  /**
+   * The user has added to the request, once provided it cannot be changed.
+   */
   'status' : RequestApprovalStatus,
+  /**
+   * The user that has recorded the approval decision.
+   */
   'approver_id' : UUID,
+  /**
+   * Optional reason for the decision.
+   */
   'status_reason' : [] | [string],
+  /**
+   * The time at which the decision was made.
+   */
   'decided_at' : TimestampRFC3339,
 }
+/**
+ * The status of a request.
+ */
 export type RequestApprovalStatus = { 'Approved' : null } |
   { 'Rejected' : null };
+/**
+ * A record type that can be used to represent the caller privileges for a given request.
+ */
 export interface RequestCallerPrivileges {
+  /**
+   * The request id.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can submit an approval decision.
+   */
   'can_approve' : boolean,
 }
+/**
+ * A record type representing the full evaluation result of all matching policies for a request.
+ */
 export interface RequestEvaluationResult {
+  /**
+   * The request id that was evaluated.
+   */
   'request_id' : UUID,
+  /**
+   * The final evaluation status of the request.
+   */
   'status' : EvaluationStatus,
+  /**
+   * The reasons why the request was approved or rejected.
+   */
   'result_reasons' : [] | [Array<EvaluationSummaryReason>],
+  /**
+   * The evaluation results of all matching policies.
+   */
   'policy_results' : Array<RequestPolicyRuleResult>,
 }
-export type RequestExecutionSchedule = { 'Immediate' : null } |
-  { 'Scheduled' : { 'execution_time' : TimestampRFC3339 } };
-export type RequestOperation = { 'RemoveAsset' : RemoveAssetOperation } |
-  { 'AddUserGroup' : AddUserGroupOperation } |
-  { 'EditPermission' : EditPermissionOperation } |
-  { 'SnapshotExternalCanister' : SnapshotExternalCanisterOperation } |
-  { 'PruneExternalCanister' : PruneExternalCanisterOperation } |
-  { 'EditNamedRule' : EditNamedRuleOperation } |
-  { 'ConfigureExternalCanister' : ConfigureExternalCanisterOperation } |
-  { 'ChangeExternalCanister' : ChangeExternalCanisterOperation } |
-  { 'MonitorExternalCanister' : MonitorExternalCanisterOperation } |
-  { 'AddUser' : AddUserOperation } |
-  { 'EditAsset' : EditAssetOperation } |
-  { 'EditUserGroup' : EditUserGroupOperation } |
-  { 'SetDisasterRecovery' : SetDisasterRecoveryOperation } |
-  { 'EditRequestPolicy' : EditRequestPolicyOperation } |
-  { 'RemoveRequestPolicy' : RemoveRequestPolicyOperation } |
-  { 'AddAsset' : AddAssetOperation } |
-  { 'SystemUpgrade' : SystemUpgradeOperation } |
-  { 'RemoveAddressBookEntry' : RemoveAddressBookEntryOperation } |
-  { 'SystemRestore' : SystemRestoreOperation } |
-  { 'CreateExternalCanister' : CreateExternalCanisterOperation } |
-  { 'EditAddressBookEntry' : EditAddressBookEntryOperation } |
-  { 'FundExternalCanister' : FundExternalCanisterOperation } |
-  { 'EditUser' : EditUserOperation } |
-  { 'ManageSystemInfo' : ManageSystemInfoOperation } |
-  { 'Transfer' : TransferOperation } |
-  { 'EditAccount' : EditAccountOperation } |
-  { 'AddAddressBookEntry' : AddAddressBookEntryOperation } |
-  { 'AddRequestPolicy' : AddRequestPolicyOperation } |
-  { 'RemoveNamedRule' : RemoveNamedRuleOperation } |
-  { 'RemoveUserGroup' : RemoveUserGroupOperation } |
-  { 'CallExternalCanister' : CallExternalCanisterOperation } |
-  { 'AddNamedRule' : AddNamedRuleOperation } |
-  { 'RestoreExternalCanister' : RestoreExternalCanisterOperation } |
-  { 'AddAccount' : AddAccountOperation };
+/**
+ * The schedule for executing a transaction of a given transfer.
+ */
+export type RequestExecutionSchedule = {
+    /**
+     * The transaction will be executed immediately.
+     */
+    'Immediate' : null
+  } |
+  {
+    /**
+     * The transaction will be executed at a given time.
+     */
+    'Scheduled' : {
+      /**
+       * The time at which the transaction will be executed,
+       * it must be in the future.
+       */
+      'execution_time' : TimestampRFC3339,
+    }
+  };
+export type RequestOperation = {
+    /**
+     * An operation for removing an existing asset.
+     */
+    'RemoveAsset' : RemoveAssetOperation
+  } |
+  {
+    /**
+     * An operation for adding a new user group.
+     */
+    'AddUserGroup' : AddUserGroupOperation
+  } |
+  {
+    /**
+     * An operation for editing an permission.
+     */
+    'EditPermission' : EditPermissionOperation
+  } |
+  {
+    /**
+     * An operation for snapshotting an external canister.
+     */
+    'SnapshotExternalCanister' : SnapshotExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for pruning an external canister.
+     */
+    'PruneExternalCanister' : PruneExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for editing an existing named rule.
+     */
+    'EditNamedRule' : EditNamedRuleOperation
+  } |
+  {
+    /**
+     * An operation for configuring an external canister.
+     */
+    'ConfigureExternalCanister' : ConfigureExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for changing a external canister.
+     */
+    'ChangeExternalCanister' : ChangeExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for monitoring an external canister.
+     */
+    'MonitorExternalCanister' : MonitorExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for adding a new user.
+     */
+    'AddUser' : AddUserOperation
+  } |
+  {
+    /**
+     * An operation for editing an existing asset.
+     */
+    'EditAsset' : EditAssetOperation
+  } |
+  {
+    /**
+     * An operation for editing an existing user group.
+     */
+    'EditUserGroup' : EditUserGroupOperation
+  } |
+  {
+    /**
+     * An operation for setting disaster recovery.
+     */
+    'SetDisasterRecovery' : SetDisasterRecoveryOperation
+  } |
+  {
+    /**
+     * An operation for editing a request policy.
+     */
+    'EditRequestPolicy' : EditRequestPolicyOperation
+  } |
+  {
+    /**
+     * An operation for removing a request policy.
+     */
+    'RemoveRequestPolicy' : RemoveRequestPolicyOperation
+  } |
+  {
+    /**
+     * An operation for adding a new asset.
+     */
+    'AddAsset' : AddAssetOperation
+  } |
+  {
+    /**
+     * An operation for performing a system upgrade on the station or upgrader.
+     */
+    'SystemUpgrade' : SystemUpgradeOperation
+  } |
+  {
+    /**
+     * An operation for removing an existing address book entry.
+     */
+    'RemoveAddressBookEntry' : RemoveAddressBookEntryOperation
+  } |
+  {
+    /**
+     * An operation for restoring the station or upgrader from a snapshot.
+     */
+    'SystemRestore' : SystemRestoreOperation
+  } |
+  {
+    /**
+     * An operation for creating a external canister.
+     */
+    'CreateExternalCanister' : CreateExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for updating an existing address book entry.
+     */
+    'EditAddressBookEntry' : EditAddressBookEntryOperation
+  } |
+  {
+    /**
+     * An operation for funding an external canister.
+     */
+    'FundExternalCanister' : FundExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for editing an existing user.
+     */
+    'EditUser' : EditUserOperation
+  } |
+  {
+    /**
+     * An operation for managing system info.
+     */
+    'ManageSystemInfo' : ManageSystemInfoOperation
+  } |
+  {
+    /**
+     * A new transfer of funds from a given account.
+     */
+    'Transfer' : TransferOperation
+  } |
+  {
+    /**
+     * An operation for updating information of an account.
+     */
+    'EditAccount' : EditAccountOperation
+  } |
+  {
+    /**
+     * An operation for creating a new address book entry.
+     */
+    'AddAddressBookEntry' : AddAddressBookEntryOperation
+  } |
+  {
+    /**
+     * An operation for adding a request policy.
+     */
+    'AddRequestPolicy' : AddRequestPolicyOperation
+  } |
+  {
+    /**
+     * An operation for removing an existing named rule.
+     */
+    'RemoveNamedRule' : RemoveNamedRuleOperation
+  } |
+  {
+    /**
+     * An operation for removing an existing user group.
+     */
+    'RemoveUserGroup' : RemoveUserGroupOperation
+  } |
+  {
+    /**
+     * An operation for calling an external canister.
+     */
+    'CallExternalCanister' : CallExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for adding a new named rule.
+     */
+    'AddNamedRule' : AddNamedRuleOperation
+  } |
+  {
+    /**
+     * An operation for restoring an external canister from a snapshot.
+     */
+    'RestoreExternalCanister' : RestoreExternalCanisterOperation
+  } |
+  {
+    /**
+     * An operation for creating a new account.
+     */
+    'AddAccount' : AddAccountOperation
+  };
 export type RequestOperationInput = {
+    /**
+     * An operation for removing an existing asset.
+     */
     'RemoveAsset' : RemoveAssetOperationInput
   } |
-  { 'AddUserGroup' : AddUserGroupOperationInput } |
-  { 'EditPermission' : EditPermissionOperationInput } |
-  { 'SnapshotExternalCanister' : SnapshotExternalCanisterOperationInput } |
-  { 'PruneExternalCanister' : PruneExternalCanisterOperationInput } |
-  { 'EditNamedRule' : EditNamedRuleOperationInput } |
-  { 'ConfigureExternalCanister' : ConfigureExternalCanisterOperationInput } |
-  { 'ChangeExternalCanister' : ChangeExternalCanisterOperationInput } |
-  { 'MonitorExternalCanister' : MonitorExternalCanisterOperationInput } |
-  { 'AddUser' : AddUserOperationInput } |
-  { 'EditAsset' : EditAssetOperationInput } |
-  { 'EditUserGroup' : EditUserGroupOperationInput } |
-  { 'SetDisasterRecovery' : SetDisasterRecoveryOperationInput } |
-  { 'EditRequestPolicy' : EditRequestPolicyOperationInput } |
-  { 'RemoveRequestPolicy' : RemoveRequestPolicyOperationInput } |
-  { 'AddAsset' : AddAssetOperationInput } |
-  { 'SystemUpgrade' : SystemUpgradeOperationInput } |
-  { 'RemoveAddressBookEntry' : RemoveAddressBookEntryOperationInput } |
-  { 'SystemRestore' : SystemRestoreOperationInput } |
-  { 'CreateExternalCanister' : CreateExternalCanisterOperationInput } |
-  { 'EditAddressBookEntry' : EditAddressBookEntryOperationInput } |
-  { 'FundExternalCanister' : FundExternalCanisterOperationInput } |
-  { 'EditUser' : EditUserOperationInput } |
-  { 'ManageSystemInfo' : ManageSystemInfoOperationInput } |
-  { 'Transfer' : TransferOperationInput } |
-  { 'EditAccount' : EditAccountOperationInput } |
-  { 'AddAddressBookEntry' : AddAddressBookEntryOperationInput } |
-  { 'AddRequestPolicy' : AddRequestPolicyOperationInput } |
-  { 'RemoveNamedRule' : RemoveNamedRuleOperationInput } |
-  { 'RemoveUserGroup' : RemoveUserGroupOperationInput } |
-  { 'CallExternalCanister' : CallExternalCanisterOperationInput } |
-  { 'AddNamedRule' : AddNamedRuleOperationInput } |
-  { 'RestoreExternalCanister' : RestoreExternalCanisterOperationInput } |
-  { 'AddAccount' : AddAccountOperationInput };
-export type RequestOperationType = { 'RemoveAsset' : null } |
-  { 'AddUserGroup' : null } |
-  { 'EditPermission' : null } |
-  { 'SnapshotExternalCanister' : null } |
-  { 'PruneExternalCanister' : null } |
-  { 'EditNamedRule' : null } |
-  { 'ConfigureExternalCanister' : null } |
-  { 'ChangeExternalCanister' : null } |
-  { 'MonitorExternalCanister' : null } |
-  { 'AddUser' : null } |
-  { 'EditAsset' : null } |
-  { 'EditUserGroup' : null } |
-  { 'SetDisasterRecovery' : null } |
-  { 'EditRequestPolicy' : null } |
-  { 'RemoveRequestPolicy' : null } |
-  { 'AddAsset' : null } |
-  { 'SystemUpgrade' : null } |
-  { 'RemoveAddressBookEntry' : null } |
-  { 'SystemRestore' : null } |
-  { 'CreateExternalCanister' : null } |
-  { 'EditAddressBookEntry' : null } |
-  { 'FundExternalCanister' : null } |
-  { 'EditUser' : null } |
-  { 'ManageSystemInfo' : null } |
-  { 'Transfer' : null } |
-  { 'EditAccount' : null } |
-  { 'AddAddressBookEntry' : null } |
-  { 'AddRequestPolicy' : null } |
-  { 'RemoveNamedRule' : null } |
-  { 'RemoveUserGroup' : null } |
-  { 'CallExternalCanister' : null } |
-  { 'AddNamedRule' : null } |
-  { 'RestoreExternalCanister' : null } |
-  { 'AddAccount' : null };
+  {
+    /**
+     * An operation for adding a new user group.
+     */
+    'AddUserGroup' : AddUserGroupOperationInput
+  } |
+  {
+    /**
+     * An operation for editing an permission.
+     */
+    'EditPermission' : EditPermissionOperationInput
+  } |
+  {
+    /**
+     * An operation for snapshotting an external canister.
+     */
+    'SnapshotExternalCanister' : SnapshotExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for pruning an external canister.
+     */
+    'PruneExternalCanister' : PruneExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for editing an existing named rule.
+     */
+    'EditNamedRule' : EditNamedRuleOperationInput
+  } |
+  {
+    /**
+     * An operation for configuring an external canister.
+     */
+    'ConfigureExternalCanister' : ConfigureExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for changing a external canister.
+     */
+    'ChangeExternalCanister' : ChangeExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for monitoring an external canister.
+     */
+    'MonitorExternalCanister' : MonitorExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for adding a new user.
+     */
+    'AddUser' : AddUserOperationInput
+  } |
+  {
+    /**
+     * An operation for editing an existing asset.
+     */
+    'EditAsset' : EditAssetOperationInput
+  } |
+  {
+    /**
+     * An operation for editing an existing user group.
+     */
+    'EditUserGroup' : EditUserGroupOperationInput
+  } |
+  {
+    /**
+     * An operation for setting disaster recovery.
+     */
+    'SetDisasterRecovery' : SetDisasterRecoveryOperationInput
+  } |
+  {
+    /**
+     * An operation for editing a request policy.
+     */
+    'EditRequestPolicy' : EditRequestPolicyOperationInput
+  } |
+  {
+    /**
+     * An operation for removing a request policy.
+     */
+    'RemoveRequestPolicy' : RemoveRequestPolicyOperationInput
+  } |
+  {
+    /**
+     * An operation for adding a new asset.
+     */
+    'AddAsset' : AddAssetOperationInput
+  } |
+  {
+    /**
+     * An operation for performing a system upgrade on the station or upgrader.
+     */
+    'SystemUpgrade' : SystemUpgradeOperationInput
+  } |
+  {
+    /**
+     * An operation for removing an address book entry.
+     */
+    'RemoveAddressBookEntry' : RemoveAddressBookEntryOperationInput
+  } |
+  {
+    /**
+     * An operation for restoring the station or upgrader from a snapshot.
+     */
+    'SystemRestore' : SystemRestoreOperationInput
+  } |
+  {
+    /**
+     * An operation for creating a external canister.
+     */
+    'CreateExternalCanister' : CreateExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for updating an address book entry.
+     */
+    'EditAddressBookEntry' : EditAddressBookEntryOperationInput
+  } |
+  {
+    /**
+     * An operation for funding an external canister.
+     */
+    'FundExternalCanister' : FundExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for editing an existing user.
+     */
+    'EditUser' : EditUserOperationInput
+  } |
+  {
+    /**
+     * An operation for managing system info.
+     */
+    'ManageSystemInfo' : ManageSystemInfoOperationInput
+  } |
+  {
+    /**
+     * A new transfer of funds from a given account.
+     */
+    'Transfer' : TransferOperationInput
+  } |
+  {
+    /**
+     * An operation for updating information of an account.
+     */
+    'EditAccount' : EditAccountOperationInput
+  } |
+  {
+    /**
+     * An operation for creating a new address book entry.
+     */
+    'AddAddressBookEntry' : AddAddressBookEntryOperationInput
+  } |
+  {
+    /**
+     * An operation for adding a request policy.
+     */
+    'AddRequestPolicy' : AddRequestPolicyOperationInput
+  } |
+  {
+    /**
+     * An operation for removing an existing named rule.
+     */
+    'RemoveNamedRule' : RemoveNamedRuleOperationInput
+  } |
+  {
+    /**
+     * An operation for removing an existing user group.
+     */
+    'RemoveUserGroup' : RemoveUserGroupOperationInput
+  } |
+  {
+    /**
+     * An operation for calling an external canister.
+     */
+    'CallExternalCanister' : CallExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for adding a new named rule.
+     */
+    'AddNamedRule' : AddNamedRuleOperationInput
+  } |
+  {
+    /**
+     * An operation for restoring an external canister from a snapshot.
+     */
+    'RestoreExternalCanister' : RestoreExternalCanisterOperationInput
+  } |
+  {
+    /**
+     * An operation for adding a new account.
+     */
+    'AddAccount' : AddAccountOperationInput
+  };
+export type RequestOperationType = {
+    /**
+     * An operation for removing an existing asset.
+     */
+    'RemoveAsset' : null
+  } |
+  {
+    /**
+     * An operation for adding a new user group.
+     */
+    'AddUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for editing an permission.
+     */
+    'EditPermission' : null
+  } |
+  {
+    /**
+     * An operation for snapshotting an external canister.
+     */
+    'SnapshotExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for pruning an external canister.
+     */
+    'PruneExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for editing an existing named rule.
+     */
+    'EditNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for creating a external canister.
+     */
+    'ConfigureExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for changing a external canister.
+     */
+    'ChangeExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for monitoring cycles of an external canister.
+     */
+    'MonitorExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for adding a new user.
+     */
+    'AddUser' : null
+  } |
+  {
+    /**
+     * An operation for editing an existing asset.
+     */
+    'EditAsset' : null
+  } |
+  {
+    /**
+     * An operation for editing an existing user group.
+     */
+    'EditUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for setting disaster recovery for a canister.
+     */
+    'SetDisasterRecovery' : null
+  } |
+  {
+    /**
+     * An operation for editing a request policy.
+     */
+    'EditRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for removing a request policy.
+     */
+    'RemoveRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for adding a new asset.
+     */
+    'AddAsset' : null
+  } |
+  {
+    /**
+     * An operation for performing a system upgrade on the station or upgrader.
+     */
+    'SystemUpgrade' : null
+  } |
+  {
+    /**
+     * An operation for removing an address book entry.
+     */
+    'RemoveAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for restoring the station or upgrader from a snapshot.
+     */
+    'SystemRestore' : null
+  } |
+  {
+    /**
+     * An operation for creating a external canister.
+     */
+    'CreateExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for updating an address book entry.
+     */
+    'EditAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for sending cycles to an external canister.
+     */
+    'FundExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for editing an existing user.
+     */
+    'EditUser' : null
+  } |
+  {
+    /**
+     * And operation for managing system info.
+     */
+    'ManageSystemInfo' : null
+  } |
+  {
+    /**
+     * A new transfer of funds from a given account.
+     */
+    'Transfer' : null
+  } |
+  {
+    /**
+     * An operation for updating information of an account.
+     */
+    'EditAccount' : null
+  } |
+  {
+    /**
+     * An operation for creating a new address book entry.
+     */
+    'AddAddressBookEntry' : null
+  } |
+  {
+    /**
+     * An operation for adding a request policy.
+     */
+    'AddRequestPolicy' : null
+  } |
+  {
+    /**
+     * An operation for removing an existing named rule.
+     */
+    'RemoveNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for removing an existing user group.
+     */
+    'RemoveUserGroup' : null
+  } |
+  {
+    /**
+     * An operation for calling an external canister.
+     */
+    'CallExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for adding a new named rule.
+     */
+    'AddNamedRule' : null
+  } |
+  {
+    /**
+     * An operation for restoring an external canister from a snapshot.
+     */
+    'RestoreExternalCanister' : null
+  } |
+  {
+    /**
+     * An operation for creating a new account.
+     */
+    'AddAccount' : null
+  };
+/**
+ * Represents a request policy with the associated rule.
+ */
 export interface RequestPolicy {
   'id' : UUID,
   'rule' : RequestPolicyRule,
   'specifier' : RequestSpecifier,
 }
+/**
+ * A record type that can be used to represent the caller privileges for a given request policy.
+ */
 export interface RequestPolicyCallerPrivileges {
+  /**
+   * The request policy id.
+   */
   'id' : UUID,
+  /**
+   * Whether or not the caller can delete the resource.
+   */
   'can_delete' : boolean,
+  /**
+   * Whether or not the caller can edit the resource.
+   */
   'can_edit' : boolean,
 }
+/**
+ * Defines the various types rules that can be used in a request evaluation.
+ */
 export type RequestPolicyRule = { 'Not' : RequestPolicyRule } |
   { 'Quorum' : Quorum } |
   { 'AllowListed' : null } |
@@ -1315,12 +4841,27 @@ export type RequestPolicyRule = { 'Not' : RequestPolicyRule } |
   { 'NamedRule' : UUID };
 export type RequestPolicyRuleInput = { 'Set' : RequestPolicyRule } |
   { 'Remove' : null };
+/**
+ * A record type representing the full evaluation result of a request policy rule.
+ */
 export interface RequestPolicyRuleResult {
+  /**
+   * The final evaluation status of the rule.
+   */
   'status' : EvaluationStatus,
+  /**
+   * The result of the evaluation of the rule and all its sub-rules.
+   */
   'evaluated_rule' : EvaluatedRequestPolicyRule,
 }
+/**
+ * The actions that are available for requests.
+ */
 export type RequestResourceAction = { 'List' : null } |
   { 'Read' : ResourceId };
+/**
+ * Defines the various types of requests that can be created.
+ */
 export type RequestSpecifier = { 'RemoveAsset' : ResourceIds } |
   { 'AddUserGroup' : null } |
   { 'EditPermission' : ResourceSpecifier } |
@@ -1349,6 +4890,9 @@ export type RequestSpecifier = { 'RemoveAsset' : ResourceIds } |
   { 'CallExternalCanister' : CallExternalCanisterResourceTarget } |
   { 'AddNamedRule' : null } |
   { 'AddAccount' : null };
+/**
+ * The status of a request.
+ */
 export type RequestStatus = { 'Failed' : { 'reason' : [] | [string] } } |
   { 'Approved' : null } |
   { 'Rejected' : null } |
@@ -1357,6 +4901,9 @@ export type RequestStatus = { 'Failed' : { 'reason' : [] | [string] } } |
   { 'Processing' : { 'started_at' : TimestampRFC3339 } } |
   { 'Created' : null } |
   { 'Completed' : { 'completed_at' : TimestampRFC3339 } };
+/**
+ * The status code of a request.
+ */
 export type RequestStatusCode = { 'Failed' : null } |
   { 'Approved' : null } |
   { 'Rejected' : null } |
@@ -1365,6 +4912,9 @@ export type RequestStatusCode = { 'Failed' : null } |
   { 'Processing' : null } |
   { 'Created' : null } |
   { 'Completed' : null };
+/**
+ * The Resource is used to specify what is being accessed.
+ */
 export type Resource = { 'Request' : RequestResourceAction } |
   { 'Notification' : NotificationResourceAction } |
   { 'System' : SystemResourceAction } |
@@ -1377,13 +4927,22 @@ export type Resource = { 'Request' : RequestResourceAction } |
   { 'UserGroup' : ResourceAction } |
   { 'Permission' : PermissionResourceAction } |
   { 'RequestPolicy' : ResourceAction };
+/**
+ * The resource actions, used to specify the action that is performed on a resource.
+ */
 export type ResourceAction = { 'List' : null } |
   { 'Read' : ResourceId } |
   { 'Delete' : ResourceId } |
   { 'Create' : null } |
   { 'Update' : ResourceId };
+/**
+ * The record id of a resource, used to specify the resource that is being accessed.
+ */
 export type ResourceId = { 'Id' : UUID } |
   { 'Any' : null };
+/**
+ * The record ids of a resource, used to specify the resources that are being accessed.
+ */
 export type ResourceIds = { 'Any' : null } |
   { 'Ids' : Array<UUID> };
 export type ResourceSpecifier = { 'Any' : null } |
@@ -1392,76 +4951,256 @@ export interface RestoreExternalCanisterOperation {
   'input' : RestoreExternalCanisterOperationInput,
 }
 export interface RestoreExternalCanisterOperationInput {
+  /**
+   * The canister to restore from a snapshot.
+   */
   'canister_id' : Principal,
+  /**
+   * A snapshot to be restored.
+   */
   'snapshot_id' : string,
 }
 export interface SetDisasterRecoveryOperation {
+  /**
+   * The disaster recovery committee.
+   */
   'committee' : [] | [DisasterRecoveryCommittee],
 }
 export interface SetDisasterRecoveryOperationInput {
+  /**
+   * The disaster recovery committee.
+   */
   'committee' : [] | [DisasterRecoveryCommittee],
 }
+/**
+ * The hash string representation for sha256.
+ */
 export type Sha256Hash = string;
 export interface SnapshotExternalCanisterOperation {
   'input' : SnapshotExternalCanisterOperationInput,
+  /**
+   * The snapshot id of the new snapshot.
+   */
   'snapshot_id' : [] | [string],
 }
 export interface SnapshotExternalCanisterOperationInput {
+  /**
+   * Should a snapshot be taken if the external canister fails to stop.
+   */
   'force' : boolean,
+  /**
+   * A snapshot to be replaced.
+   */
   'replace_snapshot' : [] | [string],
+  /**
+   * The canister to snapshot.
+   */
   'canister_id' : Principal,
 }
-export type SortByDirection = { 'Asc' : null } |
-  { 'Desc' : null };
+/**
+ * The direction to use for sorting.
+ */
+export type SortByDirection = {
+    /**
+     * Sort in ascending order.
+     */
+    'Asc' : null
+  } |
+  {
+    /**
+     * Sort in descending order.
+     */
+    'Desc' : null
+  };
+/**
+ * Describes a standard suported by a blockchain.
+ */
 export interface StandardData {
+  /**
+   * Supported operations for the standard (e.g. `["transfer", "list_transfers", "balance"]`).
+   */
   'supported_operations' : Array<string>,
+  /**
+   * Supported address formats of the standard.
+   */
   'supported_address_formats' : Array<string>,
+  /**
+   * Required metadata fields for the standard (e.g. `["ledger_canister_id"]`).
+   */
   'required_metadata_fields' : Array<string>,
+  /**
+   * The standard name.
+   */
   'standard' : string,
 }
+/**
+ * Input type for submitting an approval decision on a request.
+ */
 export interface SubmitRequestApprovalInput {
+  /**
+   * The request id to interact with.
+   */
   'request_id' : UUID,
+  /**
+   * The decision to submit.
+   */
   'decision' : RequestApprovalStatus,
+  /**
+   * The reason for the approval or rejection.
+   */
   'reason' : [] | [string],
 }
+/**
+ * Result type for submitting an approval decision on a request.
+ */
 export type SubmitRequestApprovalResult = {
     'Ok' : {
+      /**
+       * The privileges of the caller.
+       */
       'privileges' : RequestCallerPrivileges,
+      /**
+       * The request that the decision was submitted for.
+       */
       'request' : Request,
+      /**
+       * The additional info about the request.
+       */
       'additional_info' : RequestAdditionalInfo,
     }
   } |
   { 'Err' : Error };
 export interface SubnetFilter { 'subnet_type' : [] | [string] }
-export type SubnetSelection = { 'Filter' : SubnetFilter } |
-  { 'Subnet' : { 'subnet' : Principal } };
+export type SubnetSelection = {
+    /**
+     * Choose a random subnet that fulfills the specified properties
+     */
+    'Filter' : SubnetFilter
+  } |
+  {
+    /**
+     * Choose a specific subnet
+     */
+    'Subnet' : { 'subnet' : Principal }
+  };
+/**
+ * Describes a blockchain and its standards supported by the station.
+ */
 export interface SupportedBlockchain {
+  /**
+   * The blockchain name.
+   */
   'blockchain' : string,
+  /**
+   * The supported standards for the blockchain.
+   */
   'supported_standards' : Array<StandardData>,
 }
+/**
+ * The system information.
+ */
 export interface SystemInfo {
+  /**
+   * The disaster recovery configuration.
+   */
   'disaster_recovery' : [] | [DisasterRecovery],
+  /**
+   * Cycle balance of the canister.
+   */
   'upgrader_cycles' : [] | [bigint],
+  /**
+   * The name of the station.
+   */
   'name' : string,
+  /**
+   * The time at which the canister was last upgraded.
+   */
   'last_upgrade_timestamp' : TimestampRFC3339,
+  /**
+   * Did the canister successfully fetched randomness from the management canister.
+   */
   'raw_rand_successful' : boolean,
+  /**
+   * The station version.
+   */
   'version' : string,
+  /**
+   * Cycle balance of the station.
+   */
   'cycles' : bigint,
+  /**
+   * The upgrader principal id.
+   */
   'upgrader_id' : Principal,
+  /**
+   * Strategy defining how the station canister tops up its own cycles.
+   */
   'cycle_obtain_strategy' : CycleObtainStrategy,
+  /**
+   * The maximum number of upgrader backup snapshots to keep.
+   */
   'max_upgrader_backup_snapshots' : bigint,
+  /**
+   * The maximum number of station backup snapshots to keep.
+   */
   'max_station_backup_snapshots' : bigint,
 }
-export type SystemInfoResult = { 'Ok' : { 'system' : SystemInfo } } |
-  { 'Err' : Error };
+/**
+ * Result type for getting the canister system information.
+ */
+export type SystemInfoResult = {
+    /**
+     * The result data for a successful execution.
+     */
+    'Ok' : {
+      /**
+       * The system information.
+       */
+      'system' : SystemInfo,
+    }
+  } |
+  {
+    /**
+     * The error that occurred (e.g. the caller does not have sufficient privileges).
+     */
+    'Err' : Error
+  };
 export interface SystemInit {
+  /**
+   * The name of the station.
+   */
   'name' : string,
+  /**
+   * The initial configuration to apply.
+   */
   'initial_config' : InitialConfig,
+  /**
+   * An additional controller of the station and upgrader canisters (optional).
+   */
   'fallback_controller' : [] | [Principal],
+  /**
+   * The upgrader configuration.
+   */
   'upgrader' : SystemUpgraderInput,
 }
-export type SystemInstall = { 'Upgrade' : SystemUpgrade } |
-  { 'Init' : SystemInit };
+/**
+ * The input type for the canister install method (e.g. init or upgrade).
+ */
+export type SystemInstall = {
+    /**
+     * The configuration to use when upgrading the canister.
+     */
+    'Upgrade' : SystemUpgrade
+  } |
+  {
+    /**
+     * The configuration to use when initializing the canister.
+     */
+    'Init' : SystemInit
+  };
+/**
+ * The actions that are available for the system.
+ */
 export type SystemResourceAction = { 'Upgrade' : null } |
   { 'ManageSystemInfo' : null } |
   { 'SystemInfo' : null } |
@@ -1470,104 +5209,404 @@ export interface SystemRestoreOperation {
   'input' : SystemRestoreOperationInput,
 }
 export interface SystemRestoreOperationInput {
+  /**
+   * The target to restore from a snapshot.
+   */
   'target' : SystemRestoreTarget,
+  /**
+   * A snapshot to be restored.
+   */
   'snapshot_id' : string,
 }
 export type SystemRestoreTarget = { 'RestoreUpgrader' : null } |
   { 'RestoreStation' : null };
-export interface SystemUpgrade { 'name' : [] | [string] }
+/**
+ * The upgrade configuration for the canister.
+ */
+export interface SystemUpgrade {
+  /**
+   * The updated name of the station.
+   */
+  'name' : [] | [string],
+}
 export interface SystemUpgradeOperation {
+  /**
+   * Determines whether a backup snapshot should be taken (before the upgrade).
+   * If so and the maximum number of backup snapshots is reached,
+   * then the oldest backup snapshot is atomically replaced
+   * by the new backup snapshot.
+   */
   'take_backup_snapshot' : [] | [boolean],
+  /**
+   * The checksum of the wasm module.
+   */
   'module_checksum' : Sha256Hash,
+  /**
+   * The target to change.
+   */
   'target' : SystemUpgradeTarget,
+  /**
+   * The checksum of the arg blob.
+   */
   'arg_checksum' : [] | [Sha256Hash],
 }
 export interface SystemUpgradeOperationInput {
+  /**
+   * The initial argument passed to the new wasm module.
+   */
   'arg' : [] | [Uint8Array | number[]],
+  /**
+   * Additional wasm module chunks to append to the wasm module.
+   */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
+  /**
+   * Determines whether a backup snapshot should be taken (before the upgrade).
+   * If so and the maximum number of backup snapshots is reached,
+   * then the oldest backup snapshot is atomically replaced
+   * by the new backup snapshot.
+   */
   'take_backup_snapshot' : [] | [boolean],
+  /**
+   * The target to change.
+   */
   'target' : SystemUpgradeTarget,
+  /**
+   * The wasm module to install.
+   */
   'module' : Uint8Array | number[],
 }
 export type SystemUpgradeTarget = { 'UpgradeUpgrader' : null } |
   { 'UpgradeStation' : null };
-export type SystemUpgraderInput = { 'Id' : Principal } |
+/**
+ * An input type for configuring the upgrader canister.
+ */
+export type SystemUpgraderInput = {
+    /**
+     * An existing upgrader canister.
+     */
+    'Id' : Principal
+  } |
   {
+    /**
+     * Creates and deploys a new canister.
+     */
     'Deploy' : {
+      /**
+       * The initial cycles to allocate to the canister.
+       * 
+       * If not set, only the minimal amount of cycles required to create
+       * and deploy the canister will be allocated.
+       */
       'initial_cycles' : [] | [bigint],
       'wasm_module' : Uint8Array | number[],
     }
   };
+/**
+ * The timestamp type used in the canister.
+ */
 export type TimestampRFC3339 = string;
+/**
+ * A record type that can be used to represent a transfer in a given account.
+ */
 export interface Transfer {
+  /**
+   * The internal transfer id, this a unique identifier for the transfer.
+   */
   'id' : UUID,
+  /**
+   * The destination address of the transaction (e.g. "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").
+   */
   'to' : string,
+  /**
+   * The fee to pay for the transaction, if applicable.
+   */
   'fee' : bigint,
+  /**
+   * The id of the request that created the transfer.
+   */
   'request_id' : UUID,
+  /**
+   * The status of the transfer.
+   */
   'status' : TransferStatus,
+  /**
+   * The account id to use for the transfer.
+   */
   'from_account_id' : UUID,
+  /**
+   * Transfers can be tagged with optional additional info (e.g. a `nonce` for Ethereum transactions).
+   */
   'metadata' : Array<TransferMetadata>,
+  /**
+   * The network used when submitting the transaction to the blockchain.
+   */
   'network' : Network,
+  /**
+   * The amount to transfer.
+   */
   'amount' : bigint,
 }
 export interface TransferListItem {
+  /**
+   * The destination address of the transaction (e.g. "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").
+   */
   'to' : string,
+  /**
+   * The id of the request that created the transfer.
+   */
   'request_id' : UUID,
+  /**
+   * The status of the transfer.
+   */
   'status' : TransferStatus,
+  /**
+   * The time at which the transfer was created.
+   */
   'created_at' : TimestampRFC3339,
+  /**
+   * The transfer id.
+   */
   'transfer_id' : UUID,
+  /**
+   * The amount to transfer.
+   */
   'amount' : bigint,
 }
-export interface TransferMetadata { 'key' : string, 'value' : string }
+/**
+ * Transfers can have additional information attached to them,
+ * this type can be used to represent the additional info.
+ */
+export interface TransferMetadata {
+  /**
+   * The key of the additional info (e.g. "nonce",  "tag", "memo", etc...)
+   */
+  'key' : string,
+  /**
+   * The value of the additional info (e.g. "0x1234" or "my-tag")
+   */
+  'value' : string,
+}
+/**
+ * Input type for transferring funds.
+ */
 export interface TransferOperation {
+  /**
+   * The fee paid for the transaction.
+   */
   'fee' : [] | [bigint],
+  /**
+   * The asset to use for the transaction.
+   */
   'from_asset' : Asset,
+  /**
+   * The network to use for the transaction.
+   */
   'network' : Network,
+  /**
+   * The id of the executed transfer.
+   */
   'transfer_id' : [] | [UUID],
+  /**
+   * The account to use for the transaction.
+   */
   'from_account' : [] | [Account],
+  /**
+   * The input to the request to transfer funds.
+   */
   'input' : TransferOperationInput,
 }
+/**
+ * Input type for transferring funds.
+ */
 export interface TransferOperationInput {
+  /**
+   * The destination address of the transaction (e.g. "1BvBMSE...").
+   */
   'to' : string,
+  /**
+   * The fee to pay for the transaction, if applicable.
+   * 
+   * If not set, the default fee will be used.
+   */
   'fee' : [] | [bigint],
+  /**
+   * The standard to use for the transfer.
+   */
   'with_standard' : string,
+  /**
+   * The account id to use for the transaction.
+   */
   'from_account_id' : UUID,
+  /**
+   * Transactions can be tagged with an optional additional info
+   * (e.g. a nonce in the case of an Ethereum transaction)
+   */
   'metadata' : Array<TransferMetadata>,
+  /**
+   * The network to use for the transaction, if not the
+   * default network of the account will be used.
+   */
   'network' : [] | [Network],
+  /**
+   * The amount to transfer.
+   */
   'amount' : bigint,
+  /**
+   * The asset id to transfer.
+   */
   'from_asset_id' : UUID,
 }
-export type TransferStatus = { 'Failed' : { 'reason' : string } } |
-  { 'Processing' : { 'started_at' : TimestampRFC3339 } } |
-  { 'Created' : null } |
+/**
+ * The status of a transfer.
+ */
+export type TransferStatus = {
+    /**
+     * The transfer has been failed.
+     */
+    'Failed' : {
+      /**
+       * The failure reason.
+       */
+      'reason' : string,
+    }
+  } |
   {
+    /**
+     * The transfer is being processed.
+     */
+    'Processing' : {
+      /**
+       * The time at which the transfer started being processed.
+       */
+      'started_at' : TimestampRFC3339,
+    }
+  } |
+  {
+    /**
+     * The transfer is created for processing.
+     */
+    'Created' : null
+  } |
+  {
+    /**
+     * The transfer has been completed.
+     * 
+     * For natively supported tokens this means that the transaction has
+     * submitted to the blockchain. For non natively supported tokens this means
+     * that the transaction has been signed and can be submitted by the client.
+     */
     'Completed' : {
+      /**
+       * The base64 encoded value of the signed transaction, if available.
+       */
       'signature' : [] | [string],
+      /**
+       * The transaction hash, if available.
+       */
       'hash' : [] | [string],
+      /**
+       * Time at which the transaction was completed.
+       */
       'completed_at' : TimestampRFC3339,
     }
   };
+/**
+ * Transfer status type for filtering on the transfer status.
+ */
 export type TransferStatusType = { 'Failed' : null } |
   { 'Processing' : null } |
   { 'Created' : null } |
   { 'Completed' : null };
+/**
+ * Most ids under the station canister are in the UUID format (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+ */
 export type UUID = string;
+/**
+ * A record type that can be used to represent a user in the station.
+ */
 export interface User {
+  /**
+   * The UUID of the user (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
   'id' : UUID,
+  /**
+   * The status of the user (e.g. `Active`).
+   */
   'status' : UserStatus,
+  /**
+   * The list of groups the user belongs to.
+   * 
+   * Users can be tagged with groups that can be used to control access to resources.
+   */
   'groups' : Array<UserGroup>,
+  /**
+   * The user name (e.g. "John Doe").
+   */
   'name' : string,
+  /**
+   * The time at which the user was created or last modified (e.g. "2021-01-01T00:00:00Z").
+   */
   'last_modification_timestamp' : TimestampRFC3339,
+  /**
+   * The principals associated with the user.
+   */
   'identities' : Array<Principal>,
 }
-export interface UserCallerPrivileges { 'id' : UUID, 'can_edit' : boolean }
-export interface UserGroup { 'id' : UUID, 'name' : string }
-export interface UserGroupCallerPrivileges {
+/**
+ * A record type that can be used to represent the privileges of a caller for a given user.
+ */
+export interface UserCallerPrivileges {
+  /**
+   * The user id.
+   */
   'id' : UUID,
-  'can_delete' : boolean,
+  /**
+   * Whether or not the caller can edit the user.
+   */
   'can_edit' : boolean,
 }
-export interface UserIdentityInput { 'identity' : Principal }
+/**
+ * A record type that can be used to represent a user group in the station.
+ */
+export interface UserGroup {
+  /**
+   * The UUID of the group (e.g. "d0cf5b3f-7017-4cb8-9dcf-52619c42a7b0").
+   */
+  'id' : UUID,
+  /**
+   * The name of the group (e.g. "Finance").
+   */
+  'name' : string,
+}
+/**
+ * A record type that can be used to represent the privileges of a caller for a given user group.
+ */
+export interface UserGroupCallerPrivileges {
+  /**
+   * The user id.
+   */
+  'id' : UUID,
+  /**
+   * Whether or not the caller can delete the user group.
+   */
+  'can_delete' : boolean,
+  /**
+   * Whether or not the caller can edit the user group.
+   */
+  'can_edit' : boolean,
+}
+/**
+ * The input type for adding identities to a user.
+ */
+export interface UserIdentityInput {
+  /**
+   * The identity of the user.
+   */
+  'identity' : Principal,
+}
+/**
+ * The top level privileges that the user has when making calls to the canister.
+ */
 export type UserPrivilege = { 'AddUserGroup' : null } |
   { 'ListRequestPolicies' : null } |
   { 'ListNamedRules' : null } |
@@ -1591,111 +5630,278 @@ export type UserPrivilege = { 'AddUserGroup' : null } |
   { 'AddNamedRule' : null } |
   { 'Capabilities' : null } |
   { 'AddAccount' : null };
+/**
+ * The actions that are available for users.
+ */
 export type UserResourceAction = { 'List' : null } |
   { 'Read' : ResourceId } |
   { 'Create' : null } |
   { 'Update' : ResourceId };
+/**
+ * Defines a user in the context of a request.
+ */
 export type UserSpecifier = { 'Id' : Array<UUID> } |
   { 'Any' : null } |
   { 'Group' : Array<UUID> };
-export type UserStatus = { 'Inactive' : null } |
-  { 'Active' : null };
+export type UserStatus = {
+    /**
+     * The user is inactive.
+     */
+    'Inactive' : null
+  } |
+  {
+    /**
+     * The user is active.
+     */
+    'Active' : null
+  };
+/**
+ * The validation method targets of a `CallExternalCanister` request.
+ */
 export type ValidationMethodResourceTarget = { 'No' : null } |
   { 'ValidationMethod' : CanisterMethod };
 export interface WasmModuleExtraChunks {
+  /**
+   * The hash of the assembled wasm module.
+   */
   'wasm_module_hash' : Uint8Array | number[],
+  /**
+   * The asset canister from which the chunks are to be retrieved.
+   */
   'store_canister' : Principal,
+  /**
+   * The name of the asset containing extra chunks in the asset canister.
+   */
   'extra_chunks_key' : string,
 }
+/**
+ * The Station service definition.
+ */
 export interface _SERVICE {
+  /**
+   * Cancel a request if the request is in a cancelable state.
+   * 
+   * Cancelable conditions:
+   * 
+   * - The request is in the `Created` state.
+   * - The caller is the requester of the request.
+   */
   'cancel_request' : ActorMethod<[CancelRequestInput], CancelRequestResult>,
+  /**
+   * Get snapshots of a canister controlled by the station.
+   */
   'canister_snapshots' : ActorMethod<
     [CanisterSnapshotsInput],
     CanisterSnapshotsResult
   >,
+  /**
+   * Get canister status of a canister controlled by the station.
+   */
   'canister_status' : ActorMethod<
     [CanisterStatusInput],
     CanisterStatusResponse
   >,
+  /**
+   * This method exposes the supported assets and other capabilities of the canister.
+   * 
+   * By default can be accessed by any active user.
+   */
   'capabilities' : ActorMethod<[], CapabilitiesResult>,
+  /**
+   * Create a new request.
+   * 
+   * The request will be created and the caller will be added as the requester.
+   */
   'create_request' : ActorMethod<[CreateRequestInput], CreateRequestResult>,
+  /**
+   * Get the account balance.
+   * 
+   * If the caller does not have access to the account, an error will be returned.
+   */
   'fetch_account_balances' : ActorMethod<
     [FetchAccountBalancesInput],
     FetchAccountBalancesResult
   >,
+  /**
+   * Get a account by id.
+   * 
+   * If the caller does not have access to the account, an error will be returned.
+   */
   'get_account' : ActorMethod<[GetAccountInput], GetAccountResult>,
+  /**
+   * If the caller does not have access to the address book entry, an error will be returned.
+   */
   'get_address_book_entry' : ActorMethod<
     [GetAddressBookEntryInput],
     GetAddressBookEntryResult
   >,
+  /**
+   * Get an asset by id.
+   */
   'get_asset' : ActorMethod<[GetAssetInput], GetAssetResult>,
+  /**
+   * Get the external canister by its canister id.
+   */
   'get_external_canister' : ActorMethod<
     [GetExternalCanisterInput],
     GetExternalCanisterResult
   >,
+  /**
+   * Get the available filters for the external canisters.
+   */
   'get_external_canister_filters' : ActorMethod<
     [GetExternalCanisterFiltersInput],
     GetExternalCanisterFiltersResult
   >,
+  /**
+   * Get a named rule by id.
+   */
   'get_named_rule' : ActorMethod<[GetNamedRuleInput], GetNamedRuleResult>,
+  /**
+   * Finds the next aprovable request for the caller.
+   */
   'get_next_approvable_request' : ActorMethod<
     [GetNextApprovableRequestInput],
     GetNextApprovableRequestResult
   >,
+  /**
+   * Get the permission for the resource provided.
+   */
   'get_permission' : ActorMethod<[GetPermissionInput], GetPermissionResult>,
+  /**
+   * Get the request by id.
+   */
   'get_request' : ActorMethod<[GetRequestInput], GetRequestResult>,
+  /**
+   * Get request policy by id.
+   */
   'get_request_policy' : ActorMethod<
     [GetRequestPolicyInput],
     GetRequestPolicyResult
   >,
+  /**
+   * Get transfers by their ids.
+   */
   'get_transfers' : ActorMethod<[GetTransfersInput], GetTransfersResult>,
+  /**
+   * Get the user associated with the user id provided.
+   */
   'get_user' : ActorMethod<[GetUserInput], GetUserResult>,
+  /**
+   * Get a user group by id.
+   * 
+   * If the caller does not have access to the user group, an error will be returned.
+   */
   'get_user_group' : ActorMethod<[GetUserGroupInput], GetUserGroupResult>,
+  /**
+   * Check if the station is healthy and ready to be used.
+   */
   'health_status' : ActorMethod<[], HealthStatus>,
+  /**
+   * HTTP Protocol interface.
+   */
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  /**
+   * List all transfers from the requested account.
+   */
   'list_account_transfers' : ActorMethod<
     [ListAccountTransfersInput],
     ListAccountTransfersResult
   >,
+  /**
+   * List all accounts that the caller has access to.
+   * 
+   * If the caller is not the owner of any account, an error will be returned.
+   */
   'list_accounts' : ActorMethod<[ListAccountsInput], ListAccountsResult>,
+  /**
+   * List all address book entries for a given blockchain standard.
+   */
   'list_address_book_entries' : ActorMethod<
     [ListAddressBookEntriesInput],
     ListAddressBookEntriesResult
   >,
+  /**
+   * List all assets that the caller has access to.
+   */
   'list_assets' : ActorMethod<[ListAssetsInput], ListAssetsResult>,
+  /**
+   * List all external canisters that the caller has access to.
+   */
   'list_external_canisters' : ActorMethod<
     [ListExternalCanistersInput],
     ListExternalCanistersResult
   >,
+  /**
+   * List named rules that the caller has access to.
+   */
   'list_named_rules' : ActorMethod<[ListNamedRulesInput], ListNamedRulesResult>,
+  /**
+   * Get the list of notifications associated with the caller.
+   */
   'list_notifications' : ActorMethod<
     [ListNotificationsInput],
     ListNotificationsResult
   >,
+  /**
+   * List all permissions.
+   */
   'list_permissions' : ActorMethod<
     [ListPermissionsInput],
     ListPermissionsResult
   >,
+  /**
+   * List add request policies.
+   */
   'list_request_policies' : ActorMethod<
     [ListRequestPoliciesInput],
     ListRequestPoliciesResult
   >,
+  /**
+   * Get the list of requests.
+   * 
+   * Only requests that the caller has access to will be returned.
+   */
   'list_requests' : ActorMethod<[ListRequestsInput], ListRequestsResult>,
+  /**
+   * List all user groups of the station.
+   */
   'list_user_groups' : ActorMethod<[ListUserGroupsInput], ListUserGroupsResult>,
+  /**
+   * List all users of the station.
+   */
   'list_users' : ActorMethod<[ListUsersInput], ListUsersResult>,
+  /**
+   * Mark the notifications as read.
+   */
   'mark_notifications_read' : ActorMethod<
     [MarkNotificationsReadInput],
     MarkNotificationReadResult
   >,
+  /**
+   * Get the authenticated user and its privileges from the caller.
+   */
   'me' : ActorMethod<[], MeResult>,
+  /**
+   * Internal endpoint used by the upgrader canister to notify the station about a failed station upgrade request.
+   */
   'notify_failed_station_upgrade' : ActorMethod<
     [NotifyFailedStationUpgradeInput],
     NotifyFailedStationUpgradeResult
   >,
+  /**
+   * Submits the user approval decision for a request.
+   */
   'submit_request_approval' : ActorMethod<
     [SubmitRequestApprovalInput],
     SubmitRequestApprovalResult
   >,
+  /**
+   * Get the system information of the canister (e.g. version, cycles, etc.).
+   * 
+   * This method contains sensitive information and is up to the canister owner to
+   * decide who can access it (e.g. only admins).
+   */
   'system_info' : ActorMethod<[], SystemInfoResult>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/dfx.json
+++ b/dfx.json
@@ -1,20 +1,9 @@
 {
   "__ref_dfx": "dfx.json reference: https://internetcomputer.org/docs/current/references/dfx-json-reference/",
   "canisters": {
-    "cmc": {
-      "type": "custom",
-      "candid": "https://raw.githubusercontent.com/dfinity/ic/ee52ab3056cf5f39b09b08de70bdd20485c8b2dc/rs/nns/cmc/cmc.did",
-      "wasm": "https://download.dfinity.systems/ic/ee52ab3056cf5f39b09b08de70bdd20485c8b2dc/canisters/cycles-minting-canister.wasm.gz",
-      "remote": {
-        "id": {
-          "ic": "rkp4c-7iaaa-aaaaa-aaaca-cai"
-        }
-      }
-    },
     "icp_ledger": {
       "type": "custom",
       "candid": "https://raw.githubusercontent.com/dfinity/ic/d87954601e4b22972899e9957e800406a0a6b929/rs/rosetta-api/icp_ledger/ledger.did",
-      "wasm": "https://download.dfinity.systems/ic/d87954601e4b22972899e9957e800406a0a6b929/canisters/ledger-canister.wasm.gz",
       "remote": {
         "id": {
           "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -28,7 +17,6 @@
     "icp_index": {
       "type": "custom",
       "candid": "https://raw.githubusercontent.com/dfinity/ic/d87954601e4b22972899e9957e800406a0a6b929/rs/rosetta-api/icp_ledger/index/index.did",
-      "wasm": "https://download.dfinity.systems/ic/d87954601e4b22972899e9957e800406a0a6b929/canisters/ic-icp-index-canister.wasm.gz",
       "remote": {
         "id": {
           "ic": "qhbym-qaaaa-aaaaa-aaafq-cai"
@@ -42,7 +30,6 @@
     "internet_identity": {
       "type": "custom",
       "candid": "https://github.com/dfinity/internet-identity/releases/download/release-2025-08-29/internet_identity.did",
-      "wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2025-08-29/internet_identity_dev.wasm.gz",
       "remote": {
         "id": {
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
@@ -179,6 +166,6 @@
       }
     }
   },
-  "dfx": "0.25.0",
+  "dfx": "0.30.2",
   "version": 1
 }

--- a/dfx.json
+++ b/dfx.json
@@ -4,6 +4,7 @@
     "icp_ledger": {
       "type": "custom",
       "candid": "https://raw.githubusercontent.com/dfinity/ic/d87954601e4b22972899e9957e800406a0a6b929/rs/rosetta-api/icp_ledger/ledger.did",
+      "wasm": "https://download.dfinity.systems/ic/d87954601e4b22972899e9957e800406a0a6b929/canisters/ledger-canister.wasm.gz",
       "remote": {
         "id": {
           "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -17,6 +18,7 @@
     "icp_index": {
       "type": "custom",
       "candid": "https://raw.githubusercontent.com/dfinity/ic/d87954601e4b22972899e9957e800406a0a6b929/rs/rosetta-api/icp_ledger/index/index.did",
+      "wasm": "https://download.dfinity.systems/ic/d87954601e4b22972899e9957e800406a0a6b929/canisters/ic-icp-index-canister.wasm.gz",
       "remote": {
         "id": {
           "ic": "qhbym-qaaaa-aaaaa-aaafq-cai"
@@ -30,6 +32,7 @@
     "internet_identity": {
       "type": "custom",
       "candid": "https://github.com/dfinity/internet-identity/releases/download/release-2025-08-29/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2025-08-29/internet_identity_dev.wasm.gz",
       "remote": {
         "id": {
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"

--- a/docs/src/content/docs/developers/getting-started.md
+++ b/docs/src/content/docs/developers/getting-started.md
@@ -59,7 +59,7 @@ This script initializes the necessary settings for your environment.
 1. Start the Internet Computer replica in the background:
 
    ```bash
-   dfx start --clean --pocketic --host 127.0.0.1:4943
+   dfx start --clean --system-canisters --host 127.0.0.1:4943
    ```
 
 2. Deploy the canisters to the local replica:

--- a/orbit
+++ b/orbit
@@ -129,7 +129,7 @@ function setup_system_canisters_post() {
   II_WASM_URL="$(jq -r '.canisters.internet_identity.wasm' dfx.json)"
   curl -sL -o /tmp/internet_identity_dev.wasm.gz "$II_WASM_URL"
   dfx canister install rdmx6-jaaaa-aaaaa-aaadq-cai \
-    --mode upgrade --wasm /tmp/internet_identity_dev.wasm.gz --yes
+    --mode reinstall --wasm /tmp/internet_identity_dev.wasm.gz --yes
 }
 
 function uninstall_control_panel() {

--- a/orbit
+++ b/orbit
@@ -114,6 +114,22 @@ function setup_system_canisters_post() {
     who=null;
     subnets=vec {$SUBNET_IDS};
   })" --impersonate rrkah-fqaaa-aaaaa-aaaaq-cai
+
+  # Upgrade Internet Identity to the project's pinned version (defined in
+  # dfx.json) over the generic one bootstrapped by --system-canisters,
+  # so the e2e tests interact with the expected UI.
+  # The system II canister is controlled by the NNS root canister, so we
+  # impersonate it to take ownership, then install our version.
+  dfx canister call aaaaa-aa update_settings "(record {
+    canister_id = principal \"rdmx6-jaaaa-aaaaa-aaadq-cai\";
+    settings = record {
+      controllers = opt vec { principal \"$MY_PRINCIPAL\" };
+    };
+  })" --impersonate r7inp-6aaaa-aaaaa-aaabq-cai
+  II_WASM_URL="$(jq -r '.canisters.internet_identity.wasm' dfx.json)"
+  curl -sL -o /tmp/internet_identity_dev.wasm.gz "$II_WASM_URL"
+  dfx canister install rdmx6-jaaaa-aaaaa-aaadq-cai \
+    --mode upgrade --wasm /tmp/internet_identity_dev.wasm.gz --yes
 }
 
 function uninstall_control_panel() {

--- a/orbit
+++ b/orbit
@@ -100,7 +100,7 @@ function setup_system_canisters_post() {
   # Transfer ICP from anonymous to current user.
   # --system-canisters gives the anonymous identity 1 Billion ICP;
   # the current identity needs ICP for canister operations.
-  dfx ledger transfer --identity anonymous \
+  dfx ledger transfer --network local --identity anonymous \
     --amount 10000 \
     "$(dfx ledger account-id)" \
     --memo 0
@@ -108,19 +108,39 @@ function setup_system_canisters_post() {
   # Configure CMC authorized subnet list for canister creation.
   # The CMC only allows the governance canister to set authorized subnets,
   # so we use --impersonate to impersonate it (supported on PocketIC).
-  TOPO="$(curl -s http://localhost:4943/_/topology)"
-  SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
+  REPLICA_URL="$(get_replica_url)"
+  TOPOLOGY_URL="${REPLICA_URL%/}/_/topology"
+  TOPO=""
+  for _ in {1..10}; do
+    if TOPO="$(curl -fsS "$TOPOLOGY_URL" 2>/dev/null)"; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$TOPO" ]; then
+    echo "Failed to fetch topology from $TOPOLOGY_URL" >&2
+    return 1
+  fi
+
+  SUBNET_IDS="$(printf '%s' "$TOPO" | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
+
+  if [ -z "$SUBNET_IDS" ]; then
+    echo "No application subnet IDs found in topology from $TOPOLOGY_URL" >&2
+    return 1
+  fi
+
   dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {$SUBNET_IDS};
-  })" --impersonate rrkah-fqaaa-aaaaa-aaaaq-cai
+  })" --network local --impersonate rrkah-fqaaa-aaaaa-aaaaq-cai
 
   # Upgrade Internet Identity to the project's pinned version (defined in
   # dfx.json) over the generic one bootstrapped by --system-canisters,
   # so the e2e tests interact with the expected UI.
   # The system II canister is controlled by the NNS root canister, so we
   # impersonate it to take ownership, then install our version.
-  dfx canister call aaaaa-aa update_settings "(record {
+  dfx canister call --network local aaaaa-aa update_settings "(record {
     canister_id = principal \"rdmx6-jaaaa-aaaaa-aaadq-cai\";
     settings = record {
       controllers = opt vec { principal \"$MY_PRINCIPAL\" };
@@ -128,7 +148,7 @@ function setup_system_canisters_post() {
   })" --impersonate r7inp-6aaaa-aaaaa-aaabq-cai
   II_WASM_URL="$(jq -r '.canisters.internet_identity.wasm' dfx.json)"
   curl -sL -o /tmp/internet_identity_dev.wasm.gz "$II_WASM_URL"
-  dfx canister install rdmx6-jaaaa-aaaaa-aaadq-cai \
+  dfx canister install --network local rdmx6-jaaaa-aaaaa-aaadq-cai \
     --mode reinstall --wasm /tmp/internet_identity_dev.wasm.gz --yes
 }
 

--- a/orbit
+++ b/orbit
@@ -106,12 +106,14 @@ function setup_system_canisters_post() {
     --memo 0
 
   # Configure CMC authorized subnet list for canister creation.
+  # The CMC only allows the governance canister to set authorized subnets,
+  # so we use --sender to impersonate it (supported on PocketIC).
   TOPO="$(curl -s http://localhost:4943/_/topology)"
   SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
   dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {$SUBNET_IDS};
-  })"
+  })" --sender rrkah-fqaaa-aaaaa-aaaaq-cai
 }
 
 function uninstall_control_panel() {

--- a/orbit
+++ b/orbit
@@ -107,13 +107,13 @@ function setup_system_canisters_post() {
 
   # Configure CMC authorized subnet list for canister creation.
   # The CMC only allows the governance canister to set authorized subnets,
-  # so we use --sender to impersonate it (supported on PocketIC).
+  # so we use --impersonate to impersonate it (supported on PocketIC).
   TOPO="$(curl -s http://localhost:4943/_/topology)"
   SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
   dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {$SUBNET_IDS};
-  })" --sender rrkah-fqaaa-aaaaa-aaaaq-cai
+  })" --impersonate rrkah-fqaaa-aaaaa-aaaaq-cai
 }
 
 function uninstall_control_panel() {

--- a/orbit
+++ b/orbit
@@ -11,11 +11,7 @@ export NVM_DIR="$HOME/.nvm"
 MINTER_IDENTITY_NAME="minter"
 WHOAMI=$(dfx identity whoami)
 MY_PRINCIPAL=$(dfx identity get-principal)
-CANISTER_ID_CMC="rkp4c-7iaaa-aaaaa-aaaca-cai"
 CANISTER_ID_CONTROL_PANEL="wdqqk-naaaa-aaaaa-774aq-cai"
-CANISTER_ID_ICP_INDEX="qhbym-qaaaa-aaaaa-aaafq-cai"
-CANISTER_ID_ICP_LEDGER="ryjl3-tyaaa-aaaaa-aaaba-cai"
-CANISTER_ID_INTERNET_IDENTITY="rdmx6-jaaaa-aaaaa-aaadq-cai"
 CANISTER_ID_UI="werw6-ayaaa-aaaaa-774aa-cai"
 CANISTER_ID_WALLET="wkt3w-3iaaa-aaaaa-774ba-cai"
 CANISTER_ID_DOCS="bp6mw-eqaaa-aaaac-ahroq-cai"
@@ -50,11 +46,8 @@ Usage:
 
 Options:
   --init configures all the dependencies for the development environment
+         (requires 'dfx start --system-canisters' to have been run first)
   --init-control-panel fresh installs the control panel canister
-  --init-cmc fresh installs the cycles minting canister and sets the default subnets for canister deployment
-  --init-icp-index fresh installs the icp index canister, used to query the ledger transactions
-  --init-icp-ledger fresh installs the icp ledger canister, the current identity will be credited with ICP tokens
-  --init-internet-identity fresh installs the internet identity canister
   --init-app-wallet fresh installs the Orbit Wallet application
   --candid-generate generates the code for the candid specifications that the Orbit applications are using
   --approve-waiting-list approves the given principal to the waiting list
@@ -99,112 +92,26 @@ function build_wasm() {
 # SETUP                                     #
 #############################################
 
-function uninstall_cmc() {
-  dfx canister stop cmc >/dev/null 2>&1 || true
-  dfx canister delete cmc --no-withdrawal -y >/dev/null 2>&1 || true
-}
+# Post-bootstrap setup for system canisters.
+# Requires 'dfx start --system-canisters' to have been run first, which
+# bootstraps the ICP ledger, ICP index, CMC, and Internet Identity at
+# their well-known canister IDs.
+function setup_system_canisters_post() {
+  # Transfer ICP from anonymous to current user.
+  # --system-canisters gives the anonymous identity 1 Billion ICP;
+  # the current identity needs ICP for canister operations.
+  dfx ledger transfer --identity anonymous \
+    --amount 10000 \
+    "$(dfx ledger account-id)" \
+    --memo 0
 
-# sets the user principal as the governance canister
-# so that the user principal can make privileged calls on CMC
-function install_cmc() {
-  dfx deploy --specified-id $CANISTER_ID_CMC cmc --argument "
-  (opt record {
-    ledger_canister_id=opt principal\"$CANISTER_ID_ICP_LEDGER\";
-    governance_canister_id=opt principal\"$MY_PRINCIPAL\";
-  })
-"
-}
-
-function textual_encode() {
-  ( echo "$1" | xxd -r -p | crc32 /dev/stdin; echo -n "$1" ) |
-  xxd -r -p | base32 | tr A-Z a-z |
-  tr -d = | fold -w5 | paste -sd'-' -
-}
-
-function setup_cmc() {
-  uninstall_cmc
-  install_cmc
-  TOPO="$(curl http://localhost:4943/_/topology 2>/dev/null)"
-  if [[ "$?" != "0" || "$TOPO" == "Endpoint not found." ]]
-  then
-    SUBNET_ID_HEX="$(curl http://localhost:4943/api/v2/status 2>/dev/null | python3 -c "import cbor2; import hashlib; import sys; status=cbor2.loads(sys.stdin.buffer.read()); hash=hashlib.sha224(status['root_key']).digest(); principal=hash+b'\x02'; print(principal.hex())")"
-    SUBNET_IDS="principal\"$(textual_encode $SUBNET_ID_HEX)\";"
-  else
-    SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
-  fi
-  dfx canister call cmc set_authorized_subnetwork_list "(record {
+  # Configure CMC authorized subnet list for canister creation.
+  TOPO="$(curl -s http://localhost:4943/_/topology)"
+  SUBNET_IDS="$(echo $TOPO | jq -r '.subnet_configs | to_entries | map(select(.value.subnet_kind == "Application"))[] | .key' | sed "s/\(.*\)/principal\\\"\1\\\";/")"
+  dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai set_authorized_subnetwork_list "(record {
     who=null;
     subnets=vec {$SUBNET_IDS};
-  })
-"
-}
-
-function uninstall_icp_ledger() {
-  dfx canister delete icp_ledger -y >/dev/null 2>&1 || true
-}
-
-function install_icp_ledger() {
-  if [ "$MINTER_IDENTITY_NAME" == "$WHOAMI" ]; then
-    echo "You can't run this script as the minter identity. Please run it as a different identity."
-    exit 1
-  fi
-
-  if ! dfx identity list | grep -q $MINTER_IDENTITY_NAME; then
-    dfx identity new $MINTER_IDENTITY_NAME --storage-mode plaintext
-  fi
-
-  dfx deploy --specified-id $CANISTER_ID_ICP_LEDGER icp_ledger --argument "
-  (variant {
-    Init = record {
-      minting_account = \"$(dfx ledger account-id --identity $MINTER_IDENTITY_NAME)\";
-      initial_values = vec {
-        record {
-          \"$(dfx ledger account-id)\";
-          record {
-            e8s = 1_000_000_000_000 : nat64;
-          };
-        };
-      };
-      send_whitelist = vec {};
-      transfer_fee = opt record {
-        e8s = 10_000 : nat64;
-      };
-      token_symbol = opt \"ICP\";
-      token_name = opt \"Internet Computer\";
-    }
-  })
-"
-}
-
-function setup_icp_ledger() {
-  uninstall_icp_ledger
-  install_icp_ledger
-}
-
-function uninstall_icp_index() {
-  dfx canister delete icp_index -y >/dev/null 2>&1 || true
-}
-
-function install_icp_index() {
-  dfx deploy icp_index --specified-id $CANISTER_ID_ICP_INDEX --argument "(record {ledger_id = principal \"$CANISTER_ID_ICP_LEDGER\"})"
-}
-
-function setup_icp_index() {
-  uninstall_icp_index
-  install_icp_index
-}
-
-function uninstall_internet_identity() {
-  dfx canister delete internet_identity -y >/dev/null 2>&1 || true
-}
-
-function install_internet_identity() {
-  dfx deploy --specified-id $CANISTER_ID_INTERNET_IDENTITY internet_identity
-}
-
-function setup_internet_identity() {
-  uninstall_internet_identity
-  install_internet_identity
+  })"
 }
 
 function uninstall_control_panel() {
@@ -423,31 +330,10 @@ while [[ $# -gt 0 ]]; do
   --init)
     shift
     exec_function setup_devenv
-    exec_function setup_cmc
-    exec_function setup_icp_ledger
-    exec_function setup_icp_index
-    exec_function setup_internet_identity
+    exec_function setup_system_canisters_post
     exec_function setup_control_panel
     exec_function setup_app_wallet
     exec_function setup_docs_portal
-    echo
-    ;;
-  --init-cmc)
-    shift
-    exec_function setup_devenv
-    exec_function setup_cmc
-    echo
-    ;;
-  --init-icp-ledger)
-    shift
-    exec_function setup_devenv
-    exec_function setup_icp_ledger
-    echo
-    ;;
-  --init-icp-index)
-    shift
-    exec_function setup_devenv
-    exec_function setup_icp_index
     echo
     ;;
   --init-control-panel)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type-check": "pnpm run -r type-check",
     "postinstall": "pnpm run -r postinstall && pnpm run prepare-cli",
     "prepare-cli": "pnpm run --filter orbit-cli build && pnpm run --filter orbit-cli expose",
-    "test:e2e:deploy": "dfx start --background --clean  && ./orbit --init",
+    "test:e2e:deploy": "dfx start --background --clean --system-canisters && ./orbit --init",
     "test:e2e:run": "WALLET_URL=http://werw6-ayaaa-aaaaa-774aa-cai.localhost:`dfx info webserver-port` playwright test",
     "test:e2e:dev": "concurrently \"pnpm run dev:wallet\" \"WALLET_URL=http://localhost:5173?canisterId=werw6-ayaaa-aaaaa-774aa-cai playwright test --ui\"",
     "test:e2e:stop": "dfx stop",

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -101,7 +101,7 @@ function install_icx_asset() {
   if ! command -v icx-asset >/dev/null 2>&1; then
     echo "icx-asset not found, installing..."
 
-    cargo install --locked icx-asset --version 0.21.0
+    cargo install --locked icx-asset --version 0.29.0
 
     echo "icx-asset installed successfully."
 


### PR DESCRIPTION
## Summary

- Replace manual installation of system canisters (ICP ledger, ICP index, CMC, Internet Identity) with \`dfx start --system-canisters\`, which bootstraps them automatically via PocketIC
- Bump dfx from 0.25.0 to 0.30.2
- Remove ~110 lines of install/uninstall/setup functions from \`orbit\` script; add \`setup_system_canisters_post()\` that transfers ICP, configures CMC's authorized subnet list, and reinstalls the project's pinned Internet Identity version over the system-bootstrapped one so the e2e tests get the expected registration UI
- Upgrade icx-asset from 0.21.0 to 0.29.0 for compatibility with dfx 0.30.2's asset canister batch API
- Remove Python/cbor2/crc32 CI dependencies that were only needed for native replica CBOR parsing

## Test plan

- [x] CI \`deployment-test\` passes (PocketIC + \`--system-canisters\`)
- [x] CI \`deployment-test-replica\` passes (was native replica, now also PocketIC since dfx 0.27.0 removed the native replica)
- [x] CI \`prod-deployment-test\` passes
- [x] CI \`e2e-tests\` passes
- [x] Integration tests unaffected (separate PocketIC setup via \`with_icp_features\`)
- [x] Verify \`dfx ledger transfer --identity anonymous\` successfully credits ICP to current user

🤖 Generated with [Claude Code](https://claude.com/claude-code)