### PR TITLE
ci(release): add Deploy frontend workflow

### DIFF
--- a/.claude/rules/team-general
+++ b/.claude/rules/team-general
@@ -1,0 +1,1 @@
+/Users/mario.ruci/.identity-team-skills/rules/general

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -8,6 +8,10 @@ name: 'Deploy frontend'
 # environment's approval. Backends (station, upgrader, control-panel) are a
 # separate follow-up.
 #
+# These jobs deliberately install as little as possible. deploy-app needs only
+# gh, jq, docker, icx-asset and curl, so there is no Node/pnpm install here and
+# the npm dependency tree never enters the job that handles the signing key.
+#
 # The signing key is read from the `DEPLOY_IDENTITY_PEM` secret. Scope it per
 # environment: put the playground key on the `playground` environment and the
 # production key on the `production` environment, so each job only ever sees its
@@ -57,10 +61,6 @@ jobs:
           # This job downloads via gh, never pushes, so it does not need the
           # GITHUB_TOKEN left in .git/config.
           persist-credentials: false
-      - name: 'Setup Node'
-        uses: ./.github/actions/setup-node
-      - name: 'Install dependencies'
-        run: pnpm install --frozen-lockfile
       - name: 'Set up Docker'
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4
       - name: 'Install icx-asset'
@@ -106,10 +106,6 @@ jobs:
           # This job downloads via gh, never pushes, so it does not need the
           # GITHUB_TOKEN left in .git/config.
           persist-credentials: false
-      - name: 'Setup Node'
-        uses: ./.github/actions/setup-node
-      - name: 'Install dependencies'
-        run: pnpm install --frozen-lockfile
       - name: 'Install icx-asset'
         run: cargo install --locked icx-asset --version 0.29.0
       - name: 'Deploy to production'

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -12,8 +12,10 @@ name: 'Deploy frontend'
 # gh, jq, docker, icx-asset, shasum and curl, so there is no Node/pnpm install
 # here and the npm dependency tree never enters the job that handles the key.
 #
-# The signing key is read from the `DEPLOY_IDENTITY_PEM` secret, scoped per
-# environment, so a job only ever sees its own key.
+# Each job reads its own secret, `DEPLOY_STAGING_IDENTITY_PEM` on the
+# `playground` environment and `DEPLOY_PRODUCTION_IDENTITY_PEM` on `production`,
+# so which key a job holds is obvious from the job and not from environment
+# scoping alone.
 #
 # Production is deliberately not wired up by default. The production key is not
 # held here; production is deployed from an operator machine with
@@ -77,7 +79,7 @@ jobs:
           DEPLOY_WALLET: ${{ inputs.wallet }}
           DEPLOY_MARKETING: ${{ inputs.marketing }}
           DEPLOY_DOCS: ${{ inputs.docs }}
-          DEPLOY_IDENTITY_PEM: ${{ secrets.DEPLOY_IDENTITY_PEM }}
+          IDENTITY_PEM: ${{ secrets.DEPLOY_STAGING_IDENTITY_PEM }}
         run: |
           set -euo pipefail
 
@@ -86,10 +88,10 @@ jobs:
           if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
           if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
           if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
-          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then echo "DEPLOY_IDENTITY_PEM secret is not set on the playground environment."; exit 1; fi
+          if [ -z "${IDENTITY_PEM:-}" ]; then echo "DEPLOY_STAGING_IDENTITY_PEM is not set on the playground environment."; exit 1; fi
 
           pem="$(mktemp)"; chmod 600 "$pem"
-          printf '%s\n' "$DEPLOY_IDENTITY_PEM" > "$pem"
+          printf '%s\n' "$IDENTITY_PEM" > "$pem"
           trap 'rm -f "$pem"' EXIT
 
           for app in "${apps[@]}"; do
@@ -100,7 +102,7 @@ jobs:
   production:
     name: 'production'
     needs: playground
-    if: ${{ inputs.promote_to_production == 'true' }}
+    if: ${{ inputs.promote_to_production }}
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -120,7 +122,7 @@ jobs:
           DEPLOY_WALLET: ${{ inputs.wallet }}
           DEPLOY_MARKETING: ${{ inputs.marketing }}
           DEPLOY_DOCS: ${{ inputs.docs }}
-          DEPLOY_IDENTITY_PEM: ${{ secrets.DEPLOY_IDENTITY_PEM }}
+          IDENTITY_PEM: ${{ secrets.DEPLOY_PRODUCTION_IDENTITY_PEM }}
         run: |
           set -euo pipefail
 
@@ -129,15 +131,15 @@ jobs:
           if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
           if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
           if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
-          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then
-            echo "No DEPLOY_IDENTITY_PEM on the production environment."
+          if [ -z "${IDENTITY_PEM:-}" ]; then
+            echo "No DEPLOY_PRODUCTION_IDENTITY_PEM on the production environment."
             echo "Production is deployed from an operator machine. See RELEASE.md:"
             echo "  ./scripts/deploy-app --app <app> --env production --tag latest --op <ref>"
             exit 1
           fi
 
           pem="$(mktemp)"; chmod 600 "$pem"
-          printf '%s\n' "$DEPLOY_IDENTITY_PEM" > "$pem"
+          printf '%s\n' "$IDENTITY_PEM" > "$pem"
           trap 'rm -f "$pem"' EXIT
 
           # Production deploys the released tagged artifact (deploy-app defaults

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       wallet:
-        description: 'Deploy the wallet app (wallet-dapp).'
+        description: 'Deploy the station frontend (wallet-dapp).'
         type: boolean
         default: true
       # marketing and docs have no playground canister, they exist on production
@@ -93,8 +93,8 @@ jobs:
           if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
           if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
 
-          # Only the wallet has a playground canister. Reject the others here
-          # rather than after the signing key has been written to disk.
+          # Only the station frontend has a playground canister. Reject the others
+          # here, rather than after the signing key has been written to disk.
           for app in "${apps[@]}"; do
             if [ "$app" != "wallet" ]; then
               echo "$app has no playground canister, it exists on production only."

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -31,12 +31,14 @@ on:
         description: 'Deploy the wallet app (wallet-dapp).'
         type: boolean
         default: true
+      # marketing and docs have no playground canister, they exist on production
+      # only, so they are not valid for a run of this workflow.
       marketing:
-        description: 'Deploy the landing page (marketing-dapp).'
+        description: 'Deploy the landing page (marketing-dapp). Production only, see RELEASE.md.'
         type: boolean
         default: false
       docs:
-        description: 'Deploy the docs site (docs-portal).'
+        description: 'Deploy the docs site (docs-portal). Production only, see RELEASE.md.'
         type: boolean
         default: false
       # Off by default: production is normally deployed from an operator machine,
@@ -88,6 +90,16 @@ jobs:
           if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
           if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
           if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
+
+          # Only the wallet has a playground canister. Reject the others here
+          # rather than after the signing key has been written to disk.
+          for app in "${apps[@]}"; do
+            if [ "$app" != "wallet" ]; then
+              echo "$app has no playground canister, it exists on production only."
+              echo "Untick it, or deploy it with: ./scripts/deploy-app --app $app --env production --op <ref>"
+              exit 1
+            fi
+          done
           if [ -z "${IDENTITY_PEM:-}" ]; then echo "DEPLOY_STAGING_IDENTITY_PEM is not set on the playground environment."; exit 1; fi
 
           pem="$(mktemp)"; chmod 600 "$pem"

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -9,8 +9,8 @@ name: 'Deploy frontend'
 # separate follow-up.
 #
 # These jobs deliberately install as little as possible. deploy-app needs only
-# gh, jq, docker, icx-asset and curl, so there is no Node/pnpm install here and
-# the npm dependency tree never enters the job that handles the signing key.
+# gh, jq, docker, icx-asset, shasum and curl, so there is no Node/pnpm install
+# here and the npm dependency tree never enters the job that handles the key.
 #
 # The signing key is read from the `DEPLOY_IDENTITY_PEM` secret, scoped per
 # environment, so a job only ever sees its own key.

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -12,10 +12,12 @@ name: 'Deploy frontend'
 # gh, jq, docker, icx-asset, shasum and curl, so there is no Node/pnpm install
 # here and the npm dependency tree never enters the job that handles the key.
 #
-# Each job reads its own secret, `DEPLOY_STAGING_IDENTITY_PEM` on the
+# Each job reads its own secret, `DEPLOY_PLAYGROUND_IDENTITY_PEM` on the
 # `playground` environment and `DEPLOY_PRODUCTION_IDENTITY_PEM` on `production`,
 # so which key a job holds is obvious from the job and not from environment
-# scoping alone.
+# scoping alone. The names track the networks in dfx.json. Note that `staging`
+# is a different network there, declared but with no canisters, so it is not a
+# synonym for playground and is deliberately not used here.
 #
 # Production is deliberately not wired up by default. The production key is not
 # held here; production is deployed from an operator machine with
@@ -81,7 +83,7 @@ jobs:
           DEPLOY_WALLET: ${{ inputs.wallet }}
           DEPLOY_MARKETING: ${{ inputs.marketing }}
           DEPLOY_DOCS: ${{ inputs.docs }}
-          IDENTITY_PEM: ${{ secrets.DEPLOY_STAGING_IDENTITY_PEM }}
+          IDENTITY_PEM: ${{ secrets.DEPLOY_PLAYGROUND_IDENTITY_PEM }}
         run: |
           set -euo pipefail
 
@@ -100,7 +102,7 @@ jobs:
               exit 1
             fi
           done
-          if [ -z "${IDENTITY_PEM:-}" ]; then echo "DEPLOY_STAGING_IDENTITY_PEM is not set on the playground environment."; exit 1; fi
+          if [ -z "${IDENTITY_PEM:-}" ]; then echo "DEPLOY_PLAYGROUND_IDENTITY_PEM is not set on the playground environment."; exit 1; fi
 
           pem="$(mktemp)"; chmod 600 "$pem"
           printf '%s\n' "$IDENTITY_PEM" > "$pem"

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -37,6 +37,12 @@ on:
 permissions:
   contents: read
 
+# One deploy run at a time. A second trigger queues instead of racing an
+# in-flight deploy of the same apps, and a running deploy is never cancelled.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   playground:
     name: 'playground'
@@ -48,6 +54,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # This job downloads via gh, never pushes, so it does not need the
+          # GITHUB_TOKEN left in .git/config.
+          persist-credentials: false
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
       - name: 'Install dependencies'
@@ -94,6 +103,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # This job downloads via gh, never pushes, so it does not need the
+          # GITHUB_TOKEN left in .git/config.
+          persist-credentials: false
       - name: 'Setup Node'
         uses: ./.github/actions/setup-node
       - name: 'Install dependencies'

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -1,0 +1,129 @@
+name: 'Deploy frontend'
+
+# Phase 3 of the release: deploy the built artifacts to the live canisters.
+#
+# Frontends only for now (wallet, marketing, docs). Pick any subset. The run
+# deploys the selection to playground first with no gate, then, if you asked to
+# promote, deploys the same selection to production behind the `production`
+# environment's approval. Backends (station, upgrader, control-panel) are a
+# separate follow-up.
+#
+# The signing key is read from the `DEPLOY_IDENTITY_PEM` secret. Scope it per
+# environment: put the playground key on the `playground` environment and the
+# production key on the `production` environment, so each job only ever sees its
+# own key. The production approval gate is configured in
+# Settings -> Environments -> production -> Required reviewers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      wallet:
+        description: 'Deploy the wallet app (wallet-dapp).'
+        type: boolean
+        default: true
+      marketing:
+        description: 'Deploy the landing page (marketing-dapp).'
+        type: boolean
+        default: false
+      docs:
+        description: 'Deploy the docs site (docs-portal).'
+        type: boolean
+        default: false
+      promote_to_production:
+        description: 'After playground, promote the same selection to production behind the approval gate. Uncheck for a playground-only run.'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  playground:
+    name: 'playground'
+    runs-on: ubuntu-latest
+    environment: playground
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: 'Setup Node'
+        uses: ./.github/actions/setup-node
+      - name: 'Install dependencies'
+        run: pnpm install --frozen-lockfile
+      - name: 'Set up Docker'
+        uses: docker/setup-docker-action@v4
+      - name: 'Install icx-asset'
+        run: cargo install --locked icx-asset --version 0.29.0
+      - name: 'Deploy to playground'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_WALLET: ${{ inputs.wallet }}
+          DEPLOY_MARKETING: ${{ inputs.marketing }}
+          DEPLOY_DOCS: ${{ inputs.docs }}
+          DEPLOY_IDENTITY_PEM: ${{ secrets.DEPLOY_IDENTITY_PEM }}
+        run: |
+          set -euo pipefail
+
+          apps=()
+          if [ "$DEPLOY_WALLET" = "true" ]; then apps+=(wallet); fi
+          if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
+          if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
+          if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
+          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then echo "DEPLOY_IDENTITY_PEM secret is not set on the playground environment."; exit 1; fi
+
+          pem="$(mktemp)"; chmod 600 "$pem"
+          printf '%s\n' "$DEPLOY_IDENTITY_PEM" > "$pem"
+          trap 'rm -f "$pem"' EXIT
+
+          for app in "${apps[@]}"; do
+            echo "==> deploying $app to playground"
+            ./scripts/deploy-app --app "$app" --env playground --pem "$pem" --yes
+          done
+
+  production:
+    name: 'production'
+    needs: playground
+    if: ${{ inputs.promote_to_production }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: 'Setup Node'
+        uses: ./.github/actions/setup-node
+      - name: 'Install dependencies'
+        run: pnpm install --frozen-lockfile
+      - name: 'Install icx-asset'
+        run: cargo install --locked icx-asset --version 0.29.0
+      - name: 'Deploy to production'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_WALLET: ${{ inputs.wallet }}
+          DEPLOY_MARKETING: ${{ inputs.marketing }}
+          DEPLOY_DOCS: ${{ inputs.docs }}
+          DEPLOY_IDENTITY_PEM: ${{ secrets.DEPLOY_IDENTITY_PEM }}
+        run: |
+          set -euo pipefail
+
+          apps=()
+          if [ "$DEPLOY_WALLET" = "true" ]; then apps+=(wallet); fi
+          if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
+          if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
+          if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
+          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then echo "DEPLOY_IDENTITY_PEM secret is not set on the production environment."; exit 1; fi
+
+          pem="$(mktemp)"; chmod 600 "$pem"
+          printf '%s\n' "$DEPLOY_IDENTITY_PEM" > "$pem"
+          trap 'rm -f "$pem"' EXIT
+
+          # Production deploys the released tagged artifact (deploy-app defaults
+          # to --tag latest for production), not a local build.
+          for app in "${apps[@]}"; do
+            echo "==> deploying $app to production"
+            ./scripts/deploy-app --app "$app" --env production --pem "$pem" --yes
+          done

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -85,7 +85,7 @@ jobs:
   production:
     name: 'production'
     needs: playground
-    if: ${{ inputs.promote_to_production }}
+    if: ${{ inputs.promote_to_production == 'true' }}
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -44,7 +44,7 @@ jobs:
     environment: playground
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -53,7 +53,7 @@ jobs:
       - name: 'Install dependencies'
         run: pnpm install --frozen-lockfile
       - name: 'Set up Docker'
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4
       - name: 'Install icx-asset'
         run: cargo install --locked icx-asset --version 0.29.0
       - name: 'Deploy to playground'
@@ -90,7 +90,7 @@ jobs:
     environment: production
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release-deploy-frontend.yaml
+++ b/.github/workflows/release-deploy-frontend.yaml
@@ -12,11 +12,15 @@ name: 'Deploy frontend'
 # gh, jq, docker, icx-asset and curl, so there is no Node/pnpm install here and
 # the npm dependency tree never enters the job that handles the signing key.
 #
-# The signing key is read from the `DEPLOY_IDENTITY_PEM` secret. Scope it per
-# environment: put the playground key on the `playground` environment and the
-# production key on the `production` environment, so each job only ever sees its
-# own key. The production approval gate is configured in
-# Settings -> Environments -> production -> Required reviewers.
+# The signing key is read from the `DEPLOY_IDENTITY_PEM` secret, scoped per
+# environment, so a job only ever sees its own key.
+#
+# Production is deliberately not wired up by default. The production key is not
+# held here; production is deployed from an operator machine with
+# `scripts/deploy-app --op`, which keeps that key out of this repo entirely. See
+# RELEASE.md. The production job below is kept so the wiring exists if that
+# decision is ever revisited: without a key on the `production` environment it
+# fails fast with a message instead of doing anything surprising.
 
 on:
   workflow_dispatch:
@@ -33,10 +37,12 @@ on:
         description: 'Deploy the docs site (docs-portal).'
         type: boolean
         default: false
+      # Off by default: production is normally deployed from an operator machine,
+      # not from here. Only useful if a production key is put on the environment.
       promote_to_production:
-        description: 'After playground, promote the same selection to production behind the approval gate. Uncheck for a playground-only run.'
+        description: 'Also run the production job. Leave unchecked unless production deploys have been moved into CI.'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -123,7 +129,12 @@ jobs:
           if [ "$DEPLOY_MARKETING" = "true" ]; then apps+=(marketing); fi
           if [ "$DEPLOY_DOCS" = "true" ]; then apps+=(docs); fi
           if [ "${#apps[@]}" -eq 0 ]; then echo "No app selected."; exit 1; fi
-          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then echo "DEPLOY_IDENTITY_PEM secret is not set on the production environment."; exit 1; fi
+          if [ -z "${DEPLOY_IDENTITY_PEM:-}" ]; then
+            echo "No DEPLOY_IDENTITY_PEM on the production environment."
+            echo "Production is deployed from an operator machine. See RELEASE.md:"
+            echo "  ./scripts/deploy-app --app <app> --env production --tag latest --op <ref>"
+            exit 1
+          fi
 
           pem="$(mktemp)"; chmod 600 "$pem"
           printf '%s\n' "$DEPLOY_IDENTITY_PEM" > "$pem"

--- a/scripts/deploy-app
+++ b/scripts/deploy-app
@@ -78,8 +78,8 @@ done
 [[ "$ENV" == "playground" || "$ENV" == "production" ]] || { usage; die "--env must be playground or production"; }
 [[ -n "$PEM" || -n "$OP_REF" ]] || { usage; die "a key is required: pass --pem or --op"; }
 [[ -z "$PEM" || -z "$OP_REF" ]] || die "pass only one of --pem / --op"
+[[ -z "$BUILD" || -z "$TAG" ]] || die "pass only one of --build / --tag"
 [[ -z "$PEM" || -f "$PEM" ]] || die "pem file not found: $PEM"
-
 cd "$ROOT"
 
 # A temp pem, only created when reading from 1Password, always removed on exit.

--- a/scripts/deploy-app
+++ b/scripts/deploy-app
@@ -82,9 +82,14 @@ done
 [[ -z "$PEM" || -f "$PEM" ]] || die "pem file not found: $PEM"
 cd "$ROOT"
 
-# A temp pem, only created when reading from 1Password, always removed on exit.
-TMP_PEM=""
-cleanup() { [[ -n "$TMP_PEM" ]] && rm -f "$TMP_PEM"; }
+# Scratch paths, always removed on exit: the pem (only when read from 1Password)
+# and the directory the tarball is unpacked into.
+TMP_PEM="" TMP_DIST=""
+cleanup() {
+  if [[ -n "$TMP_PEM" ]]; then rm -f "$TMP_PEM"; fi
+  if [[ -n "$TMP_DIST" ]]; then rm -rf "$TMP_DIST"; fi
+  return 0
+}
 trap cleanup EXIT
 
 CANISTER="$(jq -r ".${CANISTER_KEY[$APP]}.${ENV} // empty" canister_ids.json)"
@@ -154,14 +159,16 @@ else
   BUILD_MODE="$ENV" ./scripts/docker-build.sh "${BUILD_TARGET[$APP]}"
 fi
 
-# 2. Unpack.
+# 2. Unpack somewhere of our own. Unpacking beside the tarball would mean
+#    clearing artifacts/<app>/dist first, which is a real build output that
+#    something else may have put there.
 echo "==> unpacking"
-rm -rf "$DIR/dist" && mkdir -p "$DIR/dist"
-tar -xf "$TAR" -C "$DIR/dist"
+TMP_DIST="$(mktemp -d)"
+tar -xf "$TAR" -C "$TMP_DIST"
 
 # 3. Upload the assets (never deletes existing ones).
 echo "==> uploading to $CANISTER"
-icx-asset --pem "$PEM" --replica "$REPLICA" sync --no-delete "$CANISTER" "$DIR/dist"
+icx-asset --pem "$PEM" --replica "$REPLICA" sync --no-delete "$CANISTER" "$TMP_DIST"
 
 # 4. Verify the live version.
 if [[ -n "$SITE" ]]; then

--- a/scripts/deploy-app
+++ b/scripts/deploy-app
@@ -107,11 +107,16 @@ elif [[ -z "$BUILD" && -z "$TAG" ]]; then
   TAG="latest"
 fi
 
-# Resolve "latest" to the newest tag for this app.
+# Resolve "latest" to the newest stable release for this app. Pre-releases are
+# excluded twice: on the release flag, and by anchoring the version pattern,
+# because an unanchored match reads "-v0.8.0-rc.0" as "-v0.8.0" and yields a tag
+# that does not exist. Pass --tag explicitly to deploy a pre-release on purpose.
 if [[ "$TAG" == "latest" ]]; then
-  TAG="$(gh release list --repo "$REPO" --limit 200 \
-    | grep -oE "${TAG_PREFIX[$APP]}[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1)"
-  [[ -n "$TAG" ]] || die "could not resolve the latest ${TAG_PREFIX[$APP]} release"
+  TAG="$(gh release list --repo "$REPO" --limit 500 \
+    --json tagName,isPrerelease,isDraft \
+    --jq '.[] | select(.isPrerelease == false and .isDraft == false) | .tagName' \
+    | grep -E "^${TAG_PREFIX[$APP]}[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1)"
+  [[ -n "$TAG" ]] || die "could not resolve the latest stable ${TAG_PREFIX[$APP]} release"
 fi
 
 SOURCE="build (BUILD_MODE=$ENV)"; [[ -n "$TAG" ]] && SOURCE="download $TAG"

--- a/scripts/deploy-app
+++ b/scripts/deploy-app
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+# Deploy a single Orbit frontend app to an environment, end to end:
+#   resolve the canister -> get the artifact (download a tagged release, or build
+#   it per-network) -> unpack -> upload the assets -> verify the live version.
+#
+# One command in place of the manual download / build / unpack / icx-asset /
+# check-the-version dance. The wallet frontend bakes its environment config in at
+# build time, so playground is always built locally and production defaults to
+# the deterministic tagged artifact.
+#
+# The signing key can be a pem file (--pem) or read straight from 1Password
+# (--op op://Vault/Item/field), so nothing has to be saved to disk by hand.
+#
+# Needs: gh, jq, docker, icx-asset, curl (and op for --op).
+
+REPO="dfinity/orbit"
+REPLICA="https://icp0.io"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# app -> docker-build target, release tarball, canister_ids.json key, tag prefix
+declare -A BUILD_TARGET=([wallet]="--wallet-dapp" [marketing]="--marketing-dapp" [docs]="--docs-portal")
+declare -A TARBALL=([wallet]="wallet-dapp.tar.gz" [marketing]="marketing-dapp.tar.gz" [docs]="docs-portal.tar.gz")
+declare -A CANISTER_KEY=([wallet]="app_wallet" [marketing]="app_marketing" [docs]="docs_portal")
+declare -A TAG_PREFIX=([wallet]="@orbit/wallet-dapp-v" [marketing]="@orbit/marketing-dapp-v" [docs]="@orbit/docs-portal-v")
+# app:env -> public URL, for the post-deploy version check
+declare -A URL=(
+  [wallet:playground]="https://playground.orbitwallet.io"
+  [wallet:production]="https://app.orbit.global"
+  [marketing:production]="https://orbit.global"
+  [docs:production]="https://docs.orbit.global"
+)
+
+APP="" ENV="" PEM="" OP_REF="" TAG="" BUILD="" YES="" DRY=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --app <wallet|marketing|docs> --env <playground|production> (--pem <file> | --op <ref>) [options]
+
+Signing key (one is required):
+  --pem <file>    Path to the identity pem on disk.
+  --op <ref>      1Password secret reference, e.g. "op://Orbit Mgmt/orbit-mgmt/identity.pem".
+                  Read via the op CLI into a temp file that is deleted on exit.
+
+Where the build comes from (default: build for playground, download the tag for production):
+  --build         Build the artifact locally for --env (required for playground).
+  --tag <tag>     Download this release's artifact (production only). "latest" auto-resolves.
+
+Other:
+  --yes           Skip the confirmation prompt.
+  --dry-run       Show what would happen; upload nothing.
+
+Examples:
+  $0 --app wallet --env playground --op "op://Orbit Mgmt/orbit-mgmt/identity.pem"
+  $0 --app wallet --env production --tag latest --op "op://Orbit Mgmt/orbit-mgmt/identity.pem"
+EOF
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) APP="$2"; shift 2 ;;
+    --env) ENV="$2"; shift 2 ;;
+    --pem) PEM="$2"; shift 2 ;;
+    --op) OP_REF="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --build) BUILD=1; shift ;;
+    --yes) YES=1; shift ;;
+    --dry-run) DRY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "${BUILD_TARGET[$APP]:-}" ]] || { usage; die "--app must be one of: wallet marketing docs"; }
+[[ "$ENV" == "playground" || "$ENV" == "production" ]] || { usage; die "--env must be playground or production"; }
+[[ -n "$PEM" || -n "$OP_REF" ]] || { usage; die "a key is required: pass --pem or --op"; }
+[[ -z "$PEM" || -z "$OP_REF" ]] || die "pass only one of --pem / --op"
+[[ -z "$PEM" || -f "$PEM" ]] || die "pem file not found: $PEM"
+
+cd "$ROOT"
+
+# A temp pem, only created when reading from 1Password, always removed on exit.
+TMP_PEM=""
+cleanup() { [[ -n "$TMP_PEM" ]] && rm -f "$TMP_PEM"; }
+trap cleanup EXIT
+
+CANISTER="$(jq -r ".${CANISTER_KEY[$APP]}.${ENV} // empty" canister_ids.json)"
+[[ -n "$CANISTER" ]] || die "no canister id for ${CANISTER_KEY[$APP]}.${ENV} in canister_ids.json"
+SITE="${URL[$APP:$ENV]:-}"
+DIR="artifacts/${TARBALL[$APP]%.tar.gz}"
+TAR="$DIR/${TARBALL[$APP]}"
+
+# Decide the source. Playground must be built (its config is baked in and differs
+# from the released production artifact); production defaults to the tag.
+if [[ "$ENV" == "playground" ]]; then
+  [[ -z "$TAG" ]] || die "--tag is production-only: the released artifact is a production build. Use --build for playground."
+  BUILD=1
+elif [[ -z "$BUILD" && -z "$TAG" ]]; then
+  TAG="latest"
+fi
+
+# Resolve "latest" to the newest tag for this app.
+if [[ "$TAG" == "latest" ]]; then
+  TAG="$(gh release list --repo "$REPO" --limit 200 \
+    | grep -oE "${TAG_PREFIX[$APP]}[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1)"
+  [[ -n "$TAG" ]] || die "could not resolve the latest ${TAG_PREFIX[$APP]} release"
+fi
+
+SOURCE="build (BUILD_MODE=$ENV)"; [[ -n "$TAG" ]] && SOURCE="download $TAG"
+KEY_DESC="${PEM:-$OP_REF}"
+
+echo "-------------------------------------------------------------"
+echo "  app        : $APP"
+echo "  environment: $ENV"
+echo "  canister   : $CANISTER"
+echo "  site       : ${SITE:-<none>}"
+echo "  source     : $SOURCE"
+echo "  key        : $KEY_DESC"
+echo "-------------------------------------------------------------"
+
+if [[ -n "$DRY" ]]; then echo "dry run: nothing uploaded."; exit 0; fi
+
+if [[ -z "$YES" ]]; then
+  read -r -p "Deploy to $ENV? [y/N]: " ok
+  [[ "$ok" =~ ^[yY] ]] || { echo "cancelled."; exit 1; }
+fi
+
+# Read the key from 1Password if asked, into a locked-down temp file.
+if [[ -n "$OP_REF" ]]; then
+  command -v op >/dev/null || die "1Password CLI (op) not found"
+  echo "==> reading key from 1Password"
+  TMP_PEM="$(mktemp)"; chmod 600 "$TMP_PEM"
+  op read "$OP_REF" > "$TMP_PEM" || die "could not read the key from 1Password ($OP_REF)"
+  PEM="$TMP_PEM"
+fi
+
+# 1. Get the artifact.
+mkdir -p "$DIR"
+if [[ -n "$TAG" ]]; then
+  echo "==> downloading ${TARBALL[$APP]} from $TAG"
+  gh release download "$TAG" --repo "$REPO" --pattern "${TARBALL[$APP]}" --dir "$DIR" --clobber
+else
+  echo "==> building for $ENV"
+  BUILD_MODE="$ENV" ./scripts/docker-build.sh "${BUILD_TARGET[$APP]}"
+fi
+
+# 2. Unpack.
+echo "==> unpacking"
+rm -rf "$DIR/dist" && mkdir -p "$DIR/dist"
+tar -xf "$TAR" -C "$DIR/dist"
+
+# 3. Upload the assets (never deletes existing ones).
+echo "==> uploading to $CANISTER"
+icx-asset --pem "$PEM" --replica "$REPLICA" sync --no-delete "$CANISTER" "$DIR/dist"
+
+# 4. Verify the live version.
+if [[ -n "$SITE" ]]; then
+  echo "==> deployed version at $SITE:"
+  curl -s --compressed "$SITE/" | tr '>' '\n' | grep -i 'app:build-version' || echo "  (no version meta tag found)"
+fi
+
+echo "done."

--- a/scripts/deploy-app
+++ b/scripts/deploy-app
@@ -13,7 +13,7 @@ set -eEuo pipefail
 # The signing key can be a pem file (--pem) or read straight from 1Password
 # (--op op://Vault/Item/field), so nothing has to be saved to disk by hand.
 #
-# Needs: gh, jq, docker, icx-asset, curl (and op for --op).
+# Needs: gh, jq, docker, icx-asset, shasum, curl (and op for --op).
 
 REPO="dfinity/orbit"
 REPLICA="https://icp0.io"
@@ -141,7 +141,14 @@ fi
 mkdir -p "$DIR"
 if [[ -n "$TAG" ]]; then
   echo "==> downloading ${TARBALL[$APP]} from $TAG"
-  gh release download "$TAG" --repo "$REPO" --pattern "${TARBALL[$APP]}" --dir "$DIR" --clobber
+  gh release download "$TAG" --repo "$REPO" \
+    --pattern "${TARBALL[$APP]}" --pattern "${TARBALL[$APP]}.sha256" --dir "$DIR" --clobber
+  # Verify against the checksum published beside the tarball. This is the only
+  # check on a production deploy that does not come from CI, so it is not optional.
+  expected="$(tr -d '[:space:]' < "$TAR.sha256")"
+  actual="$(shasum -a 256 "$TAR" | awk '{ print $1 }')"
+  [[ "$expected" == "$actual" ]] || die "checksum mismatch for ${TARBALL[$APP]}: expected $expected, got $actual"
+  echo "    checksum ok: $actual"
 else
   echo "==> building for $ENV"
   BUILD_MODE="$ENV" ./scripts/docker-build.sh "${BUILD_TARGET[$APP]}"


### PR DESCRIPTION
Phase 2 of 4. Stacked on #655.

Adds the `Deploy frontend` workflow_dispatch and the `scripts/deploy-app` helper it wraps.

You tick which frontends to deploy (wallet, marketing, docs) and run it. The playground job builds each app for playground and uploads it with icx-asset so you can test at the playground URL. `deploy-app` resolves the canister, gets the artifact, unpacks it, syncs the assets with `--no-delete`, and reads the live version meta tag back to confirm what landed. Frontend config is baked in at build time, so playground gets its own build while production ships the released tagged tarball. The signing key comes either from a `DEPLOY_IDENTITY_PEM` environment secret or, locally, straight from 1Password via `--op`, in both cases through a temp pem wiped on exit.

The `production` job is off by default and has no key. Production frontends are deployed with `scripts/deploy-app --op` from a machine that can read the key, which keeps that credential out of this repo entirely. A frontend sync is live to every user the moment it finishes, so we would rather it not be reachable by anything that lands in `.github/`. The job is kept so the wiring exists if that is revisited; with no key it fails fast with a pointer.

`deploy-app` now also verifies the tarball against the `.sha256` published beside it in the release. Releases have always published one and the script was not looking at it, which matters more now that this is a hand-run path with no CI attestation behind it.

The jobs install only what `deploy-app` needs (gh, jq, docker, icx-asset, shasum, curl), so the npm dependency tree and its lifecycle scripts never enter a job that writes a signing key to disk.

Requires the `playground` GitHub Environment with its key, and its deployment branches restricted to `main`. Base of this PR is #655; review that first.
