### PR TITLE
fix(wallet): playground II login and local reproducible-build fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 Dockerfile
-node_modules
+**/node_modules
 docs/old
 dist
 target

--- a/apps/wallet/src/configs/init.config.ts
+++ b/apps/wallet/src/configs/init.config.ts
@@ -30,7 +30,13 @@ const appInitConfig: AppInitConfig = {
   isProduction: !!import.meta.env.PROD,
   apiGatewayUrl: new URL(import.meta.env.PROD ? 'https://icp-api.io' : 'http://localhost:4943'),
   httpGatewayUrl: getHttpGatewayUrl(import.meta.env.PROD),
-  derivationOrigin: import.meta.env.PROD ? 'https://orbitwallet.io' : undefined,
+  // Only the production build mode derives the identity from the legacy domain; other
+  // IC-hosted build modes (e.g. playground, testing) authenticate against their own origin,
+  // which is not listed in the production domain's ii-alternative-origins.
+  derivationOrigin:
+    import.meta.env.PROD && import.meta.env.APP_BUILD_MODE === 'production'
+      ? 'https://orbitwallet.io'
+      : undefined,
   marketingSiteUrl: import.meta.env.APP_MARKETING_SITE_URL,
   locale: {
     default: defaultLocale,

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,4 +1,7 @@
 {
+  "app_marketing": {
+    "production": "kguhj-fyaaa-aaaaa-qad6a-cai"
+  },
   "app_wallet": {
     "playground": "bxkhk-6yaaa-aaaal-ai6va-cai",
     "production": "5fu67-giaaa-aaaal-ajbla-cai",
@@ -9,10 +12,8 @@
     "production": "5mxvd-qaaaa-aaaal-ajbkq-cai",
     "testing": "lotbt-qqaaa-aaaal-aduzq-cai"
   },
-  "app_marketing": {
-    "production": "kguhj-fyaaa-aaaaa-qad6a-cai"
-  },
   "docs_portal": {
+    "playground": "d537j-aaaaa-aaaal-asz5q-cai",
     "production": "bp6mw-eqaaa-aaaac-ahroq-cai"
   },
   "wasm_chunk_store": {

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -56,8 +56,9 @@ function deterministic_build() {
   local project_name=$1
   local target=$2
 
-  # Build the canister
-  docker build --build-arg BUILD_MODE=$BUILD_MODE -t orbit-$project_name --target $target . --platform=linux/amd64
+  # Build the canister. Provenance attestations are disabled so the output is a single
+  # manifest that `docker create` can resolve on non-amd64 hosts (e.g. Apple Silicon).
+  docker build --build-arg BUILD_MODE=$BUILD_MODE -t orbit-$project_name --target $target . --platform=linux/amd64 --provenance=false
 
   # Create a container to extract the generated artifacts
   docker create --name orbit-$project_name-container orbit-$project_name


### PR DESCRIPTION
## Summary

Fixes found while restoring the wiped playground environment (control_panel had run out of cycles and lost its module) and redeploying it end to end.

### 1. Internet Identity "Unverified origin" on playground/testing builds
Since the orbit.global domain migration (#520), `derivationOrigin` was gated only on `import.meta.env.PROD`, which is `true` for **all** IC-hosted build modes — playground and testing included (`.env` sets `APP_MODE=production` and the mode env files don't override it). Those builds therefore asked II to derive from `https://orbitwallet.io`, whose `/.well-known/ii-alternative-origins` only lists `https://app.orbit.global`, so II rejected every playground/testing login with **Unverified origin**. `derivationOrigin` is now only set when the build mode is `production`; other modes authenticate against their own origin (the pre-#520 behavior). Verified live on the redeployed playground wallet.

### 2. Local `./scripts/docker-build.sh` failures from dirty working trees
- `.dockerignore` only excluded the repo-root `node_modules`; Docker patterns are not recursive, so nested installs (`apps/wallet`, `docs`, `cli`) leaked host pnpm symlinks into the build context and corrupted the in-image install (`Cannot find module .../vite/bin/vite.js`). Now `**/node_modules`.
- On Apple Silicon, buildx default provenance attestations produce a manifest list that the artifact-extraction `docker create` can't resolve for `linux/amd64` (`no match for platform`). Disabled with `--provenance=false`.

### 3. Playground `docs_portal` canister id
`scripts/deploy.sh --playground` created the canister during the environment restore; this records its id (`d537j-aaaaa-aaaal-asz5q-cai`).

## Test plan
- Wallet rebuilt with `BUILD_MODE=playground` and synced to the playground canister: bundle bakes `derivationOrigin: undefined`, II login no longer shows "Unverified origin".
- Production behavior unchanged: `PROD && APP_BUILD_MODE === 'production'` still yields `https://orbitwallet.io`.
- `docker-build.sh --wallet-dapp/--control-panel` run clean on macOS (arm64) with nested `node_modules` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)