### PR TITLE
fix(cli): emit station IDL factory as CommonJS

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "expose": "pnpm link --global",
     "test": "vitest run",
     "generate-types": "didc bind --target ts ../core/control-panel/api/spec.did > ./src/generated/control_panel.d.ts",
-    "generate-station-types": "didc bind --target ts ../core/station/api/spec.did > ./src/audit/generated/station.did.d.ts && didc bind --target js ../core/station/api/spec.did > ./src/audit/generated/station.did.js && cp ../core/station/api/spec.did ./src/audit/generated/station.did"
+    "generate-station-types": "didc bind --target ts ../core/station/api/spec.did > ./src/audit/generated/station.did.d.ts && didc bind --target js ../core/station/api/spec.did | sed -E 's/^export const ([a-zA-Z_]+)/exports.\\1/g' > ./src/audit/generated/station.did.js && cp ../core/station/api/spec.did ./src/audit/generated/station.did"
   },
   "devDependencies": {
     "commander": "12.1.0",

--- a/cli/src/audit/generated/station.did.js
+++ b/cli/src/audit/generated/station.did.js
@@ -1,4 +1,4 @@
-export const idlFactory = ({ IDL }) => {
+exports.idlFactory = ({ IDL }) => {
   const RequestPolicyRule = IDL.Rec();
   const RequestPolicyRuleResult = IDL.Rec();
   const SystemUpgrade = IDL.Record({ 'name' : IDL.Opt(IDL.Text) });
@@ -1900,7 +1900,7 @@ export const idlFactory = ({ IDL }) => {
     'system_info' : IDL.Func([], [SystemInfoResult], ['query']),
   });
 };
-export const init = ({ IDL }) => {
+exports.init = ({ IDL }) => {
   const RequestPolicyRule = IDL.Rec();
   const SystemUpgrade = IDL.Record({ 'name' : IDL.Opt(IDL.Text) });
   const UUID = IDL.Text;


### PR DESCRIPTION
## Summary

- `cli/src/audit/generated/station.did.js` (vendored from `didc bind --target js`) uses ES module syntax. The cli package is plain CommonJS.
- On Node ≤ 20.18 — the version pinned by `.nvmrc` and the one CI uses — `require()` of that file throws `SyntaxError: Unexpected token 'export'` at module-load time. **Every** orbit-cli invocation fails: `registry publish`, `release publish`, `audit`, even `--help`.
- This is also the underlying cause of #638's e2e regression (`disaster-recovery.spec.ts › can recover uninstalled station` failing at \`execSync(\`orbit-cli registry publish --app station\`)\`).

## Motivation

Newer Node versions (≥ 20.20, backported from Node 22's \`--experimental-detect-module\`) silently auto-detect ESM in \`.js\` files, which masked the problem locally during development. CI's pinned Node 20.18 has no such fallback.

## What changed

- **`cli/src/audit/generated/station.did.js`** — transformed via a single sed substitution: \`export const X = ...\` → \`exports.X = ...\`. Two top-level exports affected: \`idlFactory\` and \`init\`.
- **`cli/package.json` (\`generate-station-types\`)** — same sed pipe added to the regen script so future re-generations from \`spec.did\` don't reintroduce the breakage.

## Test plan

- [x] \`pnpm --filter orbit-cli build\` — clean.
- [x] \`pnpm --filter orbit-cli test\` — 52 vitest cases pass (no test surface touched).
- [x] \`node cli/dist/cli.js registry --help\` — loads cleanly (was failing on Node 20.18 with the syntax error).
- [x] \`node cli/dist/cli.js audit --help\` — loads cleanly.
- [ ] CI \`e2e-tests:required\` — should now get past \`orbit-cli registry publish\` to whatever the actual disaster-recovery test does.

Follow-up to #638.