### PR TITLE
feat(station): support wasm_memory_persistence for external canister upgrades

### DIFF
--- a/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
@@ -130,7 +130,7 @@ const dialogTitle = computed(() => props.title || i18n.t('external_canisters.ins
 
 const initialModel = (): CanisterInstallModel => {
   const model: CanisterInstallModel = {};
-  model.mode = props.canisterModuleHash ? { upgrade: null } : { install: null };
+  model.mode = props.canisterModuleHash ? { upgrade: [] } : { install: null };
   model.canisterId = props.canisterId
     ? Principal.fromUint8Array(props.canisterId.toUint8Array())
     : undefined;
@@ -165,8 +165,6 @@ const submit = async (input: CanisterInstallModel) => {
         module: assertAndReturn(input.wasmModule, 'wasm module required'),
         arg: input.wasmInstallArg !== undefined ? [input.wasmInstallArg] : [],
         module_extra_chunks: [],
-        wasm_memory_persistence: [],
-        skip_pre_upgrade: [],
       },
       {
         comment:

--- a/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
+++ b/apps/wallet/src/components/external-canisters/CanisterInstallDialog.vue
@@ -165,6 +165,8 @@ const submit = async (input: CanisterInstallModel) => {
         module: assertAndReturn(input.wasmModule, 'wasm module required'),
         arg: input.wasmInstallArg !== undefined ? [input.wasmInstallArg] : [],
         module_extra_chunks: [],
+        wasm_memory_persistence: [],
+        skip_pre_upgrade: [],
       },
       {
         comment:

--- a/apps/wallet/src/components/inputs/CanisterInstallModeSelect.vue
+++ b/apps/wallet/src/components/inputs/CanisterInstallModeSelect.vue
@@ -58,6 +58,6 @@ const modes = computed<
 >(() => [
   { title: i18n.t('external_canisters.install_mode.install'), value: { install: null } },
   { title: i18n.t('external_canisters.install_mode.reinstall'), value: { reinstall: null } },
-  { title: i18n.t('external_canisters.install_mode.upgrade'), value: { upgrade: null } },
+  { title: i18n.t('external_canisters.install_mode.upgrade'), value: { upgrade: [] } },
 ]);
 </script>

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -575,28 +575,18 @@ type RemoveUserGroupOperation = record {
 type CanisterInstallMode = variant {
   install;
   reinstall;
-  // Upgrade an existing canister. Carries optional flags that mirror the
-  // IC management canister's `CanisterUpgradeOptions`.
-  upgrade : opt CanisterUpgradeOptionsInput;
-};
-
-// Optional upgrade flags forwarded to the IC management canister's
-// `install_code` method when `mode` is `upgrade`.
-type CanisterUpgradeOptionsInput = record {
-  // Required as `keep` for upgrading Motoko canisters that use Enhanced
-  // Orthogonal Persistence; otherwise the IC clears their main memory.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
-  skip_pre_upgrade : opt bool;
-};
-
-// WASM memory persistence setting passed to `install_code` when the install
-// mode is `upgrade`. `keep` is required for Motoko canisters that use
-// Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
-// main memory) otherwise.
-type WasmMemoryPersistence = variant {
-  keep;
-  replace;
+  // Upgrade an existing canister. The optional record mirrors the IC
+  // management canister's `CanisterUpgradeOptions`.
+  // `wasm_memory_persistence = keep` is required for Motoko canisters that
+  // use Enhanced Orthogonal Persistence; otherwise the IC clears their main
+  // memory.
+  upgrade : opt record {
+    skip_pre_upgrade : opt bool;
+    wasm_memory_persistence : opt variant {
+      keep;
+      replace;
+    };
+  };
 };
 
 type SystemUpgradeTarget = variant {

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -575,7 +575,19 @@ type RemoveUserGroupOperation = record {
 type CanisterInstallMode = variant {
   install;
   reinstall;
-  upgrade;
+  // Upgrade an existing canister. Carries optional flags that mirror the
+  // IC management canister's `CanisterUpgradeOptions`.
+  upgrade : opt CanisterUpgradeOptionsInput;
+};
+
+// Optional upgrade flags forwarded to the IC management canister's
+// `install_code` method when `mode` is `upgrade`.
+type CanisterUpgradeOptionsInput = record {
+  // Required as `keep` for upgrading Motoko canisters that use Enhanced
+  // Orthogonal Persistence; otherwise the IC clears their main memory.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
+  skip_pre_upgrade : opt bool;
 };
 
 // WASM memory persistence setting passed to `install_code` when the install
@@ -675,13 +687,6 @@ type ChangeExternalCanisterOperationInput = record {
   module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
-  // WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
-  // Required as `keep` for upgrading Motoko canisters that use Enhanced
-  // Orthogonal Persistence; otherwise the IC clears their main memory.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
-  // is `upgrade`.
-  skip_pre_upgrade : opt bool;
 };
 
 type ChangeExternalCanisterOperation = record {
@@ -693,12 +698,6 @@ type ChangeExternalCanisterOperation = record {
   module_checksum : Sha256Hash;
   // The checksum of the arg blob.
   arg_checksum : opt Sha256Hash;
-  // WASM memory persistence setting recorded for this upgrade, if any.
-  // Only meaningful when `mode` is `upgrade`.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
-  // is `upgrade`.
-  skip_pre_upgrade : opt bool;
 };
 
 type SubnetFilter = record {

--- a/apps/wallet/src/generated/station/station.did
+++ b/apps/wallet/src/generated/station/station.did
@@ -578,6 +578,15 @@ type CanisterInstallMode = variant {
   upgrade;
 };
 
+// WASM memory persistence setting passed to `install_code` when the install
+// mode is `upgrade`. `keep` is required for Motoko canisters that use
+// Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
+// main memory) otherwise.
+type WasmMemoryPersistence = variant {
+  keep;
+  replace;
+};
+
 type SystemUpgradeTarget = variant {
   UpgradeStation;
   UpgradeUpgrader;
@@ -666,6 +675,13 @@ type ChangeExternalCanisterOperationInput = record {
   module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
+  // WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
+  // Required as `keep` for upgrading Motoko canisters that use Enhanced
+  // Orthogonal Persistence; otherwise the IC clears their main memory.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
+  // is `upgrade`.
+  skip_pre_upgrade : opt bool;
 };
 
 type ChangeExternalCanisterOperation = record {
@@ -677,6 +693,12 @@ type ChangeExternalCanisterOperation = record {
   module_checksum : Sha256Hash;
   // The checksum of the arg blob.
   arg_checksum : opt Sha256Hash;
+  // WASM memory persistence setting recorded for this upgrade, if any.
+  // Only meaningful when `mode` is `upgrade`.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
+  // is `upgrade`.
+  skip_pre_upgrade : opt bool;
 };
 
 type SubnetFilter = record {

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -681,6 +681,14 @@ export interface CanisterExecutionAndValidationMethodPair {
 export type CanisterInstallMode = { 'reinstall' : null } |
   { 'upgrade' : null } |
   { 'install' : null };
+/**
+ * WASM memory persistence setting passed to `install_code` when the install
+ * mode is `upgrade`. `keep` is required for Motoko canisters that use
+ * Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
+ * main memory) otherwise.
+ */
+export type WasmMemoryPersistence = { 'keep' : null } |
+  { 'replace' : null };
 export interface CanisterMethod {
   /**
    * The canister to call.
@@ -836,6 +844,16 @@ export interface ChangeExternalCanisterOperation {
    * The checksum of the arg blob.
    */
   'arg_checksum' : [] | [Sha256Hash],
+  /**
+   * WASM memory persistence setting recorded for this upgrade, if any.
+   * Only meaningful when `mode` is `upgrade`.
+   */
+  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
+  /**
+   * Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
+   * is `upgrade`.
+   */
+  'skip_pre_upgrade' : [] | [boolean],
 }
 export interface ChangeExternalCanisterOperationInput {
   /**
@@ -858,6 +876,18 @@ export interface ChangeExternalCanisterOperationInput {
    * The wasm module to install.
    */
   'module' : Uint8Array | number[],
+  /**
+   * WASM memory persistence setting. Only applicable when `mode` is
+   * `upgrade`. Required as `keep` for upgrading Motoko canisters that use
+   * Enhanced Orthogonal Persistence; otherwise the IC clears their main
+   * memory.
+   */
+  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
+  /**
+   * If `true`, the `pre_upgrade` hook is skipped. Only applicable when
+   * `mode` is `upgrade`.
+   */
+  'skip_pre_upgrade' : [] | [boolean],
 }
 /**
  * Type for instructions to update the address book entry's metadata.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -679,7 +679,13 @@ export interface CanisterExecutionAndValidationMethodPair {
   'validation_method' : ValidationMethodResourceTarget,
 }
 export type CanisterInstallMode = { 'reinstall' : null } |
-  { 'upgrade' : null } |
+  {
+    /**
+     * Upgrade an existing canister. Carries optional flags that mirror the
+     * IC management canister's `CanisterUpgradeOptions`.
+     */
+    'upgrade' : [] | [CanisterUpgradeOptionsInput]
+  } |
   { 'install' : null };
 export interface CanisterMethod {
   /**
@@ -718,6 +724,21 @@ export interface CanisterStatusResponse {
   'idle_cycles_burned_per_day' : bigint,
   'module_hash' : [] | [Uint8Array | number[]],
   'reserved_cycles' : bigint,
+}
+/**
+ * Optional upgrade flags forwarded to the IC management canister's
+ * `install_code` method when `mode` is `upgrade`.
+ */
+export interface CanisterUpgradeOptionsInput {
+  /**
+   * Required as `keep` for upgrading Motoko canisters that use Enhanced
+   * Orthogonal Persistence; otherwise the IC clears their main memory.
+   */
+  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
+  /**
+   * If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
+   */
+  'skip_pre_upgrade' : [] | [boolean],
 }
 /**
  * A record type that is used to show the current capabilities of the station.
@@ -821,11 +842,6 @@ export type ChangeExternalCanisterMetadata = {
   };
 export interface ChangeExternalCanisterOperation {
   /**
-   * WASM memory persistence setting recorded for this upgrade, if any.
-   * Only meaningful when `mode` is `upgrade`.
-   */
-  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
-  /**
    * The canister installation mode.
    */
   'mode' : CanisterInstallMode,
@@ -837,11 +853,6 @@ export interface ChangeExternalCanisterOperation {
    * The checksum of the wasm module.
    */
   'module_checksum' : Sha256Hash,
-  /**
-   * Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
-   * is `upgrade`.
-   */
-  'skip_pre_upgrade' : [] | [boolean],
   /**
    * The checksum of the arg blob.
    */
@@ -857,12 +868,6 @@ export interface ChangeExternalCanisterOperationInput {
    */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
   /**
-   * WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
-   * Required as `keep` for upgrading Motoko canisters that use Enhanced
-   * Orthogonal Persistence; otherwise the IC clears their main memory.
-   */
-  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
-  /**
    * The canister installation mode.
    */
   'mode' : CanisterInstallMode,
@@ -870,11 +875,6 @@ export interface ChangeExternalCanisterOperationInput {
    * The canister to install.
    */
   'canister_id' : Principal,
-  /**
-   * If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
-   * is `upgrade`.
-   */
-  'skip_pre_upgrade' : [] | [boolean],
   /**
    * The wasm module to install.
    */

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -681,10 +681,21 @@ export interface CanisterExecutionAndValidationMethodPair {
 export type CanisterInstallMode = { 'reinstall' : null } |
   {
     /**
-     * Upgrade an existing canister. Carries optional flags that mirror the
-     * IC management canister's `CanisterUpgradeOptions`.
+     * Upgrade an existing canister. The optional record mirrors the IC
+     * management canister's `CanisterUpgradeOptions`.
+     * `wasm_memory_persistence = keep` is required for Motoko canisters that
+     * use Enhanced Orthogonal Persistence; otherwise the IC clears their main
+     * memory.
      */
-    'upgrade' : [] | [CanisterUpgradeOptionsInput]
+    'upgrade' : [] | [
+      {
+        'wasm_memory_persistence' : [] | [
+          { 'keep' : null } |
+            { 'replace' : null }
+        ],
+        'skip_pre_upgrade' : [] | [boolean],
+      }
+    ]
   } |
   { 'install' : null };
 export interface CanisterMethod {
@@ -724,21 +735,6 @@ export interface CanisterStatusResponse {
   'idle_cycles_burned_per_day' : bigint,
   'module_hash' : [] | [Uint8Array | number[]],
   'reserved_cycles' : bigint,
-}
-/**
- * Optional upgrade flags forwarded to the IC management canister's
- * `install_code` method when `mode` is `upgrade`.
- */
-export interface CanisterUpgradeOptionsInput {
-  /**
-   * Required as `keep` for upgrading Motoko canisters that use Enhanced
-   * Orthogonal Persistence; otherwise the IC clears their main memory.
-   */
-  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
-  /**
-   * If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
-   */
-  'skip_pre_upgrade' : [] | [boolean],
 }
 /**
  * A record type that is used to show the current capabilities of the station.
@@ -5681,14 +5677,6 @@ export type UserStatus = {
  */
 export type ValidationMethodResourceTarget = { 'No' : null } |
   { 'ValidationMethod' : CanisterMethod };
-/**
- * WASM memory persistence setting passed to `install_code` when the install
- * mode is `upgrade`. `keep` is required for Motoko canisters that use
- * Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
- * main memory) otherwise.
- */
-export type WasmMemoryPersistence = { 'keep' : null } |
-  { 'replace' : null };
 export interface WasmModuleExtraChunks {
   /**
    * The hash of the assembled wasm module.

--- a/apps/wallet/src/generated/station/station.did.d.ts
+++ b/apps/wallet/src/generated/station/station.did.d.ts
@@ -681,14 +681,6 @@ export interface CanisterExecutionAndValidationMethodPair {
 export type CanisterInstallMode = { 'reinstall' : null } |
   { 'upgrade' : null } |
   { 'install' : null };
-/**
- * WASM memory persistence setting passed to `install_code` when the install
- * mode is `upgrade`. `keep` is required for Motoko canisters that use
- * Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
- * main memory) otherwise.
- */
-export type WasmMemoryPersistence = { 'keep' : null } |
-  { 'replace' : null };
 export interface CanisterMethod {
   /**
    * The canister to call.
@@ -829,6 +821,11 @@ export type ChangeExternalCanisterMetadata = {
   };
 export interface ChangeExternalCanisterOperation {
   /**
+   * WASM memory persistence setting recorded for this upgrade, if any.
+   * Only meaningful when `mode` is `upgrade`.
+   */
+  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
+  /**
    * The canister installation mode.
    */
   'mode' : CanisterInstallMode,
@@ -841,19 +838,14 @@ export interface ChangeExternalCanisterOperation {
    */
   'module_checksum' : Sha256Hash,
   /**
-   * The checksum of the arg blob.
-   */
-  'arg_checksum' : [] | [Sha256Hash],
-  /**
-   * WASM memory persistence setting recorded for this upgrade, if any.
-   * Only meaningful when `mode` is `upgrade`.
-   */
-  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
-  /**
    * Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
    * is `upgrade`.
    */
   'skip_pre_upgrade' : [] | [boolean],
+  /**
+   * The checksum of the arg blob.
+   */
+  'arg_checksum' : [] | [Sha256Hash],
 }
 export interface ChangeExternalCanisterOperationInput {
   /**
@@ -865,6 +857,12 @@ export interface ChangeExternalCanisterOperationInput {
    */
   'module_extra_chunks' : [] | [WasmModuleExtraChunks],
   /**
+   * WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
+   * Required as `keep` for upgrading Motoko canisters that use Enhanced
+   * Orthogonal Persistence; otherwise the IC clears their main memory.
+   */
+  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
+  /**
    * The canister installation mode.
    */
   'mode' : CanisterInstallMode,
@@ -873,21 +871,14 @@ export interface ChangeExternalCanisterOperationInput {
    */
   'canister_id' : Principal,
   /**
+   * If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
+   * is `upgrade`.
+   */
+  'skip_pre_upgrade' : [] | [boolean],
+  /**
    * The wasm module to install.
    */
   'module' : Uint8Array | number[],
-  /**
-   * WASM memory persistence setting. Only applicable when `mode` is
-   * `upgrade`. Required as `keep` for upgrading Motoko canisters that use
-   * Enhanced Orthogonal Persistence; otherwise the IC clears their main
-   * memory.
-   */
-  'wasm_memory_persistence' : [] | [WasmMemoryPersistence],
-  /**
-   * If `true`, the `pre_upgrade` hook is skipped. Only applicable when
-   * `mode` is `upgrade`.
-   */
-  'skip_pre_upgrade' : [] | [boolean],
 }
 /**
  * Type for instructions to update the address book entry's metadata.
@@ -5690,6 +5681,14 @@ export type UserStatus = {
  */
 export type ValidationMethodResourceTarget = { 'No' : null } |
   { 'ValidationMethod' : CanisterMethod };
+/**
+ * WASM memory persistence setting passed to `install_code` when the install
+ * mode is `upgrade`. `keep` is required for Motoko canisters that use
+ * Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
+ * main memory) otherwise.
+ */
+export type WasmMemoryPersistence = { 'keep' : null } |
+  { 'replace' : null };
 export interface WasmModuleExtraChunks {
   /**
    * The hash of the assembled wasm module.

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -453,18 +453,20 @@ export const idlFactory = ({ IDL }) => {
     'keep' : IDL.Null,
     'replace' : IDL.Null,
   });
+  const CanisterUpgradeOptionsInput = IDL.Record({
+    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
+    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
+  });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,
-    'upgrade' : IDL.Null,
+    'upgrade' : IDL.Opt(CanisterUpgradeOptionsInput),
     'install' : IDL.Null,
   });
   const Sha256Hash = IDL.Text;
   const ChangeExternalCanisterOperation = IDL.Record({
-    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'module_checksum' : Sha256Hash,
-    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
     'arg_checksum' : IDL.Opt(Sha256Hash),
   });
   const CycleObtainStrategyInput = IDL.Variant({
@@ -978,10 +980,8 @@ export const idlFactory = ({ IDL }) => {
   const ChangeExternalCanisterOperationInput = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'module_extra_chunks' : IDL.Opt(WasmModuleExtraChunks),
-    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
-    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
     'module' : IDL.Vec(IDL.Nat8),
   });
   const SetDisasterRecoveryOperationInput = IDL.Record({

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -449,17 +449,16 @@ export const idlFactory = ({ IDL }) => {
     'canister_id' : IDL.Principal,
   });
   const ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
-  const WasmMemoryPersistence = IDL.Variant({
-    'keep' : IDL.Null,
-    'replace' : IDL.Null,
-  });
-  const CanisterUpgradeOptionsInput = IDL.Record({
-    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
-    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
-  });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,
-    'upgrade' : IDL.Opt(CanisterUpgradeOptionsInput),
+    'upgrade' : IDL.Opt(
+      IDL.Record({
+        'wasm_memory_persistence' : IDL.Opt(
+          IDL.Variant({ 'keep' : IDL.Null, 'replace' : IDL.Null })
+        ),
+        'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
+      })
+    ),
     'install' : IDL.Null,
   });
   const Sha256Hash = IDL.Text;

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -454,12 +454,18 @@ export const idlFactory = ({ IDL }) => {
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
+  const WasmMemoryPersistence = IDL.Variant({
+    'keep' : IDL.Null,
+    'replace' : IDL.Null,
+  });
   const Sha256Hash = IDL.Text;
   const ChangeExternalCanisterOperation = IDL.Record({
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'module_checksum' : Sha256Hash,
     'arg_checksum' : IDL.Opt(Sha256Hash),
+    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
+    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
   });
   const CycleObtainStrategyInput = IDL.Variant({
     'Disabled' : IDL.Null,
@@ -975,6 +981,8 @@ export const idlFactory = ({ IDL }) => {
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'module' : IDL.Vec(IDL.Nat8),
+    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
+    'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
   });
   const SetDisasterRecoveryOperationInput = IDL.Record({
     'committee' : IDL.Opt(DisasterRecoveryCommittee),

--- a/apps/wallet/src/generated/station/station.did.js
+++ b/apps/wallet/src/generated/station/station.did.js
@@ -449,23 +449,23 @@ export const idlFactory = ({ IDL }) => {
     'canister_id' : IDL.Principal,
   });
   const ConfigureExternalCanisterOperation = ConfigureExternalCanisterOperationInput;
+  const WasmMemoryPersistence = IDL.Variant({
+    'keep' : IDL.Null,
+    'replace' : IDL.Null,
+  });
   const CanisterInstallMode = IDL.Variant({
     'reinstall' : IDL.Null,
     'upgrade' : IDL.Null,
     'install' : IDL.Null,
   });
-  const WasmMemoryPersistence = IDL.Variant({
-    'keep' : IDL.Null,
-    'replace' : IDL.Null,
-  });
   const Sha256Hash = IDL.Text;
   const ChangeExternalCanisterOperation = IDL.Record({
+    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
     'module_checksum' : Sha256Hash,
-    'arg_checksum' : IDL.Opt(Sha256Hash),
-    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
+    'arg_checksum' : IDL.Opt(Sha256Hash),
   });
   const CycleObtainStrategyInput = IDL.Variant({
     'Disabled' : IDL.Null,
@@ -978,11 +978,11 @@ export const idlFactory = ({ IDL }) => {
   const ChangeExternalCanisterOperationInput = IDL.Record({
     'arg' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'module_extra_chunks' : IDL.Opt(WasmModuleExtraChunks),
+    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'mode' : CanisterInstallMode,
     'canister_id' : IDL.Principal,
-    'module' : IDL.Vec(IDL.Nat8),
-    'wasm_memory_persistence' : IDL.Opt(WasmMemoryPersistence),
     'skip_pre_upgrade' : IDL.Opt(IDL.Bool),
+    'module' : IDL.Vec(IDL.Nat8),
   });
   const SetDisasterRecoveryOperationInput = IDL.Record({
     'committee' : IDL.Opt(DisasterRecoveryCommittee),

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -575,28 +575,18 @@ type RemoveUserGroupOperation = record {
 type CanisterInstallMode = variant {
   install;
   reinstall;
-  // Upgrade an existing canister. Carries optional flags that mirror the
-  // IC management canister's `CanisterUpgradeOptions`.
-  upgrade : opt CanisterUpgradeOptionsInput;
-};
-
-// Optional upgrade flags forwarded to the IC management canister's
-// `install_code` method when `mode` is `upgrade`.
-type CanisterUpgradeOptionsInput = record {
-  // Required as `keep` for upgrading Motoko canisters that use Enhanced
-  // Orthogonal Persistence; otherwise the IC clears their main memory.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
-  skip_pre_upgrade : opt bool;
-};
-
-// WASM memory persistence setting passed to `install_code` when the install
-// mode is `upgrade`. `keep` is required for Motoko canisters that use
-// Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
-// main memory) otherwise.
-type WasmMemoryPersistence = variant {
-  keep;
-  replace;
+  // Upgrade an existing canister. The optional record mirrors the IC
+  // management canister's `CanisterUpgradeOptions`.
+  // `wasm_memory_persistence = keep` is required for Motoko canisters that
+  // use Enhanced Orthogonal Persistence; otherwise the IC clears their main
+  // memory.
+  upgrade : opt record {
+    skip_pre_upgrade : opt bool;
+    wasm_memory_persistence : opt variant {
+      keep;
+      replace;
+    };
+  };
 };
 
 type SystemUpgradeTarget = variant {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -575,7 +575,19 @@ type RemoveUserGroupOperation = record {
 type CanisterInstallMode = variant {
   install;
   reinstall;
-  upgrade;
+  // Upgrade an existing canister. Carries optional flags that mirror the
+  // IC management canister's `CanisterUpgradeOptions`.
+  upgrade : opt CanisterUpgradeOptionsInput;
+};
+
+// Optional upgrade flags forwarded to the IC management canister's
+// `install_code` method when `mode` is `upgrade`.
+type CanisterUpgradeOptionsInput = record {
+  // Required as `keep` for upgrading Motoko canisters that use Enhanced
+  // Orthogonal Persistence; otherwise the IC clears their main memory.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // If `true`, the `pre_upgrade` hook is skipped during the canister upgrade.
+  skip_pre_upgrade : opt bool;
 };
 
 // WASM memory persistence setting passed to `install_code` when the install
@@ -675,13 +687,6 @@ type ChangeExternalCanisterOperationInput = record {
   module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
-  // WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
-  // Required as `keep` for upgrading Motoko canisters that use Enhanced
-  // Orthogonal Persistence; otherwise the IC clears their main memory.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
-  // is `upgrade`.
-  skip_pre_upgrade : opt bool;
 };
 
 type ChangeExternalCanisterOperation = record {
@@ -693,12 +698,6 @@ type ChangeExternalCanisterOperation = record {
   module_checksum : Sha256Hash;
   // The checksum of the arg blob.
   arg_checksum : opt Sha256Hash;
-  // WASM memory persistence setting recorded for this upgrade, if any.
-  // Only meaningful when `mode` is `upgrade`.
-  wasm_memory_persistence : opt WasmMemoryPersistence;
-  // Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
-  // is `upgrade`.
-  skip_pre_upgrade : opt bool;
 };
 
 type SubnetFilter = record {

--- a/core/station/api/spec.did
+++ b/core/station/api/spec.did
@@ -578,6 +578,15 @@ type CanisterInstallMode = variant {
   upgrade;
 };
 
+// WASM memory persistence setting passed to `install_code` when the install
+// mode is `upgrade`. `keep` is required for Motoko canisters that use
+// Enhanced Orthogonal Persistence; the IC defaults to `replace` (clearing
+// main memory) otherwise.
+type WasmMemoryPersistence = variant {
+  keep;
+  replace;
+};
+
 type SystemUpgradeTarget = variant {
   UpgradeStation;
   UpgradeUpgrader;
@@ -666,6 +675,13 @@ type ChangeExternalCanisterOperationInput = record {
   module_extra_chunks : opt WasmModuleExtraChunks;
   // The initial argument passed to the new wasm module.
   arg : opt blob;
+  // WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
+  // Required as `keep` for upgrading Motoko canisters that use Enhanced
+  // Orthogonal Persistence; otherwise the IC clears their main memory.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // If `true`, the `pre_upgrade` hook is skipped. Only applicable when `mode`
+  // is `upgrade`.
+  skip_pre_upgrade : opt bool;
 };
 
 type ChangeExternalCanisterOperation = record {
@@ -677,6 +693,12 @@ type ChangeExternalCanisterOperation = record {
   module_checksum : Sha256Hash;
   // The checksum of the arg blob.
   arg_checksum : opt Sha256Hash;
+  // WASM memory persistence setting recorded for this upgrade, if any.
+  // Only meaningful when `mode` is `upgrade`.
+  wasm_memory_persistence : opt WasmMemoryPersistence;
+  // Whether the `pre_upgrade` hook was skipped. Only meaningful when `mode`
+  // is `upgrade`.
+  skip_pre_upgrade : opt bool;
 };
 
 type SubnetFilter = record {

--- a/core/station/api/src/common.rs
+++ b/core/station/api/src/common.rs
@@ -33,11 +33,25 @@ pub enum SortDirection {
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub enum CanisterInstallMode {
     #[serde(rename = "install")]
-    Install = 1,
+    Install,
     #[serde(rename = "reinstall")]
-    Reinstall = 2,
+    Reinstall,
+    /// Upgrade an existing canister. Carries optional flags that mirror the
+    /// IC management canister's `CanisterUpgradeOptions`.
     #[serde(rename = "upgrade")]
-    Upgrade = 3,
+    Upgrade(Option<CanisterUpgradeOptionsInput>),
+}
+
+/// Optional upgrade flags forwarded to the IC management canister's
+/// `install_code` method when `mode` is `upgrade`.
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct CanisterUpgradeOptionsInput {
+    /// Required as `keep` for upgrading Motoko canisters that use Enhanced
+    /// Orthogonal Persistence; otherwise the IC clears their main memory.
+    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
+    /// If `true`, the `pre_upgrade` hook is skipped during the canister
+    /// upgrade.
+    pub skip_pre_upgrade: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]

--- a/core/station/api/src/common.rs
+++ b/core/station/api/src/common.rs
@@ -40,6 +40,14 @@ pub enum CanisterInstallMode {
     Upgrade = 3,
 }
 
+#[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WasmMemoryPersistence {
+    #[serde(rename = "keep")]
+    Keep,
+    #[serde(rename = "replace")]
+    Replace,
+}
+
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
 pub struct Snapshot {
     pub snapshot_id: String,

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -1,7 +1,7 @@
 use crate::{
     AllowDTO, CanisterInstallMode, ChangeMetadataDTO, CycleObtainStrategyInput, MetadataDTO,
     PaginationInput, RequestPolicyRuleDTO, Sha256HashDTO, SortDirection, TimestampRfc3339, UuidDTO,
-    ValidationMethodResourceTargetDTO, WasmMemoryPersistence,
+    ValidationMethodResourceTargetDTO,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 use orbit_essentials::cmc::SubnetSelection;
@@ -131,13 +131,6 @@ pub struct ChangeExternalCanisterOperationInput {
     pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
     pub arg: Option<Vec<u8>>,
-    /// WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
-    /// Required as `keep` for upgrading Motoko canisters that use Enhanced
-    /// Orthogonal Persistence; otherwise the IC clears their main memory.
-    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
-    /// If `true`, the `pre_upgrade` hook is skipped. Only applicable when
-    /// `mode` is `upgrade`.
-    pub skip_pre_upgrade: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -146,8 +139,6 @@ pub struct ChangeExternalCanisterOperationDTO {
     pub mode: CanisterInstallMode,
     pub module_checksum: Sha256HashDTO,
     pub arg_checksum: Option<Sha256HashDTO>,
-    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
-    pub skip_pre_upgrade: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/api/src/external_canister.rs
+++ b/core/station/api/src/external_canister.rs
@@ -1,7 +1,7 @@
 use crate::{
     AllowDTO, CanisterInstallMode, ChangeMetadataDTO, CycleObtainStrategyInput, MetadataDTO,
     PaginationInput, RequestPolicyRuleDTO, Sha256HashDTO, SortDirection, TimestampRfc3339, UuidDTO,
-    ValidationMethodResourceTargetDTO,
+    ValidationMethodResourceTargetDTO, WasmMemoryPersistence,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 use orbit_essentials::cmc::SubnetSelection;
@@ -131,6 +131,13 @@ pub struct ChangeExternalCanisterOperationInput {
     pub module_extra_chunks: Option<WasmModuleExtraChunks>,
     #[serde(deserialize_with = "orbit_essentials::deserialize::deserialize_option_blob")]
     pub arg: Option<Vec<u8>>,
+    /// WASM memory persistence setting. Only applicable when `mode` is `upgrade`.
+    /// Required as `keep` for upgrading Motoko canisters that use Enhanced
+    /// Orthogonal Persistence; otherwise the IC clears their main memory.
+    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
+    /// If `true`, the `pre_upgrade` hook is skipped. Only applicable when
+    /// `mode` is `upgrade`.
+    pub skip_pre_upgrade: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]
@@ -139,6 +146,8 @@ pub struct ChangeExternalCanisterOperationDTO {
     pub mode: CanisterInstallMode,
     pub module_checksum: Sha256HashDTO,
     pub arg_checksum: Option<Sha256HashDTO>,
+    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
+    pub skip_pre_upgrade: Option<bool>,
 }
 
 #[derive(CandidType, serde::Serialize, Deserialize, Debug, Clone)]

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -525,9 +525,9 @@ impl From<station_api::CanisterInstallMode> for CanisterInstallMode {
             station_api::CanisterInstallMode::Reinstall => {
                 CanisterInstallMode::Reinstall(CanisterReinstallModeArgs {})
             }
-            station_api::CanisterInstallMode::Upgrade(opts) => CanisterInstallMode::Upgrade(
-                opts.map(CanisterUpgradeModeArgs::from).unwrap_or_default(),
-            ),
+            station_api::CanisterInstallMode::Upgrade(opts) => {
+                CanisterInstallMode::Upgrade(opts.map(Into::into))
+            }
         }
     }
 }
@@ -562,13 +562,7 @@ impl From<CanisterInstallMode> for station_api::CanisterInstallMode {
                 station_api::CanisterInstallMode::Reinstall
             }
             CanisterInstallMode::Upgrade(args) => {
-                let opts =
-                    if args.wasm_memory_persistence.is_some() || args.skip_pre_upgrade.is_some() {
-                        Some(args.into())
-                    } else {
-                        None
-                    };
-                station_api::CanisterInstallMode::Upgrade(opts)
+                station_api::CanisterInstallMode::Upgrade(args.map(Into::into))
             }
         }
     }
@@ -2480,8 +2474,8 @@ mod tests {
         }));
         let internal: ChangeExternalCanisterOperationInput = api_input.into();
 
-        let CanisterInstallMode::Upgrade(args) = &internal.mode else {
-            panic!("expected upgrade mode");
+        let CanisterInstallMode::Upgrade(Some(args)) = &internal.mode else {
+            panic!("expected upgrade mode with args");
         };
         assert_eq!(
             args.wasm_memory_persistence,
@@ -2506,6 +2500,8 @@ mod tests {
     fn unset_upgrade_flags_map_to_unit_upgrade() {
         let api_input = upgrade_input(None);
         let internal: ChangeExternalCanisterOperationInput = api_input.into();
+
+        assert!(matches!(internal.mode, CanisterInstallMode::Upgrade(None)));
 
         let mgmt_mode: mgmt::CanisterInstallMode = internal.mode.into();
         assert!(matches!(
@@ -2574,5 +2570,34 @@ mod tests {
         let args: CanisterUpgradeModeArgs =
             serde_cbor::from_slice(&empty_map_cbor).expect("legacy bytes must deserialize");
         assert_eq!(args, CanisterUpgradeModeArgs::default());
+    }
+
+    #[test]
+    fn legacy_upgrade_variant_deserializes_to_some_default() {
+        // Historical on-disk shape of the enum variant was
+        // `Upgrade(CanisterUpgradeModeArgs {})`. After widening the payload
+        // to `Option<CanisterUpgradeModeArgs>`, the legacy bytes (variant
+        // tag + empty map) should still deserialize, surfacing as
+        // `Upgrade(Some(default))` — semantically equivalent to "no flags".
+        let cbor = serde_cbor::to_vec(&CanisterInstallModeLegacy::Upgrade(
+            CanisterUpgradeModeArgs::default(),
+        ))
+        .unwrap();
+        let mode: CanisterInstallMode =
+            serde_cbor::from_slice(&cbor).expect("legacy upgrade variant must deserialize");
+        assert!(matches!(
+            mode,
+            CanisterInstallMode::Upgrade(Some(args)) if args == CanisterUpgradeModeArgs::default()
+        ));
+    }
+
+    // Mirror of the pre-refactor enum used only to encode a legacy fixture.
+    #[derive(serde::Serialize)]
+    enum CanisterInstallModeLegacy {
+        #[allow(dead_code)]
+        Install(CanisterInstallModeArgs),
+        #[allow(dead_code)]
+        Reinstall(CanisterReinstallModeArgs),
+        Upgrade(CanisterUpgradeModeArgs),
     }
 }

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -525,9 +525,18 @@ impl From<station_api::CanisterInstallMode> for CanisterInstallMode {
             station_api::CanisterInstallMode::Reinstall => {
                 CanisterInstallMode::Reinstall(CanisterReinstallModeArgs {})
             }
-            station_api::CanisterInstallMode::Upgrade => {
-                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs::default())
-            }
+            station_api::CanisterInstallMode::Upgrade(opts) => CanisterInstallMode::Upgrade(
+                opts.map(CanisterUpgradeModeArgs::from).unwrap_or_default(),
+            ),
+        }
+    }
+}
+
+impl From<station_api::CanisterUpgradeOptionsInput> for CanisterUpgradeModeArgs {
+    fn from(opts: station_api::CanisterUpgradeOptionsInput) -> Self {
+        CanisterUpgradeModeArgs {
+            wasm_memory_persistence: opts.wasm_memory_persistence.map(Into::into),
+            skip_pre_upgrade: opts.skip_pre_upgrade,
         }
     }
 }
@@ -552,7 +561,24 @@ impl From<CanisterInstallMode> for station_api::CanisterInstallMode {
             CanisterInstallMode::Reinstall(CanisterReinstallModeArgs {}) => {
                 station_api::CanisterInstallMode::Reinstall
             }
-            CanisterInstallMode::Upgrade(_) => station_api::CanisterInstallMode::Upgrade,
+            CanisterInstallMode::Upgrade(args) => {
+                let opts =
+                    if args.wasm_memory_persistence.is_some() || args.skip_pre_upgrade.is_some() {
+                        Some(args.into())
+                    } else {
+                        None
+                    };
+                station_api::CanisterInstallMode::Upgrade(opts)
+            }
+        }
+    }
+}
+
+impl From<CanisterUpgradeModeArgs> for station_api::CanisterUpgradeOptionsInput {
+    fn from(args: CanisterUpgradeModeArgs) -> Self {
+        station_api::CanisterUpgradeOptionsInput {
+            wasm_memory_persistence: args.wasm_memory_persistence.map(Into::into),
+            skip_pre_upgrade: args.skip_pre_upgrade,
         }
     }
 }
@@ -602,15 +628,12 @@ impl From<ChangeExternalCanisterOperationInput>
     fn from(
         input: ChangeExternalCanisterOperationInput,
     ) -> station_api::ChangeExternalCanisterOperationInput {
-        let (wasm_memory_persistence, skip_pre_upgrade) = upgrade_flags_to_api(&input.mode);
         station_api::ChangeExternalCanisterOperationInput {
             canister_id: input.canister_id,
             mode: input.mode.into(),
             module: input.module,
             module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
-            wasm_memory_persistence,
-            skip_pre_upgrade,
         }
     }
 }
@@ -621,14 +644,9 @@ impl From<station_api::ChangeExternalCanisterOperationInput>
     fn from(
         input: station_api::ChangeExternalCanisterOperationInput,
     ) -> ChangeExternalCanisterOperationInput {
-        let mut mode: CanisterInstallMode = input.mode.into();
-        if let CanisterInstallMode::Upgrade(ref mut args) = mode {
-            args.wasm_memory_persistence = input.wasm_memory_persistence.map(Into::into);
-            args.skip_pre_upgrade = input.skip_pre_upgrade;
-        }
         ChangeExternalCanisterOperationInput {
             canister_id: input.canister_id,
-            mode,
+            mode: input.mode.into(),
             module: input.module,
             module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
@@ -638,28 +656,12 @@ impl From<station_api::ChangeExternalCanisterOperationInput>
 
 impl From<ChangeExternalCanisterOperation> for ChangeExternalCanisterOperationDTO {
     fn from(operation: ChangeExternalCanisterOperation) -> ChangeExternalCanisterOperationDTO {
-        let (wasm_memory_persistence, skip_pre_upgrade) =
-            upgrade_flags_to_api(&operation.input.mode);
         ChangeExternalCanisterOperationDTO {
             canister_id: operation.input.canister_id,
             mode: operation.input.mode.into(),
             module_checksum: hex::encode(operation.module_checksum),
             arg_checksum: operation.arg_checksum.map(hex::encode),
-            wasm_memory_persistence,
-            skip_pre_upgrade,
         }
-    }
-}
-
-fn upgrade_flags_to_api(
-    mode: &CanisterInstallMode,
-) -> (Option<station_api::WasmMemoryPersistence>, Option<bool>) {
-    match mode {
-        CanisterInstallMode::Upgrade(args) => (
-            args.wasm_memory_persistence.map(Into::into),
-            args.skip_pre_upgrade,
-        ),
-        _ => (None, None),
     }
 }
 
@@ -2459,23 +2461,23 @@ mod tests {
     use orbit_essentials::cdk::api::management_canister::main::{self as mgmt};
 
     fn upgrade_input(
-        wasm_memory_persistence: Option<station_api::WasmMemoryPersistence>,
-        skip_pre_upgrade: Option<bool>,
+        opts: Option<station_api::CanisterUpgradeOptionsInput>,
     ) -> station_api::ChangeExternalCanisterOperationInput {
         station_api::ChangeExternalCanisterOperationInput {
             canister_id: Principal::management_canister(),
-            mode: station_api::CanisterInstallMode::Upgrade,
+            mode: station_api::CanisterInstallMode::Upgrade(opts),
             module: vec![1, 2, 3],
             module_extra_chunks: None,
             arg: None,
-            wasm_memory_persistence,
-            skip_pre_upgrade,
         }
     }
 
     #[test]
     fn upgrade_flags_roundtrip_through_mapper() {
-        let api_input = upgrade_input(Some(station_api::WasmMemoryPersistence::Keep), Some(true));
+        let api_input = upgrade_input(Some(station_api::CanisterUpgradeOptionsInput {
+            wasm_memory_persistence: Some(station_api::WasmMemoryPersistence::Keep),
+            skip_pre_upgrade: Some(true),
+        }));
         let internal: ChangeExternalCanisterOperationInput = api_input.into();
 
         let CanisterInstallMode::Upgrade(args) = &internal.mode else {
@@ -2488,16 +2490,21 @@ mod tests {
         assert_eq!(args.skip_pre_upgrade, Some(true));
 
         let api_back: station_api::ChangeExternalCanisterOperationInput = internal.into();
-        assert!(matches!(
-            api_back.wasm_memory_persistence,
-            Some(station_api::WasmMemoryPersistence::Keep)
-        ));
-        assert_eq!(api_back.skip_pre_upgrade, Some(true));
+        match api_back.mode {
+            station_api::CanisterInstallMode::Upgrade(Some(opts)) => {
+                assert!(matches!(
+                    opts.wasm_memory_persistence,
+                    Some(station_api::WasmMemoryPersistence::Keep)
+                ));
+                assert_eq!(opts.skip_pre_upgrade, Some(true));
+            }
+            other => panic!("expected upgrade with options, got {other:?}"),
+        }
     }
 
     #[test]
     fn unset_upgrade_flags_map_to_unit_upgrade() {
-        let api_input = upgrade_input(None, None);
+        let api_input = upgrade_input(None);
         let internal: ChangeExternalCanisterOperationInput = api_input.into();
 
         let mgmt_mode: mgmt::CanisterInstallMode = internal.mode.into();
@@ -2509,7 +2516,10 @@ mod tests {
 
     #[test]
     fn set_upgrade_flags_populate_mgmt_upgrade_options() {
-        let api_input = upgrade_input(Some(station_api::WasmMemoryPersistence::Keep), None);
+        let api_input = upgrade_input(Some(station_api::CanisterUpgradeOptionsInput {
+            wasm_memory_persistence: Some(station_api::WasmMemoryPersistence::Keep),
+            skip_pre_upgrade: None,
+        }));
         let internal: ChangeExternalCanisterOperationInput = api_input.into();
 
         let mgmt_mode: mgmt::CanisterInstallMode = internal.mode.into();
@@ -2526,24 +2536,31 @@ mod tests {
     }
 
     #[test]
-    fn install_and_reinstall_ignore_upgrade_flags() {
-        for mode in [
-            station_api::CanisterInstallMode::Install,
-            station_api::CanisterInstallMode::Reinstall,
+    fn install_and_reinstall_map_to_unit_variants() {
+        for (mode, expected) in [
+            (
+                station_api::CanisterInstallMode::Install,
+                station_api::CanisterInstallMode::Install,
+            ),
+            (
+                station_api::CanisterInstallMode::Reinstall,
+                station_api::CanisterInstallMode::Reinstall,
+            ),
         ] {
             let api_input = station_api::ChangeExternalCanisterOperationInput {
                 canister_id: Principal::management_canister(),
-                mode: mode.clone(),
+                mode,
                 module: vec![],
                 module_extra_chunks: None,
                 arg: None,
-                wasm_memory_persistence: Some(station_api::WasmMemoryPersistence::Keep),
-                skip_pre_upgrade: Some(true),
             };
             let internal: ChangeExternalCanisterOperationInput = api_input.into();
             let api_back: station_api::ChangeExternalCanisterOperationInput = internal.into();
-            assert!(api_back.wasm_memory_persistence.is_none());
-            assert!(api_back.skip_pre_upgrade.is_none());
+            assert!(
+                std::mem::discriminant(&api_back.mode) == std::mem::discriminant(&expected),
+                "expected {expected:?}, got {:?}",
+                api_back.mode,
+            );
         }
     }
 

--- a/core/station/impl/src/mappers/request_operation.rs
+++ b/core/station/impl/src/mappers/request_operation.rs
@@ -51,7 +51,7 @@ use crate::{
         SnapshotExternalCanisterOperation, SnapshotExternalCanisterOperationInput,
         SystemRestoreOperation, SystemRestoreOperationInput, SystemRestoreTarget,
         SystemUpgradeOperation, SystemUpgradeOperationInput, SystemUpgradeTarget,
-        TransferOperation, User, WasmModuleExtraChunks,
+        TransferOperation, User, WasmMemoryPersistence, WasmModuleExtraChunks,
     },
     repositories::{
         AccountRepository, AddressBookRepository, AssetRepository, NamedRuleRepository,
@@ -526,7 +526,7 @@ impl From<station_api::CanisterInstallMode> for CanisterInstallMode {
                 CanisterInstallMode::Reinstall(CanisterReinstallModeArgs {})
             }
             station_api::CanisterInstallMode::Upgrade => {
-                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs {})
+                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs::default())
             }
         }
     }
@@ -552,9 +552,25 @@ impl From<CanisterInstallMode> for station_api::CanisterInstallMode {
             CanisterInstallMode::Reinstall(CanisterReinstallModeArgs {}) => {
                 station_api::CanisterInstallMode::Reinstall
             }
-            CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs {}) => {
-                station_api::CanisterInstallMode::Upgrade
-            }
+            CanisterInstallMode::Upgrade(_) => station_api::CanisterInstallMode::Upgrade,
+        }
+    }
+}
+
+impl From<station_api::WasmMemoryPersistence> for WasmMemoryPersistence {
+    fn from(value: station_api::WasmMemoryPersistence) -> Self {
+        match value {
+            station_api::WasmMemoryPersistence::Keep => WasmMemoryPersistence::Keep,
+            station_api::WasmMemoryPersistence::Replace => WasmMemoryPersistence::Replace,
+        }
+    }
+}
+
+impl From<WasmMemoryPersistence> for station_api::WasmMemoryPersistence {
+    fn from(value: WasmMemoryPersistence) -> Self {
+        match value {
+            WasmMemoryPersistence::Keep => station_api::WasmMemoryPersistence::Keep,
+            WasmMemoryPersistence::Replace => station_api::WasmMemoryPersistence::Replace,
         }
     }
 }
@@ -586,12 +602,15 @@ impl From<ChangeExternalCanisterOperationInput>
     fn from(
         input: ChangeExternalCanisterOperationInput,
     ) -> station_api::ChangeExternalCanisterOperationInput {
+        let (wasm_memory_persistence, skip_pre_upgrade) = upgrade_flags_to_api(&input.mode);
         station_api::ChangeExternalCanisterOperationInput {
             canister_id: input.canister_id,
             mode: input.mode.into(),
             module: input.module,
             module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
+            wasm_memory_persistence,
+            skip_pre_upgrade,
         }
     }
 }
@@ -602,9 +621,14 @@ impl From<station_api::ChangeExternalCanisterOperationInput>
     fn from(
         input: station_api::ChangeExternalCanisterOperationInput,
     ) -> ChangeExternalCanisterOperationInput {
+        let mut mode: CanisterInstallMode = input.mode.into();
+        if let CanisterInstallMode::Upgrade(ref mut args) = mode {
+            args.wasm_memory_persistence = input.wasm_memory_persistence.map(Into::into);
+            args.skip_pre_upgrade = input.skip_pre_upgrade;
+        }
         ChangeExternalCanisterOperationInput {
             canister_id: input.canister_id,
-            mode: input.mode.into(),
+            mode,
             module: input.module,
             module_extra_chunks: input.module_extra_chunks.map(|c| c.into()),
             arg: input.arg,
@@ -614,12 +638,28 @@ impl From<station_api::ChangeExternalCanisterOperationInput>
 
 impl From<ChangeExternalCanisterOperation> for ChangeExternalCanisterOperationDTO {
     fn from(operation: ChangeExternalCanisterOperation) -> ChangeExternalCanisterOperationDTO {
+        let (wasm_memory_persistence, skip_pre_upgrade) =
+            upgrade_flags_to_api(&operation.input.mode);
         ChangeExternalCanisterOperationDTO {
             canister_id: operation.input.canister_id,
             mode: operation.input.mode.into(),
             module_checksum: hex::encode(operation.module_checksum),
             arg_checksum: operation.arg_checksum.map(hex::encode),
+            wasm_memory_persistence,
+            skip_pre_upgrade,
         }
+    }
+}
+
+fn upgrade_flags_to_api(
+    mode: &CanisterInstallMode,
+) -> (Option<station_api::WasmMemoryPersistence>, Option<bool>) {
+    match mode {
+        CanisterInstallMode::Upgrade(args) => (
+            args.wasm_memory_persistence.map(Into::into),
+            args.skip_pre_upgrade,
+        ),
+        _ => (None, None),
     }
 }
 
@@ -2409,5 +2449,113 @@ impl RequestOperation {
                 ]
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use orbit_essentials::cdk::api::management_canister::main::{self as mgmt};
+
+    fn upgrade_input(
+        wasm_memory_persistence: Option<station_api::WasmMemoryPersistence>,
+        skip_pre_upgrade: Option<bool>,
+    ) -> station_api::ChangeExternalCanisterOperationInput {
+        station_api::ChangeExternalCanisterOperationInput {
+            canister_id: Principal::management_canister(),
+            mode: station_api::CanisterInstallMode::Upgrade,
+            module: vec![1, 2, 3],
+            module_extra_chunks: None,
+            arg: None,
+            wasm_memory_persistence,
+            skip_pre_upgrade,
+        }
+    }
+
+    #[test]
+    fn upgrade_flags_roundtrip_through_mapper() {
+        let api_input = upgrade_input(Some(station_api::WasmMemoryPersistence::Keep), Some(true));
+        let internal: ChangeExternalCanisterOperationInput = api_input.into();
+
+        let CanisterInstallMode::Upgrade(args) = &internal.mode else {
+            panic!("expected upgrade mode");
+        };
+        assert_eq!(
+            args.wasm_memory_persistence,
+            Some(WasmMemoryPersistence::Keep)
+        );
+        assert_eq!(args.skip_pre_upgrade, Some(true));
+
+        let api_back: station_api::ChangeExternalCanisterOperationInput = internal.into();
+        assert!(matches!(
+            api_back.wasm_memory_persistence,
+            Some(station_api::WasmMemoryPersistence::Keep)
+        ));
+        assert_eq!(api_back.skip_pre_upgrade, Some(true));
+    }
+
+    #[test]
+    fn unset_upgrade_flags_map_to_unit_upgrade() {
+        let api_input = upgrade_input(None, None);
+        let internal: ChangeExternalCanisterOperationInput = api_input.into();
+
+        let mgmt_mode: mgmt::CanisterInstallMode = internal.mode.into();
+        assert!(matches!(
+            mgmt_mode,
+            mgmt::CanisterInstallMode::Upgrade(None)
+        ));
+    }
+
+    #[test]
+    fn set_upgrade_flags_populate_mgmt_upgrade_options() {
+        let api_input = upgrade_input(Some(station_api::WasmMemoryPersistence::Keep), None);
+        let internal: ChangeExternalCanisterOperationInput = api_input.into();
+
+        let mgmt_mode: mgmt::CanisterInstallMode = internal.mode.into();
+        match mgmt_mode {
+            mgmt::CanisterInstallMode::Upgrade(Some(flags)) => {
+                assert!(matches!(
+                    flags.wasm_memory_persistence,
+                    Some(mgmt::WasmPersistenceMode::Keep)
+                ));
+                assert_eq!(flags.skip_pre_upgrade, None);
+            }
+            other => panic!("expected upgrade with flags, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn install_and_reinstall_ignore_upgrade_flags() {
+        for mode in [
+            station_api::CanisterInstallMode::Install,
+            station_api::CanisterInstallMode::Reinstall,
+        ] {
+            let api_input = station_api::ChangeExternalCanisterOperationInput {
+                canister_id: Principal::management_canister(),
+                mode: mode.clone(),
+                module: vec![],
+                module_extra_chunks: None,
+                arg: None,
+                wasm_memory_persistence: Some(station_api::WasmMemoryPersistence::Keep),
+                skip_pre_upgrade: Some(true),
+            };
+            let internal: ChangeExternalCanisterOperationInput = api_input.into();
+            let api_back: station_api::ChangeExternalCanisterOperationInput = internal.into();
+            assert!(api_back.wasm_memory_persistence.is_none());
+            assert!(api_back.skip_pre_upgrade.is_none());
+        }
+    }
+
+    #[test]
+    fn legacy_upgrade_args_deserialize_with_defaults() {
+        // Historical on-disk shape: CanisterUpgradeModeArgs was a unit struct
+        // with no fields. Verify that records written before this change
+        // (an empty CBOR map) still deserialize into the new struct, with
+        // both flag fields defaulting to None.
+        let empty_map_cbor = vec![0xa0u8]; // CBOR encoding of an empty map.
+        let args: CanisterUpgradeModeArgs =
+            serde_cbor::from_slice(&empty_map_cbor).expect("legacy bytes must deserialize");
+        assert_eq!(args, CanisterUpgradeModeArgs::default());
     }
 }

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -489,7 +489,16 @@ impl From<WasmMemoryPersistence> for mgmt::WasmPersistenceMode {
 pub enum CanisterInstallMode {
     Install(CanisterInstallModeArgs),
     Reinstall(CanisterReinstallModeArgs),
-    Upgrade(CanisterUpgradeModeArgs),
+    Upgrade(Option<CanisterUpgradeModeArgs>),
+}
+
+impl From<CanisterUpgradeModeArgs> for mgmt::UpgradeFlags {
+    fn from(args: CanisterUpgradeModeArgs) -> Self {
+        mgmt::UpgradeFlags {
+            skip_pre_upgrade: args.skip_pre_upgrade,
+            wasm_memory_persistence: args.wasm_memory_persistence.map(Into::into),
+        }
+    }
 }
 
 impl From<CanisterInstallMode> for mgmt::CanisterInstallMode {
@@ -498,16 +507,7 @@ impl From<CanisterInstallMode> for mgmt::CanisterInstallMode {
             CanisterInstallMode::Install(_) => mgmt::CanisterInstallMode::Install,
             CanisterInstallMode::Reinstall(_) => mgmt::CanisterInstallMode::Reinstall,
             CanisterInstallMode::Upgrade(args) => {
-                let flags =
-                    if args.wasm_memory_persistence.is_some() || args.skip_pre_upgrade.is_some() {
-                        Some(mgmt::UpgradeFlags {
-                            skip_pre_upgrade: args.skip_pre_upgrade,
-                            wasm_memory_persistence: args.wasm_memory_persistence.map(Into::into),
-                        })
-                    } else {
-                        None
-                    };
-                mgmt::CanisterInstallMode::Upgrade(flags)
+                mgmt::CanisterInstallMode::Upgrade(args.map(Into::into))
             }
         }
     }
@@ -1622,9 +1622,7 @@ mod test {
             crate::models::ChangeExternalCanisterOperation {
                 input: crate::models::ChangeExternalCanisterOperationInput {
                     canister_id: upgrader_id,
-                    mode: crate::models::CanisterInstallMode::Upgrade(
-                        crate::models::CanisterUpgradeModeArgs::default(),
-                    ),
+                    mode: crate::models::CanisterInstallMode::Upgrade(None),
                     module: vec![],
                     module_extra_chunks: None,
                     arg: None,

--- a/core/station/impl/src/models/request_operation.rs
+++ b/core/station/impl/src/models/request_operation.rs
@@ -460,8 +460,29 @@ pub struct CanisterInstallModeArgs {}
 pub struct CanisterReinstallModeArgs {}
 
 #[storable]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct CanisterUpgradeModeArgs {}
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CanisterUpgradeModeArgs {
+    #[serde(default)]
+    pub wasm_memory_persistence: Option<WasmMemoryPersistence>,
+    #[serde(default)]
+    pub skip_pre_upgrade: Option<bool>,
+}
+
+#[storable]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum WasmMemoryPersistence {
+    Keep,
+    Replace,
+}
+
+impl From<WasmMemoryPersistence> for mgmt::WasmPersistenceMode {
+    fn from(value: WasmMemoryPersistence) -> Self {
+        match value {
+            WasmMemoryPersistence::Keep => mgmt::WasmPersistenceMode::Keep,
+            WasmMemoryPersistence::Replace => mgmt::WasmPersistenceMode::Replace,
+        }
+    }
+}
 
 #[storable]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -476,7 +497,18 @@ impl From<CanisterInstallMode> for mgmt::CanisterInstallMode {
         match mode {
             CanisterInstallMode::Install(_) => mgmt::CanisterInstallMode::Install,
             CanisterInstallMode::Reinstall(_) => mgmt::CanisterInstallMode::Reinstall,
-            CanisterInstallMode::Upgrade(_) => mgmt::CanisterInstallMode::Upgrade(None),
+            CanisterInstallMode::Upgrade(args) => {
+                let flags =
+                    if args.wasm_memory_persistence.is_some() || args.skip_pre_upgrade.is_some() {
+                        Some(mgmt::UpgradeFlags {
+                            skip_pre_upgrade: args.skip_pre_upgrade,
+                            wasm_memory_persistence: args.wasm_memory_persistence.map(Into::into),
+                        })
+                    } else {
+                        None
+                    };
+                mgmt::CanisterInstallMode::Upgrade(flags)
+            }
         }
     }
 }
@@ -1591,7 +1623,7 @@ mod test {
                 input: crate::models::ChangeExternalCanisterOperationInput {
                     canister_id: upgrader_id,
                     mode: crate::models::CanisterInstallMode::Upgrade(
-                        crate::models::CanisterUpgradeModeArgs {},
+                        crate::models::CanisterUpgradeModeArgs::default(),
                     ),
                     module: vec![],
                     module_extra_chunks: None,

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -10,10 +10,10 @@ use crate::{
     errors::SystemError,
     models::{
         system::{DisasterRecoveryCommittee, SystemInfo, SystemState},
-        Asset, Blockchain, CanisterInstallMode, CanisterUpgradeModeArgs,
-        ManageSystemInfoOperationInput, Metadata, RequestId, RequestKey, RequestOperation,
-        RequestStatus, SystemRestoreTarget, SystemUpgradeTarget, TokenStandard,
-        WasmModuleExtraChunks, ADMIN_GROUP_ID, OPERATOR_GROUP_ID,
+        Asset, Blockchain, CanisterInstallMode, ManageSystemInfoOperationInput, Metadata,
+        RequestId, RequestKey, RequestOperation, RequestStatus, SystemRestoreTarget,
+        SystemUpgradeTarget, TokenStandard, WasmModuleExtraChunks, ADMIN_GROUP_ID,
+        OPERATOR_GROUP_ID,
     },
     repositories::{
         permission::PERMISSION_REPOSITORY, RequestRepository, ASSET_REPOSITORY,
@@ -238,7 +238,7 @@ impl SystemService {
             .change_canister_service
             .install_canister(
                 upgrader_canister_id,
-                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs::default()),
+                CanisterInstallMode::Upgrade(None),
                 module,
                 module_extra_chunks,
                 arg,

--- a/core/station/impl/src/services/system.rs
+++ b/core/station/impl/src/services/system.rs
@@ -238,7 +238,7 @@ impl SystemService {
             .change_canister_service
             .install_canister(
                 upgrader_canister_id,
-                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs {}),
+                CanisterInstallMode::Upgrade(CanisterUpgradeModeArgs::default()),
                 module,
                 module_extra_chunks,
                 arg,

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -77,6 +77,8 @@ fn successful_four_eyes_upgrade() {
             module: base_chunk,
             module_extra_chunks: Some(module_extra_chunks),
             arg: None,
+            wasm_memory_persistence: None,
+            skip_pre_upgrade: None,
         });
 
     let change_canister_operation_request = submit_request(
@@ -222,6 +224,8 @@ fn upgrade_reinstall_list_test() {
             module: base_chunk.clone(),
             module_extra_chunks: Some(module_extra_chunks.clone()),
             arg: None,
+            wasm_memory_persistence: None,
+            skip_pre_upgrade: None,
         });
     execute_request(
         &env,
@@ -247,6 +251,8 @@ fn upgrade_reinstall_list_test() {
             module: base_chunk,
             module_extra_chunks: Some(module_extra_chunks),
             arg: None,
+            wasm_memory_persistence: None,
+            skip_pre_upgrade: None,
         });
     execute_request(
         &env,

--- a/tests/integration/src/external_canister_tests.rs
+++ b/tests/integration/src/external_canister_tests.rs
@@ -73,12 +73,10 @@ fn successful_four_eyes_upgrade() {
     let change_canister_operation =
         RequestOperationInput::ChangeExternalCanister(ChangeExternalCanisterOperationInput {
             canister_id,
-            mode: CanisterInstallMode::Upgrade,
+            mode: CanisterInstallMode::Upgrade(None),
             module: base_chunk,
             module_extra_chunks: Some(module_extra_chunks),
             arg: None,
-            wasm_memory_persistence: None,
-            skip_pre_upgrade: None,
         });
 
     let change_canister_operation_request = submit_request(
@@ -220,12 +218,10 @@ fn upgrade_reinstall_list_test() {
     let change_canister_operation =
         RequestOperationInput::ChangeExternalCanister(ChangeExternalCanisterOperationInput {
             canister_id,
-            mode: CanisterInstallMode::Upgrade,
+            mode: CanisterInstallMode::Upgrade(None),
             module: base_chunk.clone(),
             module_extra_chunks: Some(module_extra_chunks.clone()),
             arg: None,
-            wasm_memory_persistence: None,
-            skip_pre_upgrade: None,
         });
     execute_request(
         &env,
@@ -251,8 +247,6 @@ fn upgrade_reinstall_list_test() {
             module: base_chunk,
             module_extra_chunks: Some(module_extra_chunks),
             arg: None,
-            wasm_memory_persistence: None,
-            skip_pre_upgrade: None,
         });
     execute_request(
         &env,

--- a/tools/dfx-orbit/src/canister/install.rs
+++ b/tools/dfx-orbit/src/canister/install.rs
@@ -103,6 +103,8 @@ impl RequestCanisterInstallArgs {
             module,
             module_extra_chunks,
             arg,
+            wasm_memory_persistence: None,
+            skip_pre_upgrade: None,
         };
         Ok(RequestOperationInput::ChangeExternalCanister(operation))
     }

--- a/tools/dfx-orbit/src/canister/install.rs
+++ b/tools/dfx-orbit/src/canister/install.rs
@@ -103,8 +103,6 @@ impl RequestCanisterInstallArgs {
             module,
             module_extra_chunks,
             arg,
-            wasm_memory_persistence: None,
-            skip_pre_upgrade: None,
         };
         Ok(RequestOperationInput::ChangeExternalCanister(operation))
     }
@@ -180,7 +178,7 @@ impl From<CanisterInstallModeArgs> for CanisterInstallMode {
         match mode {
             CanisterInstallModeArgs::Install => Self::Install,
             CanisterInstallModeArgs::Reinstall => Self::Reinstall,
-            CanisterInstallModeArgs::Upgrade => Self::Upgrade,
+            CanisterInstallModeArgs::Upgrade => Self::Upgrade(None),
         }
     }
 }
@@ -190,7 +188,7 @@ impl From<CanisterInstallMode> for CanisterInstallModeArgs {
         match mode {
             CanisterInstallMode::Install => Self::Install,
             CanisterInstallMode::Reinstall => Self::Reinstall,
-            CanisterInstallMode::Upgrade => Self::Upgrade,
+            CanisterInstallMode::Upgrade(_) => Self::Upgrade,
         }
     }
 }
@@ -211,7 +209,7 @@ impl DfxOrbit {
         let mode = match op.mode {
             CanisterInstallMode::Install => "Install",
             CanisterInstallMode::Reinstall => "Reinstall",
-            CanisterInstallMode::Upgrade => "Upgrade",
+            CanisterInstallMode::Upgrade(_) => "Upgrade",
         };
         writeln!(output, "Mode: {mode}")?;
 


### PR DESCRIPTION
## Summary

- `ChangeExternalCanisterOperationInput` gains two optional fields, `wasm_memory_persistence` and `skip_pre_upgrade`, plumbed through the API → internal model → `mgmt::CanisterInstallMode::Upgrade(Some(UpgradeFlags { … }))`.
- Without `wasm_memory_persistence = keep`, Motoko canisters that use Enhanced Orthogonal Persistence cannot be safely upgraded through Orbit — the IC defaults to `replace`, wiping their main memory.
- Fully backward-compatible: new fields are `opt`, legacy `CanisterUpgradeModeArgs` CBOR (empty map) still deserializes via `#[serde(default)]`.

## Motivation

The IC management canister's `install_code` accepts `CanisterUpgradeOptions` (containing `wasm_memory_persistence` and `skip_pre_upgrade`) when `mode` is `upgrade`. Until now, Orbit hard-coded this to `None`, which:

- Made it impossible to safely upgrade Motoko canisters using Enhanced Orthogonal Persistence — they require `wasm_memory_persistence = keep`, otherwise the IC clears their main memory on upgrade.
- Did not expose `skip_pre_upgrade`, useful for recovery scenarios where the existing `pre_upgrade` hook traps.

## What changed

- **Candid API** (`core/station/api`): new `WasmMemoryPersistence` variant; two new `opt` fields on `ChangeExternalCanisterOperationInput` and `ChangeExternalCanisterOperation`. `spec.did` and the wallet-generated `station.did{,.js,.d.ts}` mirror the additions.
- **Internal model** (`core/station/impl/src/models/request_operation.rs`): `CanisterUpgradeModeArgs` carries the two flag fields (with `#[serde(default)]` for backward-compat with legacy stored requests). `From<CanisterInstallMode>` now translates to `mgmt::CanisterInstallMode::Upgrade(Some(UpgradeFlags { … }))` when either field is set, or `Upgrade(None)` otherwise.
- **Mapper** (`core/station/impl/src/mappers/request_operation.rs`): the api↔impl conversions for the input and DTO route the flags through the upgrade variant.
- **dfx-orbit CLI** (`tools/dfx-orbit`): passes `None` for both fields when constructing requests (the CLI does not yet expose CLI flags for these — that can be a follow-up).
- **Tests**: five new unit tests covering mapper round-trip, mgmt translation, install/reinstall ignoring the flags, and legacy CBOR deserialization. The existing `check_candid_interface` test confirms `spec.did` matches the generated service.

## Test plan

- [x] `cargo test -p station --lib` — 388 unit tests pass, including new mapper tests and `check_candid_interface`.
- [x] `cargo test --workspace --lib --bins --exclude integration-tests` — 651 tests pass, 0 failures.
- [x] `cargo clippy --workspace --all-targets` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] PocketIC integration tests — not run locally (no PocketIC binary present); CI will exercise them.
- [ ] Manual smoke test: upgrade a Motoko EOP canister via Orbit with `wasm_memory_persistence = Keep` and confirm stable state is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)