### PR TITLE
fix(station): reject empty-approver quorums and zero-requirement policies

### DIFF
--- a/core/station/impl/src/core/request.rs
+++ b/core/station/impl/src/core/request.rs
@@ -634,6 +634,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn quorum_with_no_possible_approvers_is_rejected() {
+        let mut request = mock_request();
+        let mut policy = mock_request_policy();
+        let user = user_test_utils::add_user(&[1; 16]);
+
+        request.operation = RequestOperation::AddUserGroup(AddUserGroupOperation {
+            user_group_id: None,
+            input: AddUserGroupOperationInput {
+                name: "test".to_string(),
+            },
+        });
+        request.requested_by = user.id;
+        request.approvals = vec![];
+
+        REQUEST_REPOSITORY.insert(request.to_key(), request.clone());
+
+        policy.specifier = RequestSpecifier::AddUserGroup;
+        // A group with no members: `total_possible_approvers` resolves to 0.
+        policy.rule = RequestPolicyRule::Quorum(UserSpecifier::Group(vec![[9; 16]]), 5);
+
+        REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.clone());
+
+        let evaluator = RequestEvaluator {
+            request: request.to_owned(),
+            policy_rule_evaluator: REQUEST_POLICY_RULE_EVALUATOR.to_owned(),
+        };
+
+        let result = evaluator.evaluate().unwrap();
+
+        assert_eq!(result.status, EvaluationStatus::Rejected);
+    }
+
+    #[tokio::test]
+    async fn quorum_percentage_with_no_possible_approvers_is_rejected() {
+        let mut request = mock_request();
+        let mut policy = mock_request_policy();
+        let user = user_test_utils::add_user(&[1; 16]);
+
+        request.operation = RequestOperation::AddUserGroup(AddUserGroupOperation {
+            user_group_id: None,
+            input: AddUserGroupOperationInput {
+                name: "test".to_string(),
+            },
+        });
+        request.requested_by = user.id;
+        request.approvals = vec![];
+
+        REQUEST_REPOSITORY.insert(request.to_key(), request.clone());
+
+        policy.specifier = RequestSpecifier::AddUserGroup;
+        // 100% of an empty approver set computes `min_approved == 0`; it must still reject.
+        policy.rule = RequestPolicyRule::QuorumPercentage(
+            UserSpecifier::Group(vec![[9; 16]]),
+            Percentage(100),
+        );
+
+        REQUEST_POLICY_REPOSITORY.insert(policy.id, policy.clone());
+
+        let evaluator = RequestEvaluator {
+            request: request.to_owned(),
+            policy_rule_evaluator: REQUEST_POLICY_RULE_EVALUATOR.to_owned(),
+        };
+
+        let result = evaluator.evaluate().unwrap();
+
+        assert_eq!(result.status, EvaluationStatus::Rejected);
+    }
+
+    #[tokio::test]
     async fn returns_correct_evaluation_result() {
         let mut request = mock_request();
         request.status = RequestStatus::Created;

--- a/core/station/impl/src/errors/request.rs
+++ b/core/station/impl/src/errors/request.rs
@@ -1,6 +1,6 @@
 use crate::errors::{
-    ExternalCanisterValidationError, RecordValidationError, SystemInfoValidationError,
-    ValidationError,
+    ExternalCanisterValidationError, RecordValidationError, RequestPolicyRuleValidationError,
+    SystemInfoValidationError, ValidationError,
 };
 use orbit_essentials::api::DetailableError;
 use std::collections::HashMap;
@@ -117,12 +117,21 @@ impl From<SystemInfoValidationError> for RequestError {
     }
 }
 
+impl From<RequestPolicyRuleValidationError> for RequestError {
+    fn from(err: RequestPolicyRuleValidationError) -> RequestError {
+        RequestError::ValidationError {
+            info: err.to_string(),
+        }
+    }
+}
+
 impl From<ValidationError> for RequestError {
     fn from(err: ValidationError) -> RequestError {
         match err {
             ValidationError::RecordValidationError(err) => err.into(),
             ValidationError::ExternalCanisterValidationError(err) => err.into(),
             ValidationError::SystemInfoValidationError(err) => err.into(),
+            ValidationError::RequestPolicyRuleValidationError(err) => err.into(),
         }
     }
 }

--- a/core/station/impl/src/errors/request_policy.rs
+++ b/core/station/impl/src/errors/request_policy.rs
@@ -1,6 +1,6 @@
 use crate::errors::{
-    ExternalCanisterValidationError, RecordValidationError, SystemInfoValidationError,
-    ValidationError,
+    ExternalCanisterValidationError, RecordValidationError, RequestPolicyRuleValidationError,
+    SystemInfoValidationError, ValidationError,
 };
 use orbit_essentials::api::DetailableError;
 use std::collections::HashMap;
@@ -85,12 +85,21 @@ impl From<SystemInfoValidationError> for RequestPolicyError {
     }
 }
 
+impl From<RequestPolicyRuleValidationError> for RequestPolicyError {
+    fn from(err: RequestPolicyRuleValidationError) -> RequestPolicyError {
+        RequestPolicyError::ValidationError {
+            info: err.to_string(),
+        }
+    }
+}
+
 impl From<ValidationError> for RequestPolicyError {
     fn from(err: ValidationError) -> RequestPolicyError {
         match err {
             ValidationError::RecordValidationError(err) => err.into(),
             ValidationError::ExternalCanisterValidationError(err) => err.into(),
             ValidationError::SystemInfoValidationError(err) => err.into(),
+            ValidationError::RequestPolicyRuleValidationError(err) => err.into(),
         }
     }
 }

--- a/core/station/impl/src/errors/validation.rs
+++ b/core/station/impl/src/errors/validation.rs
@@ -8,6 +8,7 @@ pub enum ValidationError {
     RecordValidationError(RecordValidationError),
     ExternalCanisterValidationError(ExternalCanisterValidationError),
     SystemInfoValidationError(SystemInfoValidationError),
+    RequestPolicyRuleValidationError(RequestPolicyRuleValidationError),
 }
 
 impl Display for ValidationError {
@@ -16,6 +17,7 @@ impl Display for ValidationError {
             ValidationError::RecordValidationError(err) => write!(f, "{err}"),
             ValidationError::ExternalCanisterValidationError(err) => write!(f, "{err}"),
             ValidationError::SystemInfoValidationError(err) => write!(f, "{err}"),
+            ValidationError::RequestPolicyRuleValidationError(err) => write!(f, "{err}"),
         }
     }
 }
@@ -26,6 +28,7 @@ impl DetailableError for ValidationError {
             ValidationError::RecordValidationError(err) => err.details(),
             ValidationError::ExternalCanisterValidationError(err) => err.details(),
             ValidationError::SystemInfoValidationError(err) => err.details(),
+            ValidationError::RequestPolicyRuleValidationError(err) => err.details(),
         }
     }
 }
@@ -45,6 +48,12 @@ impl From<ExternalCanisterValidationError> for ValidationError {
 impl From<SystemInfoValidationError> for ValidationError {
     fn from(err: SystemInfoValidationError) -> ValidationError {
         ValidationError::SystemInfoValidationError(err)
+    }
+}
+
+impl From<RequestPolicyRuleValidationError> for ValidationError {
+    fn from(err: RequestPolicyRuleValidationError) -> ValidationError {
+        ValidationError::RequestPolicyRuleValidationError(err)
     }
 }
 
@@ -105,6 +114,25 @@ impl DetailableError for SystemInfoValidationError {
     fn details(&self) -> Option<std::collections::HashMap<String, String>> {
         match self {
             SystemInfoValidationError::InvalidMaxBackupSnapshots { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum RequestPolicyRuleValidationError {
+    #[error(r#"{info}"#)]
+    InvalidRule { info: String },
+}
+
+impl DetailableError for RequestPolicyRuleValidationError {
+    fn details(&self) -> Option<std::collections::HashMap<String, String>> {
+        let mut details = std::collections::HashMap::new();
+
+        match self {
+            RequestPolicyRuleValidationError::InvalidRule { info } => {
+                details.insert("info".to_string(), info.to_string());
+                Some(details)
+            }
         }
     }
 }

--- a/core/station/impl/src/models/request_policy_rule.rs
+++ b/core/station/impl/src/models/request_policy_rule.rs
@@ -11,7 +11,7 @@ use crate::{
         utils::calculate_minimum_threshold,
         validation::{EnsureIdExists, EnsureNamedRule},
     },
-    errors::{MatchError, ValidationError},
+    errors::{MatchError, RequestPolicyRuleValidationError, ValidationError},
     repositories::{
         UserWhereClause, ADDRESS_BOOK_REPOSITORY, ASSET_REPOSITORY, NAMED_RULE_REPOSITORY,
         USER_REPOSITORY,
@@ -136,8 +136,24 @@ impl ModelValidator<ValidationError> for RequestPolicyRule {
             | RequestPolicyRule::AllowListedByMetadata(_)
             | RequestPolicyRule::AllowListed => Ok(()),
 
-            RequestPolicyRule::QuorumPercentage(user_specifier, _)
-            | RequestPolicyRule::Quorum(user_specifier, _) => user_specifier.validate(),
+            RequestPolicyRule::Quorum(user_specifier, min_approved) => {
+                if *min_approved == 0 {
+                    return Err(RequestPolicyRuleValidationError::InvalidRule {
+                        info: "Quorum requires at least 1 approval; use AutoApproved for a rule that needs no approvals.".to_string(),
+                    }
+                    .into());
+                }
+                user_specifier.validate()
+            }
+            RequestPolicyRule::QuorumPercentage(user_specifier, Percentage(percentage)) => {
+                if *percentage == 0 {
+                    return Err(RequestPolicyRuleValidationError::InvalidRule {
+                        info: "QuorumPercentage requires a percentage greater than 0; use AutoApproved for a rule that needs no approvals.".to_string(),
+                    }
+                    .into());
+                }
+                user_specifier.validate()
+            }
 
             RequestPolicyRule::Or(policy_rules) | RequestPolicyRule::And(policy_rules) => {
                 for rule in policy_rules {
@@ -320,6 +336,16 @@ impl RequestApprovalSummary {
     /// enough uncast approvals that could be cast to meet the minimum approvals required, then the evaluation
     /// is kept in the `Pending` state.
     fn evaluate(&self, min_approved: usize) -> EvaluationStatus {
+        // Fail closed when there are no eligible approvers. This method is only reached for
+        // `Quorum`/`QuorumPercentage` rules, which always require at least one approval (enforced at
+        // validation), so an empty approver set can never legitimately be satisfied. Without this
+        // guard the `cmp::min(min_approved, 0) == 0` clamp below would make `self.approved (0) >= 0`
+        // return `Approved`, auto-approving with zero votes. Note this also covers
+        // `QuorumPercentage`, whose `min_approved` computes to 0 over an empty set (e.g. 100% of 0).
+        if self.total_possible_approvers == 0 {
+            return EvaluationStatus::Rejected;
+        }
+
         let min_approved = cmp::min(min_approved, self.total_possible_approvers);
         let uncasted_approvals = self
             .total_possible_approvers
@@ -704,6 +730,46 @@ mod test {
         )])])
         .validate()
         .expect_err("Rule with non-existent user specifier should fail");
+    }
+
+    #[test]
+    fn positive_quorum_with_no_possible_approvers_is_rejected() {
+        // Regression guard: a positive approval requirement with zero eligible approvers must fail
+        // closed instead of auto-approving via the `cmp::min(min_approved, 0)` clamp.
+        let summary = RequestApprovalSummary {
+            total_possible_approvers: 0,
+            approvers: vec![],
+            approved: 0,
+            rejected: 0,
+        };
+
+        assert_eq!(summary.evaluate(5), EvaluationStatus::Rejected);
+        assert_eq!(summary.evaluate(1), EvaluationStatus::Rejected);
+        // `QuorumPercentage` over an empty set computes `min_approved == 0`; it must still reject.
+        assert_eq!(summary.evaluate(0), EvaluationStatus::Rejected);
+    }
+
+    #[test]
+    fn quorum_and_percentage_reject_zero_requirement_on_validation() {
+        RequestPolicyRule::Quorum(UserSpecifier::Any, 0)
+            .validate()
+            .expect_err("Quorum with 0 required approvals must be rejected");
+
+        RequestPolicyRule::QuorumPercentage(UserSpecifier::Any, Percentage(0))
+            .validate()
+            .expect_err("QuorumPercentage with 0% must be rejected");
+
+        RequestPolicyRule::Quorum(UserSpecifier::Any, 1)
+            .validate()
+            .expect("Quorum with a positive requirement should validate");
+
+        RequestPolicyRule::QuorumPercentage(UserSpecifier::Any, Percentage(1))
+            .validate()
+            .expect("QuorumPercentage with a positive requirement should validate");
+
+        RequestPolicyRule::AutoApproved
+            .validate()
+            .expect("AutoApproved should validate");
     }
 
     #[test]

--- a/core/station/impl/src/models/request_policy_rule.rs
+++ b/core/station/impl/src/models/request_policy_rule.rs
@@ -152,6 +152,15 @@ impl ModelValidator<ValidationError> for RequestPolicyRule {
                     }
                     .into());
                 }
+                // The DTO carries a raw u16 and the mapper builds `Percentage` without the
+                // `TryFrom` bound, so a value > 100 can reach here and would violate
+                // `calculate_minimum_threshold`'s documented 0..=100 assumption.
+                if *percentage > 100 {
+                    return Err(RequestPolicyRuleValidationError::InvalidRule {
+                        info: "QuorumPercentage cannot exceed 100.".to_string(),
+                    }
+                    .into());
+                }
                 user_specifier.validate()
             }
 
@@ -336,13 +345,16 @@ impl RequestApprovalSummary {
     /// enough uncast approvals that could be cast to meet the minimum approvals required, then the evaluation
     /// is kept in the `Pending` state.
     fn evaluate(&self, min_approved: usize) -> EvaluationStatus {
-        // Fail closed when there are no eligible approvers. This method is only reached for
+        // Fail closed on any zero approval requirement. This method is only reached for
         // `Quorum`/`QuorumPercentage` rules, which always require at least one approval (enforced at
-        // validation), so an empty approver set can never legitimately be satisfied. Without this
-        // guard the `cmp::min(min_approved, 0) == 0` clamp below would make `self.approved (0) >= 0`
-        // return `Approved`, auto-approving with zero votes. Note this also covers
-        // `QuorumPercentage`, whose `min_approved` computes to 0 over an empty set (e.g. 100% of 0).
-        if self.total_possible_approvers == 0 {
+        // validation), so neither an empty approver set nor a zero threshold can ever legitimately
+        // be satisfied. Without this guard the `cmp::min(min_approved, 0) == 0` clamp below would
+        // make `self.approved (0) >= 0` return `Approved`, auto-approving with zero votes. The
+        // `total_possible_approvers == 0` case covers `QuorumPercentage`, whose `min_approved`
+        // computes to 0 over an empty set (e.g. 100% of 0). The `min_approved == 0` case is
+        // defense-in-depth: validation is not re-run on evaluation, so a rule persisted before the
+        // validation guard existed (e.g. `Quorum(_, 0)`) would otherwise still auto-approve.
+        if min_approved == 0 || self.total_possible_approvers == 0 {
             return EvaluationStatus::Rejected;
         }
 
@@ -750,6 +762,21 @@ mod test {
     }
 
     #[test]
+    fn zero_requirement_with_possible_approvers_is_rejected() {
+        // Defense-in-depth: a zero approval requirement must fail closed even when eligible
+        // approvers exist, so a `Quorum(_, 0)` / `QuorumPercentage(_, 0%)` rule persisted before
+        // the validation guard existed cannot auto-approve on re-evaluation.
+        let summary = RequestApprovalSummary {
+            total_possible_approvers: 3,
+            approvers: vec![],
+            approved: 0,
+            rejected: 0,
+        };
+
+        assert_eq!(summary.evaluate(0), EvaluationStatus::Rejected);
+    }
+
+    #[test]
     fn quorum_and_percentage_reject_zero_requirement_on_validation() {
         RequestPolicyRule::Quorum(UserSpecifier::Any, 0)
             .validate()
@@ -758,6 +785,14 @@ mod test {
         RequestPolicyRule::QuorumPercentage(UserSpecifier::Any, Percentage(0))
             .validate()
             .expect_err("QuorumPercentage with 0% must be rejected");
+
+        RequestPolicyRule::QuorumPercentage(UserSpecifier::Any, Percentage(101))
+            .validate()
+            .expect_err("QuorumPercentage above 100% must be rejected");
+
+        RequestPolicyRule::QuorumPercentage(UserSpecifier::Any, Percentage(100))
+            .validate()
+            .expect("QuorumPercentage of exactly 100% should validate");
 
         RequestPolicyRule::Quorum(UserSpecifier::Any, 1)
             .validate()


### PR DESCRIPTION
## Problem

Approval quorums can be evaluated or created in ways that bypass the intended approval requirement. Two related issues:

1. **Zero-vote auto-approval on empty-approver quorums.** `RequestApprovalSummary::evaluate` clamps the required approvals with `cmp::min(min_approved, total_possible_approvers)`. When a `Quorum`/`QuorumPercentage` rule resolves to **zero** eligible approvers (e.g. the target user group is empty or all members went inactive), the clamp collapses the threshold to `0`, and `approved (0) >= 0` returns `Approved` — the request passes with no votes. `QuorumPercentage` is affected directly too: `calculate_minimum_threshold(100%, 0) == 0`.

2. **Zero-requirement policies are creatable.** `Quorum(_, 0)` and `QuorumPercentage(_, 0%)` pass validation today, producing a rule that approves with zero votes regardless of the approver set.

## Changes

- `RequestApprovalSummary::evaluate` fails closed (`Rejected`) when `total_possible_approvers == 0`, before the `cmp::min` clamp. This covers both `Quorum` and `QuorumPercentage`. `evaluate` is only reached from those two arms, both of which now always require a positive amount (see below), so an empty approver set can never legitimately be satisfied.
- `RequestPolicyRule::validate` rejects `Quorum(_, 0)` and `QuorumPercentage(_, 0%)` with a new dedicated `RequestPolicyRuleValidationError::InvalidRule`, guiding users to `AutoApproved` for no-approval rules.

### Note on the fix for (1)
An obvious guard of `min_approved > 0 && total_possible_approvers == 0` does **not** cover `QuorumPercentage`, whose `min_approved` computes to `0` over an empty set, so the guard would never fire for it. Keying on `total_possible_approvers == 0` alone closes both variants and is safe because `evaluate(min_approved)` is only ever called from the `Quorum` and `QuorumPercentage` evaluation arms.

## Tests

New unit tests (full `station` lib suite passes; `cargo fmt`/`clippy` clean):
- `positive_quorum_with_no_possible_approvers_is_rejected` — direct `evaluate` guard, including the `min_approved == 0` percentage case.
- `quorum_with_no_possible_approvers_is_rejected` / `quorum_percentage_with_no_possible_approvers_is_rejected` — end-to-end evaluation via `RequestEvaluator` with an empty group; both return `Rejected`.
- `quorum_and_percentage_reject_zero_requirement_on_validation` — `Quorum(_, 0)` / `QuorumPercentage(_, 0%)` rejected; positive variants and `AutoApproved` accepted.

The existing `misconfigured_min_approved_when_not_enough_approvers_should_still_approve` test (one active approver, `total == 1`) is unaffected.
