### PR TITLE
ci(release): add Deploy backend workflow

### DIFF
--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -1,6 +1,10 @@
 name: 'Deploy backend'
 description: 'Publish station/upgrader to the control-panel registry, or upgrade the control-panel canister, on one network.'
 
+# All of the actual work lives in scripts/deploy-backend so that CI and an
+# operator on a laptop run the same code. This action only installs the
+# toolchain, materialises the key, and calls the script once per target.
+
 inputs:
   network:
     description: 'dfx network to target (playground or production).'
@@ -28,6 +32,7 @@ runs:
       uses: ./.github/actions/setup-node
     - name: 'Install dependencies'
       shell: bash
+      # Needed for orbit-cli, which performs the registry publish.
       run: pnpm install --frozen-lockfile
     - name: 'Install dfx'
       uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main (no tags/releases published)
@@ -39,7 +44,6 @@ runs:
     - name: 'Deploy'
       shell: bash
       env:
-        REPO: 'dfinity/orbit'
         NET: ${{ inputs.network }}
         DEPLOY_STATION: ${{ inputs.station }}
         DEPLOY_UPGRADER: ${{ inputs.upgrader }}
@@ -54,56 +58,18 @@ runs:
         if [ "$DEPLOY_UPGRADER" = "true" ]; then targets+=(upgrader); fi
         if [ "$DEPLOY_CONTROL_PANEL" = "true" ]; then targets+=(control-panel); fi
         if [ "${#targets[@]}" -eq 0 ]; then echo "No backend selected."; exit 1; fi
-        if [ -z "${BACKEND_IDENTITY_PEM:-}" ]; then echo "BACKEND_IDENTITY_PEM secret is not set on the $NET environment."; exit 1; fi
 
-        # Import the key into dfx as a named identity the CLI can resolve.
-        dfx_root="$(mktemp -d)"; chmod 700 "$dfx_root"; export DFX_CONFIG_ROOT="$dfx_root"
-        pem="$(mktemp)"; chmod 600 "$pem"; printf '%s\n' "$BACKEND_IDENTITY_PEM" > "$pem"
-        trap 'rm -rf "$pem" "$dfx_root"' EXIT
-        dfx identity import ci-backend "$pem" --storage-mode plaintext --force
+        if [ -z "${BACKEND_IDENTITY_PEM:-}" ]; then
+          echo "No BACKEND_IDENTITY_PEM on the $NET environment."
+          echo "Production is deployed from an operator machine. See RELEASE.md:"
+          echo "  ./scripts/deploy-backend --target <target> --network production --op <ref>"
+          exit 1
+        fi
 
-        # Download a released wasm artifact into artifacts/<dir>/<file>, resolving
-        # the newest tag for that project.
-        dl() {
-          local key="$1" dir="$2" file="$3" tag
-          tag="$(gh release list --repo "$REPO" --limit 200 \
-            | grep -oE "@orbit/${key}-v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1)"
-          [ -n "$tag" ] || { echo "no release found for $key"; exit 1; }
-          echo "==> $key: downloading $file from $tag"
-          mkdir -p "artifacts/$dir"
-          gh release download "$tag" --repo "$REPO" \
-            --pattern "$file" --pattern "$file.sha256" --dir "artifacts/$dir" --clobber
-          # Verify the wasm against the checksum published beside it in the release.
-          local expected actual
-          expected="$(tr -d '[:space:]' < "artifacts/$dir/$file.sha256")"
-          actual="$(sha256sum "artifacts/$dir/$file" | awk '{ print $1 }')"
-          if [ "$expected" != "$actual" ]; then
-            echo "checksum mismatch for $file: expected $expected, got $actual"; exit 1
-          fi
-          echo "    checksum ok: $actual"
-        }
+        pem="$(mktemp)"; chmod 600 "$pem"
+        printf '%s\n' "$BACKEND_IDENTITY_PEM" > "$pem"
+        trap 'rm -f "$pem"' EXIT
 
         for target in "${targets[@]}"; do
-          case "$target" in
-            station)
-              # station publishes upgrader as its dependency, so both wasms are needed.
-              dl station station station.wasm.gz
-              dl upgrader upgrader upgrader.wasm.gz
-              echo "==> publishing station to the $NET registry"
-              orbit-cli registry publish --app station --network "$NET" --identity ci-backend
-              ;;
-            upgrader)
-              dl upgrader upgrader upgrader.wasm.gz
-              echo "==> publishing upgrader to the $NET registry"
-              orbit-cli registry publish --app upgrader --network "$NET" --identity ci-backend
-              ;;
-            control-panel)
-              dl control-panel control-panel control_panel.wasm.gz
-              echo "==> upgrading the control-panel canister on $NET"
-              dfx canister install control_panel \
-                --network "$NET" --identity ci-backend \
-                --wasm artifacts/control-panel/control_panel.wasm.gz \
-                --mode upgrade --yes
-              ;;
-          esac
+          ./scripts/deploy-backend --target "$target" --network "$NET" --pem "$pem" --yes
         done

--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -71,7 +71,16 @@ runs:
           [ -n "$tag" ] || { echo "no release found for $key"; exit 1; }
           echo "==> $key: downloading $file from $tag"
           mkdir -p "artifacts/$dir"
-          gh release download "$tag" --repo "$REPO" --pattern "$file" --dir "artifacts/$dir" --clobber
+          gh release download "$tag" --repo "$REPO" \
+            --pattern "$file" --pattern "$file.sha256" --dir "artifacts/$dir" --clobber
+          # Verify the wasm against the checksum published beside it in the release.
+          local expected actual
+          expected="$(tr -d '[:space:]' < "artifacts/$dir/$file.sha256")"
+          actual="$(sha256sum "artifacts/$dir/$file" | awk '{ print $1 }')"
+          if [ "$expected" != "$actual" ]; then
+            echo "checksum mismatch for $file: expected $expected, got $actual"; exit 1
+          fi
+          echo "    checksum ok: $actual"
         }
 
         for target in "${targets[@]}"; do

--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -57,9 +57,9 @@ runs:
         if [ -z "${BACKEND_IDENTITY_PEM:-}" ]; then echo "BACKEND_IDENTITY_PEM secret is not set on the $NET environment."; exit 1; fi
 
         # Import the key into dfx as a named identity the CLI can resolve.
-        pem="$(mktemp)"; chmod 600 "$pem"
-        printf '%s\n' "$BACKEND_IDENTITY_PEM" > "$pem"
-        trap 'rm -f "$pem"' EXIT
+        dfx_root="$(mktemp -d)"; chmod 700 "$dfx_root"; export DFX_CONFIG_ROOT="$dfx_root"
+        pem="$(mktemp)"; chmod 600 "$pem"; printf '%s\n' "$BACKEND_IDENTITY_PEM" > "$pem"
+        trap 'rm -rf "$pem" "$dfx_root"' EXIT
         dfx identity import ci-backend "$pem" --storage-mode plaintext --force
 
         # Download a released wasm artifact into artifacts/<dir>/<file>, resolving

--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -1,0 +1,100 @@
+name: 'Deploy backend'
+description: 'Publish station/upgrader to the control-panel registry, or upgrade the control-panel canister, on one network.'
+
+inputs:
+  network:
+    description: 'dfx network to target (playground or production).'
+    required: true
+  station:
+    description: 'Publish station ("true"/"false").'
+    required: true
+  upgrader:
+    description: 'Publish upgrader ("true"/"false").'
+    required: true
+  control_panel:
+    description: 'Upgrade the control-panel canister ("true"/"false").'
+    required: true
+  identity_pem:
+    description: 'The signing identity pem. Must be a registry admin and a control-panel controller.'
+    required: true
+  gh_token:
+    description: 'Token used to download release artifacts.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Node'
+      uses: ./.github/actions/setup-node
+    - name: 'Install dependencies'
+      shell: bash
+      run: pnpm install --frozen-lockfile
+    - name: 'Install dfx'
+      uses: dfinity/setup-dfx@main
+      with:
+        dfx-version: '0.30.2'
+    - name: 'Install icx-asset'
+      shell: bash
+      run: cargo install --locked icx-asset --version 0.29.0
+    - name: 'Deploy'
+      shell: bash
+      env:
+        REPO: 'dfinity/orbit'
+        NET: ${{ inputs.network }}
+        DEPLOY_STATION: ${{ inputs.station }}
+        DEPLOY_UPGRADER: ${{ inputs.upgrader }}
+        DEPLOY_CONTROL_PANEL: ${{ inputs.control_panel }}
+        BACKEND_IDENTITY_PEM: ${{ inputs.identity_pem }}
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        set -euo pipefail
+
+        targets=()
+        if [ "$DEPLOY_STATION" = "true" ]; then targets+=(station); fi
+        if [ "$DEPLOY_UPGRADER" = "true" ]; then targets+=(upgrader); fi
+        if [ "$DEPLOY_CONTROL_PANEL" = "true" ]; then targets+=(control-panel); fi
+        if [ "${#targets[@]}" -eq 0 ]; then echo "No backend selected."; exit 1; fi
+        if [ -z "${BACKEND_IDENTITY_PEM:-}" ]; then echo "BACKEND_IDENTITY_PEM secret is not set on the $NET environment."; exit 1; fi
+
+        # Import the key into dfx as a named identity the CLI can resolve.
+        pem="$(mktemp)"; chmod 600 "$pem"
+        printf '%s\n' "$BACKEND_IDENTITY_PEM" > "$pem"
+        trap 'rm -f "$pem"' EXIT
+        dfx identity import ci-backend "$pem" --storage-mode plaintext --force
+
+        # Download a released wasm artifact into artifacts/<dir>/<file>, resolving
+        # the newest tag for that project.
+        dl() {
+          local key="$1" dir="$2" file="$3" tag
+          tag="$(gh release list --repo "$REPO" --limit 200 \
+            | grep -oE "@orbit/${key}-v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1)"
+          [ -n "$tag" ] || { echo "no release found for $key"; exit 1; }
+          echo "==> $key: downloading $file from $tag"
+          mkdir -p "artifacts/$dir"
+          gh release download "$tag" --repo "$REPO" --pattern "$file" --dir "artifacts/$dir" --clobber
+        }
+
+        for target in "${targets[@]}"; do
+          case "$target" in
+            station)
+              # station publishes upgrader as its dependency, so both wasms are needed.
+              dl station station station.wasm.gz
+              dl upgrader upgrader upgrader.wasm.gz
+              echo "==> publishing station to the $NET registry"
+              orbit-cli registry publish --app station --network "$NET" --identity ci-backend
+              ;;
+            upgrader)
+              dl upgrader upgrader upgrader.wasm.gz
+              echo "==> publishing upgrader to the $NET registry"
+              orbit-cli registry publish --app upgrader --network "$NET" --identity ci-backend
+              ;;
+            control-panel)
+              dl control-panel control-panel control_panel.wasm.gz
+              echo "==> upgrading the control-panel canister on $NET"
+              dfx canister install control_panel \
+                --network "$NET" --identity ci-backend \
+                --wasm artifacts/control-panel/control_panel.wasm.gz \
+                --mode upgrade --yes
+              ;;
+          esac
+        done

--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -60,7 +60,7 @@ runs:
         if [ "${#targets[@]}" -eq 0 ]; then echo "No backend selected."; exit 1; fi
 
         if [ -z "${BACKEND_IDENTITY_PEM:-}" ]; then
-          echo "No BACKEND_IDENTITY_PEM on the $NET environment."
+          echo "No signing key on the $NET environment."
           echo "Production is deployed from an operator machine. See RELEASE.md:"
           echo "  ./scripts/deploy-backend --target <target> --network production --op <ref>"
           exit 1

--- a/.github/actions/deploy-backend/action.yaml
+++ b/.github/actions/deploy-backend/action.yaml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile
     - name: 'Install dfx'
-      uses: dfinity/setup-dfx@main
+      uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main (no tags/releases published)
       with:
         dfx-version: '0.30.2'
     - name: 'Install icx-asset'

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -42,6 +42,12 @@ on:
 permissions:
   contents: read
 
+# One deploy run at a time. A second trigger queues instead of racing an
+# in-flight deploy of the same targets, and a running deploy is never cancelled.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   playground:
     name: 'playground'
@@ -53,6 +59,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # This job downloads via gh, never pushes, so it does not need the
+          # GITHUB_TOKEN left in .git/config.
+          persist-credentials: false
       - name: 'Deploy backend to playground'
         uses: ./.github/actions/deploy-backend
         with:
@@ -75,6 +84,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # This job downloads via gh, never pushes, so it does not need the
+          # GITHUB_TOKEN left in .git/config.
+          persist-credentials: false
       - name: 'Deploy backend to production'
         uses: ./.github/actions/deploy-backend
         with:

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -15,9 +15,19 @@ name: 'Deploy backend'
 #     gate is the only thing standing between this and every wallet.
 #
 # The signing key is read from the `BACKEND_IDENTITY_PEM` secret, scoped per
-# environment, and imported into dfx as a named identity. That identity must be
-# a registry admin on the control-panel (for registry publish) and a controller
-# of the control-panel canister (for the control-panel upgrade).
+# environment. That identity must be a registry admin on the control-panel (for
+# registry publish) and a controller of the control-panel canister (for the
+# control-panel upgrade).
+#
+# Production is deliberately not wired up by default. The production key is not
+# held here; production is deployed from an operator machine with
+# `scripts/deploy-backend --op`, which keeps that key out of this repo entirely.
+# See RELEASE.md. The production job below is kept so the wiring exists if that
+# decision is ever revisited: without a key on the `production` environment it
+# fails fast with a message instead of doing anything surprising.
+#
+# Both jobs call scripts/deploy-backend, the same script an operator runs by
+# hand, so there is only one implementation of a backend deploy.
 
 on:
   workflow_dispatch:
@@ -34,10 +44,12 @@ on:
         description: 'Upgrade the control-panel canister in place.'
         type: boolean
         default: false
+      # Off by default: production is normally deployed from an operator machine,
+      # not from here. Only useful if a production key is put on the environment.
       promote_to_production:
-        description: 'After the playground network, promote the same selection to the production network behind the approval gate. Uncheck for a playground-only run.'
+        description: 'Also run the production job. Leave unchecked unless production deploys have been moved into CI.'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -11,8 +11,8 @@ name: 'Deploy backend'
 #     production station still self-upgrades on its own admins' approval.
 #     Publishing station also publishes upgrader, its dependency.
 #   - control-panel: a direct `dfx canister install --mode upgrade` of the one
-#     control-panel canister. No registry, no per-wallet buffer, so the approval
-#     gate is the only thing standing between this and every wallet.
+#     control-panel canister. No registry, no per-station buffer, so nothing
+#     stands between this and every station.
 #
 # Each job reads its own secret, `BACKEND_PLAYGROUND_IDENTITY_PEM` on the
 # `playground` environment and `BACKEND_PRODUCTION_IDENTITY_PEM` on `production`.

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -14,10 +14,10 @@ name: 'Deploy backend'
 #     control-panel canister. No registry, no per-wallet buffer, so the approval
 #     gate is the only thing standing between this and every wallet.
 #
-# The signing key is read from the `BACKEND_IDENTITY_PEM` secret, scoped per
-# environment. That identity must be a registry admin on the control-panel (for
-# registry publish) and a controller of the control-panel canister (for the
-# control-panel upgrade).
+# Each job reads its own secret, `BACKEND_STAGING_IDENTITY_PEM` on the
+# `playground` environment and `BACKEND_PRODUCTION_IDENTITY_PEM` on `production`.
+# That identity must be a registry admin on the control-panel (for registry
+# publish) and a controller of the control-panel canister (for the upgrade).
 #
 # Production is deliberately not wired up by default. The production key is not
 # held here; production is deployed from an operator machine with
@@ -81,13 +81,13 @@ jobs:
           station: ${{ inputs.station }}
           upgrader: ${{ inputs.upgrader }}
           control_panel: ${{ inputs.control_panel }}
-          identity_pem: ${{ secrets.BACKEND_IDENTITY_PEM }}
+          identity_pem: ${{ secrets.BACKEND_STAGING_IDENTITY_PEM }}
           gh_token: ${{ github.token }}
 
   production:
     name: 'production'
     needs: playground
-    if: ${{ inputs.promote_to_production == 'true' }}
+    if: ${{ inputs.promote_to_production }}
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -106,5 +106,5 @@ jobs:
           station: ${{ inputs.station }}
           upgrader: ${{ inputs.upgrader }}
           control_panel: ${{ inputs.control_panel }}
-          identity_pem: ${{ secrets.BACKEND_IDENTITY_PEM }}
+          identity_pem: ${{ secrets.BACKEND_PRODUCTION_IDENTITY_PEM }}
           gh_token: ${{ github.token }}

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -1,0 +1,86 @@
+name: 'Deploy backend'
+
+# Phase 3 of the release, backend half: get a released backend wasm onto the
+# network. Pick any subset of station, upgrader, control-panel. The run does the
+# playground network first with no gate, then, if you asked to promote, the
+# production network behind the `production` environment's approval.
+#
+# Two different deploy paths, matching the architecture:
+#   - station / upgrader: `orbit-cli registry publish` loads the wasm into the
+#     control-panel registry. This only makes the version available. Each
+#     production station still self-upgrades on its own admins' approval.
+#     Publishing station also publishes upgrader, its dependency.
+#   - control-panel: a direct `dfx canister install --mode upgrade` of the one
+#     control-panel canister. No registry, no per-wallet buffer, so the approval
+#     gate is the only thing standing between this and every wallet.
+#
+# The signing key is read from the `BACKEND_IDENTITY_PEM` secret, scoped per
+# environment, and imported into dfx as a named identity. That identity must be
+# a registry admin on the control-panel (for registry publish) and a controller
+# of the control-panel canister (for the control-panel upgrade).
+
+on:
+  workflow_dispatch:
+    inputs:
+      station:
+        description: 'Publish station to the registry.'
+        type: boolean
+        default: false
+      upgrader:
+        description: 'Publish upgrader to the registry.'
+        type: boolean
+        default: false
+      control_panel:
+        description: 'Upgrade the control-panel canister in place.'
+        type: boolean
+        default: false
+      promote_to_production:
+        description: 'After the playground network, promote the same selection to the production network behind the approval gate. Uncheck for a playground-only run.'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  playground:
+    name: 'playground'
+    runs-on: ubuntu-latest
+    environment: playground
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: 'Deploy backend to playground'
+        uses: ./.github/actions/deploy-backend
+        with:
+          network: playground
+          station: ${{ inputs.station }}
+          upgrader: ${{ inputs.upgrader }}
+          control_panel: ${{ inputs.control_panel }}
+          identity_pem: ${{ secrets.BACKEND_IDENTITY_PEM }}
+          gh_token: ${{ github.token }}
+
+  production:
+    name: 'production'
+    needs: playground
+    if: ${{ inputs.promote_to_production }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: 'Deploy backend to production'
+        uses: ./.github/actions/deploy-backend
+        with:
+          network: production
+          station: ${{ inputs.station }}
+          upgrader: ${{ inputs.upgrader }}
+          control_panel: ${{ inputs.control_panel }}
+          identity_pem: ${{ secrets.BACKEND_IDENTITY_PEM }}
+          gh_token: ${{ github.token }}

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -14,7 +14,7 @@ name: 'Deploy backend'
 #     control-panel canister. No registry, no per-wallet buffer, so the approval
 #     gate is the only thing standing between this and every wallet.
 #
-# Each job reads its own secret, `BACKEND_STAGING_IDENTITY_PEM` on the
+# Each job reads its own secret, `BACKEND_PLAYGROUND_IDENTITY_PEM` on the
 # `playground` environment and `BACKEND_PRODUCTION_IDENTITY_PEM` on `production`.
 # That identity must be a registry admin on the control-panel (for registry
 # publish) and a controller of the control-panel canister (for the upgrade).
@@ -81,7 +81,7 @@ jobs:
           station: ${{ inputs.station }}
           upgrader: ${{ inputs.upgrader }}
           control_panel: ${{ inputs.control_panel }}
-          identity_pem: ${{ secrets.BACKEND_STAGING_IDENTITY_PEM }}
+          identity_pem: ${{ secrets.BACKEND_PLAYGROUND_IDENTITY_PEM }}
           gh_token: ${{ github.token }}
 
   production:

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -66,7 +66,7 @@ jobs:
   production:
     name: 'production'
     needs: playground
-    if: ${{ inputs.promote_to_production }}
+    if: ${{ inputs.promote_to_production == 'true' }}
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/release-deploy-backend.yaml
+++ b/.github/workflows/release-deploy-backend.yaml
@@ -49,7 +49,7 @@ jobs:
     environment: playground
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -71,7 +71,7 @@ jobs:
     environment: production
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/scripts/deploy-backend
+++ b/scripts/deploy-backend
@@ -112,9 +112,14 @@ targets=("$TARGET")
 CARGO_META="$(cargo metadata --format-version 1 --no-deps)"
 crate_version() { jq -r --arg n "$1" '.packages[] | select(.name == $n) | .version' <<<"$CARGO_META"; }
 
+# Newest stable release for a project. Pre-releases are excluded twice: on the
+# release flag, and by anchoring the version pattern, because an unanchored match
+# reads "-v0.8.0-rc.0" as "-v0.8.0" and yields a tag that does not exist.
 resolve_tag() {
-  gh release list --repo "$REPO" --limit 200 \
-    | grep -oE "${TAG_PREFIX[$1]}[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1
+  gh release list --repo "$REPO" --limit 500 \
+    --json tagName,isPrerelease,isDraft \
+    --jq '.[] | select(.isPrerelease == false and .isDraft == false) | .tagName' \
+    | grep -E "^${TAG_PREFIX[$1]}[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -1
 }
 
 echo "-------------------------------------------------------------"
@@ -126,7 +131,7 @@ echo "  identity   : $IDENTITY"
 declare -A TAGS=()
 for t in "${targets[@]}"; do
   tag="$(resolve_tag "$t")"
-  [[ -n "$tag" ]] || die "could not resolve the latest ${TAG_PREFIX[$t]} release"
+  [[ -n "$tag" ]] || die "could not resolve the latest stable ${TAG_PREFIX[$t]} release"
   TAGS[$t]="$tag"
   echo "  artifact   : $tag (${WASM[$t]})"
 done

--- a/scripts/deploy-backend
+++ b/scripts/deploy-backend
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+# Deploy a single Orbit backend to a network, end to end:
+#   resolve the newest release tag -> download the wasm -> verify its checksum ->
+#   check it against the working tree -> sign with an isolated identity -> ship.
+#
+# Two very different destinations, picked by --target:
+#   station / upgrader  publish the wasm into the control-panel registry. This
+#                       only makes the version available. Each station still
+#                       upgrades itself when its own admins approve it.
+#   control-panel       install the wasm onto the one control-panel canister.
+#                       There is no registry and no buffer, it is live at once.
+#
+# The signing key can be a pem file (--pem) or read straight from 1Password
+# (--op op://Vault/Item/field), so nothing has to be saved to disk by hand.
+#
+# Needs: gh, jq, cargo, dfx, icx-asset, orbit-cli (and op for --op).
+
+REPO="dfinity/orbit"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# target -> release tag prefix, wasm file name, artifacts subdir, cargo package
+declare -A TAG_PREFIX=(
+  [station]="@orbit/station-v"
+  [upgrader]="@orbit/upgrader-v"
+  [control-panel]="@orbit/control-panel-v"
+)
+declare -A WASM=(
+  [station]="station.wasm.gz"
+  [upgrader]="upgrader.wasm.gz"
+  [control-panel]="control_panel.wasm.gz"
+)
+declare -A CRATE=(
+  [station]="station"
+  [upgrader]="upgrader"
+  [control-panel]="control-panel"
+)
+
+TARGET="" NETWORK="" PEM="" OP_REF="" IDENTITY="orbit-deploy" YES="" DRY=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --target <station|upgrader|control-panel> --network <playground|production> (--pem <file> | --op <ref>) [options]
+
+Signing key (one is required). The identity must be a registry admin on the
+control-panel to publish, and a controller of the control-panel canister to
+upgrade it.
+  --pem <file>       Path to the identity pem on disk.
+  --op <ref>         1Password secret reference, e.g. "op://Orbit Mgmt/orbit-mgmt/identity.pem".
+                     Read via the op CLI into a temp file that is deleted on exit.
+
+Other:
+  --identity <name>  Name to import the key under. Default: $IDENTITY.
+  --yes              Skip the confirmation prompt.
+  --dry-run          Download and verify the artifact, then stop. Ships nothing.
+
+Examples:
+  $0 --target station --network playground --op "op://Orbit Mgmt/orbit-mgmt/identity.pem"
+  $0 --target control-panel --network production --op "op://Orbit Mgmt/orbit-mgmt/identity.pem"
+EOF
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    --network) NETWORK="$2"; shift 2 ;;
+    --pem) PEM="$2"; shift 2 ;;
+    --op) OP_REF="$2"; shift 2 ;;
+    --identity) IDENTITY="$2"; shift 2 ;;
+    --yes) YES=1; shift ;;
+    --dry-run) DRY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "${TAG_PREFIX[$TARGET]:-}" ]] || { usage; die "--target must be one of: station upgrader control-panel"; }
+[[ "$NETWORK" == "playground" || "$NETWORK" == "production" ]] || { usage; die "--network must be playground or production"; }
+[[ -n "$PEM" || -n "$OP_REF" ]] || { usage; die "a key is required: pass --pem or --op"; }
+[[ -z "$PEM" || -z "$OP_REF" ]] || die "pass only one of --pem / --op"
+[[ -z "$PEM" || -f "$PEM" ]] || die "pem file not found: $PEM"
+cd "$ROOT"
+
+# A dry run only resolves and verifies artifacts, so it needs neither dfx nor
+# orbit-cli. Do not make people install a toolchain to check a checksum.
+for c in gh jq cargo; do command -v "$c" >/dev/null || die "$c not found"; done
+if [[ -z "$DRY" ]]; then
+  command -v dfx >/dev/null || die "dfx not found"
+  if [[ "$TARGET" != "control-panel" ]]; then
+    command -v orbit-cli >/dev/null || die "orbit-cli not found: run pnpm install at the repo root"
+  fi
+fi
+
+# A temp pem (only when reading from 1Password) and an isolated dfx home, both
+# always removed on exit so a production key never outlives the run.
+TMP_PEM="" DFX_HOME=""
+cleanup() {
+  [[ -n "$TMP_PEM" ]] && rm -f "$TMP_PEM"
+  [[ -n "$DFX_HOME" ]] && rm -rf "$DFX_HOME"
+  return 0
+}
+trap cleanup EXIT
+
+# Publishing station also publishes upgrader, its declared dependency, so that
+# wasm has to be on disk too.
+targets=("$TARGET")
+[[ "$TARGET" == "station" ]] && targets=(station upgrader)
+
+CARGO_META="$(cargo metadata --format-version 1 --no-deps)"
+crate_version() { jq -r --arg n "$1" '.packages[] | select(.name == $n) | .version' <<<"$CARGO_META"; }
+
+resolve_tag() {
+  gh release list --repo "$REPO" --limit 200 \
+    | grep -oE "${TAG_PREFIX[$1]}[0-9]+\.[0-9]+\.[0-9]+" | sort -V | tail -1
+}
+
+echo "-------------------------------------------------------------"
+echo "  target     : $TARGET"
+echo "  network    : $NETWORK"
+echo "  key        : ${PEM:-$OP_REF}"
+echo "  identity   : $IDENTITY"
+
+declare -A TAGS=()
+for t in "${targets[@]}"; do
+  tag="$(resolve_tag "$t")"
+  [[ -n "$tag" ]] || die "could not resolve the latest ${TAG_PREFIX[$t]} release"
+  TAGS[$t]="$tag"
+  echo "  artifact   : $tag (${WASM[$t]})"
+done
+echo "-------------------------------------------------------------"
+
+# The registry entry's version label comes from the working tree via `cargo
+# metadata`, not from the artifact, so a stale checkout would publish the right
+# wasm under the wrong version. Refuse rather than mislabel it.
+for t in "${targets[@]}"; do
+  tag_version="${TAGS[$t]#"${TAG_PREFIX[$t]}"}"
+  tree_version="$(crate_version "${CRATE[$t]}")"
+  [[ -n "$tree_version" ]] || die "no cargo package named ${CRATE[$t]}"
+  if [[ "$tag_version" != "$tree_version" ]]; then
+    die "checkout mismatch for $t: the release is $tag_version but this working tree is $tree_version.
+       Deploy from a checkout of the release, for example: git checkout ${TAGS[$t]}"
+  fi
+done
+
+if [[ -z "$YES" && -z "$DRY" ]]; then
+  read -r -p "Deploy $TARGET to $NETWORK? [y/N]: " ok
+  [[ "$ok" =~ ^[yY] ]] || { echo "cancelled."; exit 1; }
+fi
+
+# 1. Download each wasm and verify it against the checksum published beside it.
+#    Done before the key is touched, so nothing privileged is loaded if this fails.
+for t in "${targets[@]}"; do
+  dir="artifacts/$t" file="${WASM[$t]}"
+  echo "==> downloading $file from ${TAGS[$t]}"
+  mkdir -p "$dir"
+  gh release download "${TAGS[$t]}" --repo "$REPO" \
+    --pattern "$file" --pattern "$file.sha256" --dir "$dir" --clobber
+  expected="$(tr -d '[:space:]' < "$dir/$file.sha256")"
+  actual="$(shasum -a 256 "$dir/$file" | awk '{ print $1 }')"
+  [[ "$expected" == "$actual" ]] || die "checksum mismatch for $file: expected $expected, got $actual"
+  echo "    checksum ok: $actual"
+done
+
+if [[ -n "$DRY" ]]; then echo "dry run: artifacts verified, nothing shipped."; exit 0; fi
+
+# 2. Load the key into a throwaway dfx home.
+#
+#    HOME and DFX_CONFIG_ROOT both have to point at it: dfx honours
+#    DFX_CONFIG_ROOT, but orbit-cli resolves the pem from homedir() directly. Set
+#    only one and `registry publish` cannot find the identity dfx just imported.
+#    Doing this after the downloads keeps the real HOME in place for gh.
+if [[ -n "$OP_REF" ]]; then
+  command -v op >/dev/null || die "1Password CLI (op) not found"
+  echo "==> reading key from 1Password"
+  TMP_PEM="$(mktemp)"; chmod 600 "$TMP_PEM"
+  op read "$OP_REF" > "$TMP_PEM" || die "could not read the key from 1Password ($OP_REF)"
+  PEM="$TMP_PEM"
+fi
+
+DFX_HOME="$(mktemp -d)"; chmod 700 "$DFX_HOME"
+export HOME="$DFX_HOME" DFX_CONFIG_ROOT="$DFX_HOME"
+dfx identity import "$IDENTITY" "$PEM" --storage-mode plaintext --force
+
+# 3. Ship it.
+case "$TARGET" in
+  station|upgrader)
+    echo "==> publishing $TARGET to the $NETWORK registry"
+    orbit-cli registry publish --app "$TARGET" --network "$NETWORK" --identity "$IDENTITY"
+    ;;
+  control-panel)
+    echo "==> upgrading the control-panel canister on $NETWORK"
+    dfx canister install control_panel \
+      --network "$NETWORK" --identity "$IDENTITY" \
+      --wasm "artifacts/control-panel/${WASM[control-panel]}" \
+      --mode upgrade --yes
+    ;;
+esac
+
+echo "done."


### PR DESCRIPTION
Phase 3 of 4. Stacked on #656.

Adds the `Deploy backend` workflow_dispatch, a `deploy-backend` composite action, and `scripts/deploy-backend`.

You tick station, upgrader, or control-panel and run it. The workflow's two jobs each call the composite action, which installs the toolchain, materialises the key from the `BACKEND_IDENTITY_PEM` environment secret, and then calls `scripts/deploy-backend` once per target. All of the real work lives in the script, so CI and an operator on a laptop run the same code rather than two copies that drift. The script resolves the newest release tag, downloads the wasm, verifies it against the `.sha256` published beside it, loads the key into a throwaway dfx home, and dispatches: station and upgrader go through `orbit-cli registry publish`, which only makes the version available (each production station still self-upgrades on its own admins' approval, and publishing station also publishes its upgrader dependency); control-panel is a direct `dfx canister install --mode upgrade` of the one canister, so nothing buffers it.

The `production` job is off by default and has no key. Production backends are deployed with `scripts/deploy-backend --op`, which keeps that credential out of this repo. The job is kept so the wiring exists if that is revisited; with no key it fails fast with a pointer.

Two defects surfaced while moving the logic out of the action, both fixed here. `orbit-cli` resolves the identity pem from `homedir()` and ignores `DFX_CONFIG_ROOT`, so the isolated dfx root the action set up would have left `registry publish` unable to find the identity dfx had just imported; the script exports `HOME` alongside it. And the registry entry's version label comes from `cargo metadata` rather than from the artifact, so deploying from a stale checkout would publish the right wasm under the wrong version; the script compares the two and refuses, naming the tag to check out.

The backend identity must be both a registry admin and a control-panel controller. Base of this PR is #656; review the stack in order.
