### PR TITLE
fix(upgrader): reject invalid disaster recovery committee quorum

### DIFF
--- a/core/upgrader/impl/src/errors/mod.rs
+++ b/core/upgrader/impl/src/errors/mod.rs
@@ -5,6 +5,7 @@ pub enum UpgraderApiError {
     Unauthorized,
     DisasterRecoveryInProgress,
     EmptyCommittee,
+    InvalidQuorum,
     Unexpected(String),
 }
 
@@ -29,6 +30,14 @@ impl From<UpgraderApiError> for ApiError {
             UpgraderApiError::EmptyCommittee => ApiError {
                 code: "EMPTY_COMMITTEE".to_owned(),
                 message: Some("Committee cannot be empty.".to_owned()),
+                details: None,
+            },
+            UpgraderApiError::InvalidQuorum => ApiError {
+                code: "INVALID_QUORUM".to_owned(),
+                message: Some(
+                    "Committee quorum must be greater than 0 and at most the number of committee members."
+                        .to_owned(),
+                ),
                 details: None,
             },
             UpgraderApiError::Unexpected(err) => ApiError {

--- a/core/upgrader/impl/src/services/disaster_recovery.rs
+++ b/core/upgrader/impl/src/services/disaster_recovery.rs
@@ -124,9 +124,13 @@ impl DisasterRecoveryService {
             return Err(UpgraderApiError::EmptyCommittee.into());
         }
 
-        // A quorum of 0 would approve disaster recovery with no votes; a quorum larger than the
-        // committee could never be met. Both are misconfigurations that must be rejected.
-        if committee.quorum == 0 || committee.quorum as usize > committee.users.len() {
+        // Membership is deduplicated by user id elsewhere in the service (and requests are keyed by
+        // user id), so the quorum must be validated against the number of unique voters, not the
+        // length of the (possibly duplicate-containing) users vec. A quorum of 0 would approve
+        // disaster recovery with no votes; a quorum larger than the unique membership could never
+        // be met. Both are misconfigurations that must be rejected.
+        let committee_set: HashSet<_> = committee.users.iter().map(|user| user.id).collect();
+        if committee.quorum == 0 || committee.quorum as usize > committee_set.len() {
             return Err(UpgraderApiError::InvalidQuorum.into());
         }
 
@@ -134,7 +138,6 @@ impl DisasterRecoveryService {
 
         // only retain recovery requests from committee members
         // who are in the new committee
-        let committee_set: HashSet<_> = committee.users.iter().map(|user| user.id).collect();
         value
             .recovery_requests
             .retain(|request| committee_set.contains(&request.user_id));
@@ -607,6 +610,16 @@ mod tests {
         committee.quorum = 1;
         dr.set_committee(committee)
             .expect("a positive quorum within the committee size must be accepted");
+
+        // Duplicate members must not inflate the effective quorum ceiling: 3 vec entries but only
+        // 2 unique voters, so a quorum of 3 is unreachable and must be rejected.
+        let mut committee = mock_committee();
+        committee.users[2].id = committee.users[1].id;
+        committee.quorum = 3;
+        let err = dr
+            .set_committee(committee)
+            .expect_err("quorum greater than the number of unique members must be rejected");
+        assert_eq!(err.code, "INVALID_QUORUM".to_string());
     }
 
     #[tokio::test]

--- a/core/upgrader/impl/src/services/disaster_recovery.rs
+++ b/core/upgrader/impl/src/services/disaster_recovery.rs
@@ -124,6 +124,12 @@ impl DisasterRecoveryService {
             return Err(UpgraderApiError::EmptyCommittee.into());
         }
 
+        // A quorum of 0 would approve disaster recovery with no votes; a quorum larger than the
+        // committee could never be met. Both are misconfigurations that must be rejected.
+        if committee.quorum == 0 || committee.quorum as usize > committee.users.len() {
+            return Err(UpgraderApiError::InvalidQuorum.into());
+        }
+
         value.committee = Some(committee.clone());
 
         // only retain recovery requests from committee members
@@ -570,6 +576,34 @@ mod tests {
         async fn stop(&self, _canister_id: Principal) -> Result<(), String> {
             Ok(())
         }
+    }
+
+    #[tokio::test]
+    async fn set_committee_rejects_invalid_quorum() {
+        let dr = DisasterRecoveryService {
+            installer: Arc::new(TestInstaller::default()),
+            storage: Default::default(),
+            logger: Default::default(),
+        };
+
+        // mock_committee has 3 members.
+        let mut committee = mock_committee();
+
+        committee.quorum = 0;
+        dr.set_committee(committee.clone())
+            .expect_err("quorum of 0 must be rejected");
+
+        committee.quorum = committee.users.len() as u16 + 1;
+        dr.set_committee(committee.clone())
+            .expect_err("quorum greater than the number of members must be rejected");
+
+        committee.quorum = committee.users.len() as u16;
+        dr.set_committee(committee.clone())
+            .expect("quorum equal to the number of members must be accepted");
+
+        committee.quorum = 1;
+        dr.set_committee(committee)
+            .expect("a positive quorum within the committee size must be accepted");
     }
 
     #[tokio::test]

--- a/core/upgrader/impl/src/services/disaster_recovery.rs
+++ b/core/upgrader/impl/src/services/disaster_recovery.rs
@@ -590,13 +590,16 @@ mod tests {
         let mut committee = mock_committee();
 
         committee.quorum = 0;
-        dr.set_committee(committee.clone())
+        let err = dr
+            .set_committee(committee.clone())
             .expect_err("quorum of 0 must be rejected");
+        assert_eq!(err.code, "INVALID_QUORUM".to_string());
 
         committee.quorum = committee.users.len() as u16 + 1;
-        dr.set_committee(committee.clone())
+        let err = dr
+            .set_committee(committee.clone())
             .expect_err("quorum greater than the number of members must be rejected");
-
+        assert_eq!(err.code, "INVALID_QUORUM".to_string());
         committee.quorum = committee.users.len() as u16;
         dr.set_committee(committee.clone())
             .expect("quorum equal to the number of members must be accepted");


### PR DESCRIPTION
## Change

`DisasterRecoveryService::set_committee` validated that a committee is non-empty, but not that its quorum is within range. It now also rejects `quorum == 0` and `quorum > users.len()` with a new `UpgraderApiError::InvalidQuorum` (code `INVALID_QUORUM`).

Neither is a configuration the recovery flow can act on sensibly, so both are rejected where the committee is set rather than surfacing later.

## Tests

- `set_committee_rejects_invalid_quorum` — `0` and `> members` rejected; `== members` and a valid positive quorum accepted.
