### PR TITLE
docs(release): add release process guide

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,12 +10,14 @@ There is no single "Orbit release". There are independently versioned projects, 
 
 The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is the clearer one we would move to in a separate PR if we decide to.
 
+Prose here says station, not wallet. Identifiers still say wallet, because that is what they literally are: the `wallet-dapp` project, the `wallet` checkbox on the deploy form, `--app wallet`, the `app_wallet` key in `canister_ids.json`. Changing those is the rename PR, not a wording fix.
+
 | Current name | Proposed name | Type | Role and where it deploys | Ships alone |
 | --- | --- | --- | --- | --- |
-| `wallet-dapp` | `station-frontend` | Frontend | The wallet UI users log into. Asset tarball to the wallet canister (`5fu67`, app.orbit.global). | Yes |
+| `wallet-dapp` | `station-frontend` | Frontend | The station UI users log into. Asset tarball to its asset canister (`5fu67`, app.orbit.global). | Yes |
 | `marketing-dapp` | `landing-page` | Frontend | The public marketing site. Asset tarball to the marketing canister (orbit.global). | Yes |
 | `docs-portal` | `docs-portal` | Frontend | The documentation site. Asset tarball to the docs canister (docs.orbit.global). | Yes |
-| `station` | `station` | Backend | Per-wallet backend, one deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
+| `station` | `station` | Backend | The backend, one instance deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
 | `upgrader` | `upgrader` | Backend | Per-station helper that performs safe upgrades, paired one-to-one with a station. Wasm to the registry. | Yes |
 | `control-panel` | `control-panel` | Backend | The single global registry and directory. Deploys stations. Wasm, deployed as the control-panel canister. | Yes |
 | `dfx-orbit` | `orbit-cli`, but see below | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
@@ -23,7 +25,7 @@ The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the a
 
 Things worth stating plainly, because they are the usual source of confusion:
 
-* The three frontends are separate projects with separate versions and separate asset canisters. They are not one "wallet dapp" bundle.
+* The three frontends are separate projects with separate versions and separate asset canisters. They are not a single bundle.
 * Only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
 * The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
 * `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. Which is why the rename in the table above has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name refers to two different tools. Every other row in that table is a straight rename; this one is the exception.
@@ -57,9 +59,9 @@ Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-b
 
 ### Frontends to playground
 
-Actions tab, run **Deploy frontend**. Tick **wallet** and run it. It builds the wallet for playground and uploads it to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
+Actions tab, run **Deploy frontend**. Tick **wallet** and run it. It builds the station frontend for playground and uploads it to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
 
-Only the wallet has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. The backends are unaffected: all three targets work on playground, since the registry publish path needs only the control-panel and the wasm chunk store, both of which exist there.
+Only the station frontend has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. The backends are unaffected: all three targets work on playground, since the registry publish path needs only the control-panel and the wasm chunk store, both of which exist there.
 
 Leave **promote_to_production** unchecked. It is off by default and only does anything if a production key has been put on the environment, which is not how this is set up.
 
@@ -68,7 +70,7 @@ Leave **promote_to_production** unchecked. It is off by default and only does an
 Actions tab, run **Deploy backend**. Tick station, upgrader, or control-panel and run it. Same as above: leave promote unchecked. The two backend types deploy differently:
 
 * **station / upgrader**: `orbit-cli registry publish` loads the wasm into the control-panel registry. This only makes the version available. Each production station still upgrades itself, or its upgrader, only when that station's own admins submit and approve the request (finance being 2-of-N). Publishing station also publishes upgrader, its dependency.
-* **control-panel**: a direct `dfx canister install --mode upgrade` of the one canister. There is no registry and no per-wallet buffer, so nothing stands between this and every wallet. Handle with care.
+* **control-panel**: a direct `dfx canister install --mode upgrade` of the one canister. There is no registry and no per-station buffer, so nothing stands between this and every station. Handle with care.
 
 ### Production
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. All of it runs from the Actions tab. This is the guide to what to click.
 
-Most of this used to be manual, run from a laptop with the production key. It is now three workflows: **Cut release**, **Deploy frontend**, **Deploy backend**. Publishing was already automated and has not changed.
+Most of this used to be manual. It is now three workflows: **Cut release**, **Deploy frontend**, **Deploy backend**. Publishing was already automated and has not changed.
 
 ## Components
 
@@ -74,13 +74,7 @@ The gate is native **GitHub Environments**. A `playground` environment that runs
 The deploy workflows need this in place before they can run:
 
 * Create the `playground` and `production` GitHub Environments.
-* Add the signing key as a secret on each: `DEPLOY_IDENTITY_PEM` for the frontend workflow, `BACKEND_IDENTITY_PEM` for the backend workflow, each scoped to the environment so a job only ever sees its own key. The backend identity must be both a registry admin on the control-panel and a controller of the control-panel canister.
+* Configure each environment with the deployment credentials its jobs expect. The required names are declared at the top of the deploy workflows, and the values are held by the team that administers releases.
 * Add required reviewers to `production`. That is the approval gate.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.
 * Stand up a persistent test station so backend wasms published to the playground registry can be exercised by a real self-upgrade before production.
-
-One decision affects the frontend production job: whether the production key lives in the `production` environment as a secret, or stays off CI. In CI, production is a one-approval click. Off CI, production stays a local `scripts/deploy-app` run reading the key from 1Password, and the master key never touches GitHub. A reasonable start is production local, playground automated, and move production into the protected environment once the flow is trusted.
-
-## Release cadence
-
-We don't have a set release cadence today. I'd propose a bi-weekly one, every second Thursday. It would be best-effort, but it gives us a bit of urgency and a rhythm to work to. A recurring Google Calendar event can act as the soft reminder.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,8 @@ The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the a
 
 Prose here says station. The identifiers still say wallet for historical reasons: the `wallet-dapp` project, the `wallet` checkbox on the deploy form, `--app wallet`, the `app_wallet` key in `canister_ids.json`. Renaming those is a lot of work for a wording change. It splits the release tag series in two, so the scripts that resolve `latest` have to know both names, and every published release keeps the old one. It needs its own PR.
 
+So backticked names below are the current ones, matching what you see in the repo and on the workflow forms. The table above maps each to its proposed name.
+
 | Current name | Proposed name | Type | Role and where it deploys | Ships alone |
 | --- | --- | --- | --- | --- |
 | `wallet-dapp` | `station-frontend` | Frontend | The station UI users log into. Asset tarball to its asset canister (`5fu67`, app.orbit.global). | Yes |
@@ -35,7 +37,7 @@ The usual points of confusion:
 
 Actions tab, run the **Cut release** workflow. The form:
 
-* **one checkbox per project**: tick `wallet-dapp`, `station`, and so on. Tick nothing and it releases everything that changed since the last release, which nx works out from the commits. This is where you pick the whole batch or a subset.
+* **one checkbox per project**, named as in the table above. Tick nothing and it releases everything that changed since the last release, which nx works out from the commits. This is where you pick the whole batch or a subset.
 * **version_specifier**: `auto` lets the conventional commits decide the bump. Override with `patch` / `minor` / `major`, or with `prepatch` / `preminor` / `premajor` / `prerelease` to move onto a pre-release version.
 * **pre_release**: `none`, or `alpha` / `beta` / `rc` to cut something like `0.8.0-rc.0` instead of `0.8.0`. Only valid with `auto` or `prerelease`.
 * **dry_run**: computes the versions and changelogs and opens nothing, so you can preview.
@@ -60,7 +62,7 @@ Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-b
 
 ### Frontends to playground
 
-Actions tab, run **Deploy frontend**. Tick **wallet** and run it. It builds the station frontend for playground and uploads it to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
+Actions tab, run **Deploy frontend**. Tick the station frontend, which the form still calls **wallet**, and run it. It builds for playground and uploads to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
 
 Only the station frontend has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. All three backend targets do work on playground. Publishing to the registry needs only the control-panel and the wasm chunk store, and both exist there.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the a
 | `station` | `station` | Backend | Per-wallet backend, one deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
 | `upgrader` | `upgrader` | Backend | Per-station helper that performs safe upgrades, paired one-to-one with a station. Wasm to the registry. | Yes |
 | `control-panel` | `control-panel` | Backend | The single global registry and directory. Deploys stations. Wasm, deployed as the control-panel canister. | Yes |
-| `dfx-orbit` | `orbit-cli` | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
+| `dfx-orbit` | `orbit-cli`, but see below | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
 | `*-api`, `orbit-essentials` | (unchanged) | Crates | Shared Candid and types. No artifact, deploys nowhere. | Bumped automatically |
 
 Things worth stating plainly, because they are the usual source of confusion:
@@ -26,14 +26,14 @@ Things worth stating plainly, because they are the usual source of confusion:
 * The three frontends are separate projects with separate versions and separate asset canisters. They are not one "wallet dapp" bundle.
 * Only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
 * The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
-* `dfx-orbit` and `orbit-cli` are not the same tool. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target.
+* `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. Which is why the rename in the table above has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name refers to two different tools. Every other row in that table is a straight rename; this one is the exception.
 
 ## Phase 1: cut a release
 
 Actions tab, run the **Cut release** workflow. The form:
 
 * **one checkbox per project**: tick `wallet-dapp`, `station`, and so on. Tick nothing and it releases everything that changed since the last release, which nx works out from the commits. This is where you pick the whole batch or a subset.
-* **version_specifier**: `auto` lets the conventional commits decide the bump. Override with `patch` / `minor` / `major` if you need to.
+* **version_specifier**: `auto` lets the conventional commits decide the bump. Override with `patch` / `minor` / `major`, or with `prepatch` / `preminor` / `premajor` / `prerelease` to move onto a pre-release version.
 * **pre_release**: `none`, or `alpha` / `beta` / `rc` to cut something like `0.8.0-rc.0` instead of `0.8.0`. Only valid with `auto` or `prerelease`.
 * **dry_run**: computes the versions and changelogs and opens nothing, so you can preview.
 
@@ -92,8 +92,8 @@ Ask the release administrators for the vault reference. Whoever holds it is who 
 
 The deploy workflows need this in place before they can run:
 
-* Create the `playground` GitHub Environment and give it the playground deployment credential. The name the jobs look for is declared at the top of each deploy workflow.
+* Create the `playground` GitHub Environment and add `DEPLOY_STAGING_IDENTITY_PEM` (frontends) and `BACKEND_STAGING_IDENTITY_PEM` (backends) to it.
 * Restrict that environment's deployment branches to `main`, so a job on some other branch cannot claim the credential.
-* Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs required reviewers and the same branch restriction first.
+* Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs `DEPLOY_PRODUCTION_IDENTITY_PEM` and `BACKEND_PRODUCTION_IDENTITY_PEM`, plus required reviewers and the same branch restriction, first.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.
 * Stand up a persistent test station so backend wasms published to the playground registry can be exercised by a real self-upgrade before production.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the a
 
 | Current name | Proposed name | Type | Role and where it deploys | Ships alone |
 | --- | --- | --- | --- | --- |
-| `wallet-dapp` | `wallet-app` | Frontend | The wallet UI users log into. Asset tarball to the wallet canister (`5fu67`, app.orbit.global). | Yes |
+| `wallet-dapp` | `station-frontend` | Frontend | The wallet UI users log into. Asset tarball to the wallet canister (`5fu67`, app.orbit.global). | Yes |
 | `marketing-dapp` | `landing-page` | Frontend | The public marketing site. Asset tarball to the marketing canister (orbit.global). | Yes |
 | `docs-portal` | `docs-site` | Frontend | The documentation site. Asset tarball to the docs canister (docs.orbit.global). | Yes |
 | `station` | `station` | Backend | Per-wallet backend, one deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Most of this used to be manual. It is now three workflows: **Cut release**, **De
 
 ## Components
 
-There is no single "Orbit release". There are independently versioned projects, and nx bumps each one on its own from the conventional commits that touched it. Six produce a deployable artifact. The rest are internal crates that only exist to cascade a version bump.
+There is no single "Orbit release". There are independently versioned projects, and nx bumps each one on its own from the conventional commits that touched it. Six produce a deployable artifact. The rest are internal: shared crates that exist only to cascade a version bump, and the release tooling itself.
 
 The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is what we would rename it to in a separate PR. That rename has not been decided yet.
 
@@ -20,7 +20,8 @@ Prose here says station. The identifiers still say wallet for historical reasons
 | `station` | `station` | Backend | The backend, one instance deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
 | `upgrader` | `upgrader` | Backend | Per-station helper that performs safe upgrades, paired one-to-one with a station. Wasm to the registry. | Yes |
 | `control-panel` | `control-panel` | Backend | The single global registry and directory. Deploys stations. Wasm, deployed as the control-panel canister. | Yes |
-| `dfx-orbit` | `orbit-cli`, but see below | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
+| `dfx-orbit` | `orbit-cli` | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
+| `orbit-cli` (internal) | `orbit-release-cli` | Tooling | Drives the release: `release prepare`, `release publish`, `registry publish`. | Not released |
 | `*-api`, `orbit-essentials` | (unchanged) | Crates | Shared Candid and types. No artifact, deploys nowhere. | Bumped automatically |
 
 The usual points of confusion:
@@ -28,7 +29,7 @@ The usual points of confusion:
 * The three frontends are separate projects with separate versions and separate asset canisters. They are not a single bundle.
 * Apart from the three frontends, only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
 * The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
-* `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. So the rename in the table has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name means two different tools. Every other row is a straight rename.
+* `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. The rename settles this by moving the internal tool out of the way: it becomes `orbit-release-cli`, which frees `orbit-cli` for the CLI users install.
 
 ## Phase 1: cut a release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,7 +96,9 @@ Ask the release administrators for the vault reference. Whoever holds it is who 
 
 The playground network, its canisters and the live site all exist already. What is missing is the GitHub Actions plumbing to reach them:
 
-* Create the `playground` GitHub Environment and add `DEPLOY_PLAYGROUND_IDENTITY_PEM` (frontends) and `BACKEND_PLAYGROUND_IDENTITY_PEM` (backends) to it.
+* Mint an identity for CI that can reach playground and nothing else, then create the `playground` GitHub Environment and add it as `DEPLOY_PLAYGROUND_IDENTITY_PEM` (frontends) and `BACKEND_PLAYGROUND_IDENTITY_PEM` (backends).
+
+  Do not reuse the identity that deploys today. It controls the production canisters as well as the playground ones, so putting it here would give CI production access and undo the reason production is deployed by hand. The playground canisters already trust several principals that production does not, so a playground-only controller is a shape they already support. The new identity needs to be a controller of the playground canisters, authorized on the playground asset canister, and a registry admin on the playground control-panel.
 * Restrict that environment's deployment branches to `main`, so a job on some other branch cannot claim the credential.
 * Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs `DEPLOY_PRODUCTION_IDENTITY_PEM` and `BACKEND_PRODUCTION_IDENTITY_PEM`, plus required reviewers and the same branch restriction, first.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ Prose here says station. The identifiers still say wallet for historical reasons
 The usual points of confusion:
 
 * The three frontends are separate projects with separate versions and separate asset canisters. They are not a single bundle.
-* Only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
+* Apart from the three frontends, only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
 * The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
 * `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. So the rename in the table has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name means two different tools. Every other row is a straight rename.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Orbit release process
 
-A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. All of it runs from the Actions tab. This is the guide to what to click.
+A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. Everything up to and including a playground deploy runs from the Actions tab; production is a command an operator runs. This is the guide to both.
 
 Most of this used to be manual. It is now three workflows: **Cut release**, **Deploy frontend**, **Deploy backend**. Publishing was already automated and has not changed.
 
@@ -32,9 +32,9 @@ Things worth stating plainly, because they are the usual source of confusion:
 
 Actions tab, run the **Cut release** workflow. The form:
 
-* **projects**: comma-separated project names, for example `wallet-dapp,station`. Empty releases everything that changed since the last release. This is where you pick the whole batch or a subset.
+* **one checkbox per project**: tick `wallet-dapp`, `station`, and so on. Tick nothing and it releases everything that changed since the last release, which nx works out from the commits. This is where you pick the whole batch or a subset.
 * **version_specifier**: `auto` lets the conventional commits decide the bump. Override with `patch` / `minor` / `major` if you need to.
-* **pre_release**: `none`, or `alpha` / `beta` / `rc` for a pre-release.
+* **pre_release**: `none`, or `alpha` / `beta` / `rc` to cut something like `0.8.0-rc.0` instead of `0.8.0`. Only valid with `auto` or `prerelease`.
 * **dry_run**: computes the versions and changelogs and opens nothing, so you can preview.
 
 It runs `orbit-cli release prepare`, which bumps the versions, writes the changelogs, and updates `.release.json` in one commit, then opens a PR whose body lists exactly what is being released. Review the versions and merge it. If nothing changed, it says so and opens no PR.
@@ -47,34 +47,53 @@ This stops at the GitHub release. Nothing is on a live canister yet. That is pha
 
 ## Phase 3: deploy
 
-Two workflows, same shape. Pick a subset or the whole set, deploy to playground with no gate, then promote to production behind a single approval. One approval covers the whole selection.
+Playground and production are deployed differently on purpose.
 
-### Deploy frontend
+**Playground is a workflow.** Two of them, same shape: tick what you want, run it, done. No gate, because nothing user-facing is behind it.
 
-Actions tab, run **Deploy frontend**. Tick the apps you want (wallet on by default, marketing and docs off), and leave **promote_to_production** on unless you want a playground-only run.
+**Production is a command you run.** The key that signs a production deploy is not a repo secret, so there is no button for it. You run one script from a machine that can read the key. The reason is blast radius: a production frontend sync is live to every user the moment it finishes, and a control-panel upgrade has no buffer either, so we would rather the credential not sit somewhere a merged pull request can reach it.
 
-* The **playground** job builds each app for playground and uploads it. Go test at the playground URL.
-* The **production** job pauses for approval. Once approved, it uploads the released tarball to production.
+Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-backend`. The workflows are wrappers around them, so CI and a laptop do the same thing.
 
-Frontend config is baked in at build time, so playground gets its own build while production deploys the released production tarball.
+### Frontends to playground
 
-### Deploy backend
+Actions tab, run **Deploy frontend**. Tick the apps you want (wallet on by default, marketing and docs off) and run it. It builds each app for playground and uploads it. Go test at the playground URL.
 
-Actions tab, run **Deploy backend**. Tick station, upgrader, or control-panel, and leave promote on unless it is a playground-only run. The two backend types deploy differently:
+Leave **promote_to_production** unchecked. It is off by default and only does anything if a production key has been put on the environment, which is not how this is set up.
+
+### Backends to playground
+
+Actions tab, run **Deploy backend**. Tick station, upgrader, or control-panel and run it. Same as above: leave promote unchecked. The two backend types deploy differently:
 
 * **station / upgrader**: `orbit-cli registry publish` loads the wasm into the control-panel registry. This only makes the version available. Each production station still upgrades itself, or its upgrader, only when that station's own admins submit and approve the request (finance being 2-of-N). Publishing station also publishes upgrader, its dependency.
-* **control-panel**: a direct `dfx canister install --mode upgrade` of the one canister. There is no registry and no per-wallet buffer, so the approval gate is the only thing between this and every wallet. Handle with care.
+* **control-panel**: a direct `dfx canister install --mode upgrade` of the one canister. There is no registry and no per-wallet buffer, so nothing stands between this and every wallet. Handle with care.
 
-### The approval gate
+### Production
 
-The gate is native **GitHub Environments**. A `playground` environment that runs freely, and a `production` environment that requires a named approver. When a run reaches the production job, GitHub pauses it and shows a "review pending deployments" banner. A reviewer clicks approve and the job runs. If you are not on the reviewer list, the run stops at playground. Reviewers are set in Settings, Environments, production, Required reviewers.
+Run it from a machine that can read the signing key. `--op` takes a 1Password secret reference and reads the key into a temp file that is deleted when the script exits, so nothing is written down by hand. `--pem` takes a path if you already have the key on disk.
+
+Frontends. This deploys the released tarball, not a local build:
+
+```
+./scripts/deploy-app --app wallet --env production --tag latest --op "op://<vault>/<item>/identity.pem"
+```
+
+Backends. One target per run, and `station` publishes `upgrader` with it:
+
+```
+./scripts/deploy-backend --target station --network production --op "op://<vault>/<item>/identity.pem"
+```
+
+Both print what they are about to do and ask for confirmation. Both verify the artifact's published checksum before shipping it. `deploy-backend` also refuses to run if your checkout is not the release you are deploying, because the registry labels the entry with the version from your working tree rather than from the artifact, so a stale checkout would publish the right wasm under the wrong version. If it stops for that reason, check out the tag it names and run it again.
+
+Ask the release administrators for the vault reference. Whoever holds it is who can deploy production, which is the point.
 
 ## One-time setup
 
 The deploy workflows need this in place before they can run:
 
-* Create the `playground` and `production` GitHub Environments.
-* Configure each environment with the deployment credentials its jobs expect. The required names are declared at the top of the deploy workflows, and the values are held by the team that administers releases.
-* Add required reviewers to `production`. That is the approval gate.
+* Create the `playground` GitHub Environment and give it the playground deployment credential. The name the jobs look for is declared at the top of each deploy workflow.
+* Restrict that environment's deployment branches to `main`, so a job on some other branch cannot claim the credential.
+* Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs required reviewers and the same branch restriction first.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.
 * Stand up a persistent test station so backend wasms published to the playground registry can be exercised by a real self-upgrade before production.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,7 +57,9 @@ Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-b
 
 ### Frontends to playground
 
-Actions tab, run **Deploy frontend**. Tick the apps you want (wallet on by default, marketing and docs off) and run it. It builds each app for playground and uploads it. Go test at the playground URL.
+Actions tab, run **Deploy frontend**. Tick **wallet** and run it. It builds the wallet for playground and uploads it to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
+
+Only the wallet has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. The backends are unaffected: all three targets work on playground, since the registry publish path needs only the control-panel and the wasm chunk store, both of which exist there.
 
 Leave **promote_to_production** unchecked. It is off by default and only does anything if a production key has been put on the environment, which is not how this is set up.
 
@@ -92,9 +94,9 @@ Ask the release administrators for the vault reference. Whoever holds it is who 
 
 ## One-time setup
 
-The deploy workflows need this in place before they can run:
+The playground network, its canisters and the live site all exist already. What is missing is the GitHub Actions plumbing to reach them:
 
-* Create the `playground` GitHub Environment and add `DEPLOY_STAGING_IDENTITY_PEM` (frontends) and `BACKEND_STAGING_IDENTITY_PEM` (backends) to it.
+* Create the `playground` GitHub Environment and add `DEPLOY_PLAYGROUND_IDENTITY_PEM` (frontends) and `BACKEND_PLAYGROUND_IDENTITY_PEM` (backends) to it.
 * Restrict that environment's deployment branches to `main`, so a job on some other branch cannot claim the credential.
 * Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs `DEPLOY_PRODUCTION_IDENTITY_PEM` and `BACKEND_PRODUCTION_IDENTITY_PEM`, plus required reviewers and the same branch restriction, first.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the a
 | --- | --- | --- | --- | --- |
 | `wallet-dapp` | `station-frontend` | Frontend | The wallet UI users log into. Asset tarball to the wallet canister (`5fu67`, app.orbit.global). | Yes |
 | `marketing-dapp` | `landing-page` | Frontend | The public marketing site. Asset tarball to the marketing canister (orbit.global). | Yes |
-| `docs-portal` | `docs-site` | Frontend | The documentation site. Asset tarball to the docs canister (docs.orbit.global). | Yes |
+| `docs-portal` | `docs-portal` | Frontend | The documentation site. Asset tarball to the docs canister (docs.orbit.global). | Yes |
 | `station` | `station` | Backend | Per-wallet backend, one deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
 | `upgrader` | `upgrader` | Backend | Per-station helper that performs safe upgrades, paired one-to-one with a station. Wasm to the registry. | Yes |
 | `control-panel` | `control-panel` | Backend | The single global registry and directory. Deploys stations. Wasm, deployed as the control-panel canister. | Yes |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,86 @@
+# Orbit release process
+
+A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. All of it runs from the Actions tab. This is the guide to what to click.
+
+Most of this used to be manual, run from a laptop with the production key. It is now three workflows: **Cut release**, **Deploy frontend**, **Deploy backend**. Publishing was already automated and has not changed.
+
+## Components
+
+There is no single "Orbit release". There are independently versioned projects, and nx bumps each one on its own from the conventional commits that touched it. Six produce a deployable artifact. The rest are internal crates that only exist to cascade a version bump.
+
+The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is the clearer one we would move to in a separate PR if we decide to.
+
+| Current name | Proposed name | Type | Role and where it deploys | Ships alone |
+| --- | --- | --- | --- | --- |
+| `wallet-dapp` | `wallet-app` | Frontend | The wallet UI users log into. Asset tarball to the wallet canister (`5fu67`, app.orbit.global). | Yes |
+| `marketing-dapp` | `landing-page` | Frontend | The public marketing site. Asset tarball to the marketing canister (orbit.global). | Yes |
+| `docs-portal` | `docs-site` | Frontend | The documentation site. Asset tarball to the docs canister (docs.orbit.global). | Yes |
+| `station` | `station` | Backend | Per-wallet backend, one deployed per org. Wasm to the control-panel registry, stations self-upgrade. | Yes |
+| `upgrader` | `upgrader` | Backend | Per-station helper that performs safe upgrades, paired one-to-one with a station. Wasm to the registry. | Yes |
+| `control-panel` | `control-panel` | Backend | The single global registry and directory. Deploys stations. Wasm, deployed as the control-panel canister. | Yes |
+| `dfx-orbit` | `orbit-cli` | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
+| `*-api`, `orbit-essentials` | (unchanged) | Crates | Shared Candid and types. No artifact, deploys nowhere. | Bumped automatically |
+
+Things worth stating plainly, because they are the usual source of confusion:
+
+* The three frontends are separate projects with separate versions and separate asset canisters. They are not one "wallet dapp" bundle.
+* Only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
+* The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
+* `dfx-orbit` and `orbit-cli` are not the same tool. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target.
+
+## Phase 1: cut a release
+
+Actions tab, run the **Cut release** workflow. The form:
+
+* **projects**: comma-separated project names, for example `wallet-dapp,station`. Empty releases everything that changed since the last release. This is where you pick the whole batch or a subset.
+* **version_specifier**: `auto` lets the conventional commits decide the bump. Override with `patch` / `minor` / `major` if you need to.
+* **pre_release**: `none`, or `alpha` / `beta` / `rc` for a pre-release.
+* **dry_run**: computes the versions and changelogs and opens nothing, so you can preview.
+
+It runs `orbit-cli release prepare`, which bumps the versions, writes the changelogs, and updates `.release.json` in one commit, then opens a PR whose body lists exactly what is being released. Review the versions and merge it. If nothing changed, it says so and opens no PR.
+
+## Phase 2: publish (automatic)
+
+Merging the release PR touches `.release.json`, which fires the existing **Release** workflow (`release.yaml`). It builds each artifact, creates the `@orbit/<project>-v<version>` tag, and creates the GitHub release with the artifact attached. You do not click anything.
+
+This stops at the GitHub release. Nothing is on a live canister yet. That is phase 3.
+
+## Phase 3: deploy
+
+Two workflows, same shape. Pick a subset or the whole set, deploy to playground with no gate, then promote to production behind a single approval. One approval covers the whole selection.
+
+### Deploy frontend
+
+Actions tab, run **Deploy frontend**. Tick the apps you want (wallet on by default, marketing and docs off), and leave **promote_to_production** on unless you want a playground-only run.
+
+* The **playground** job builds each app for playground and uploads it. Go test at the playground URL.
+* The **production** job pauses for approval. Once approved, it uploads the released tarball to production.
+
+Frontend config is baked in at build time, so playground gets its own build while production deploys the released production tarball.
+
+### Deploy backend
+
+Actions tab, run **Deploy backend**. Tick station, upgrader, or control-panel, and leave promote on unless it is a playground-only run. The two backend types deploy differently:
+
+* **station / upgrader**: `orbit-cli registry publish` loads the wasm into the control-panel registry. This only makes the version available. Each production station still upgrades itself, or its upgrader, only when that station's own admins submit and approve the request (finance being 2-of-N). Publishing station also publishes upgrader, its dependency.
+* **control-panel**: a direct `dfx canister install --mode upgrade` of the one canister. There is no registry and no per-wallet buffer, so the approval gate is the only thing between this and every wallet. Handle with care.
+
+### The approval gate
+
+The gate is native **GitHub Environments**. A `playground` environment that runs freely, and a `production` environment that requires a named approver. When a run reaches the production job, GitHub pauses it and shows a "review pending deployments" banner. A reviewer clicks approve and the job runs. If you are not on the reviewer list, the run stops at playground. Reviewers are set in Settings, Environments, production, Required reviewers.
+
+## One-time setup
+
+The deploy workflows need this in place before they can run:
+
+* Create the `playground` and `production` GitHub Environments.
+* Add the signing key as a secret on each: `DEPLOY_IDENTITY_PEM` for the frontend workflow, `BACKEND_IDENTITY_PEM` for the backend workflow, each scoped to the environment so a job only ever sees its own key. The backend identity must be both a registry admin on the control-panel and a controller of the control-panel canister.
+* Add required reviewers to `production`. That is the approval gate.
+* Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.
+* Stand up a persistent test station so backend wasms published to the playground registry can be exercised by a real self-upgrade before production.
+
+One decision affects the frontend production job: whether the production key lives in the `production` environment as a secret, or stays off CI. In CI, production is a one-approval click. Off CI, production stays a local `scripts/deploy-app` run reading the key from 1Password, and the master key never touches GitHub. A reasonable start is production local, playground automated, and move production into the protected environment once the flow is trusted.
+
+## Release cadence
+
+We don't have a set release cadence today. I'd propose a bi-weekly one, every second Thursday. It would be best-effort, but it gives us a bit of urgency and a rhythm to work to. A recurring Google Calendar event can act as the soft reminder.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Orbit release process
 
-A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. Everything up to and including a playground deploy runs from the Actions tab; production is a command an operator runs. This is the guide to both.
+A release has three phases: cut, publish, deploy. Cutting and publishing are one flow that ends in a GitHub release with the built artifact attached. Deploying is what puts that artifact on the live canisters. Everything up to and including a playground deploy runs from the Actions tab. Production is a command an operator runs.
 
 Most of this used to be manual. It is now three workflows: **Cut release**, **Deploy frontend**, **Deploy backend**. Publishing was already automated and has not changed.
 
@@ -8,7 +8,7 @@ Most of this used to be manual. It is now three workflows: **Cut release**, **De
 
 There is no single "Orbit release". There are independently versioned projects, and nx bumps each one on its own from the conventional commits that touched it. Six produce a deployable artifact. The rest are internal crates that only exist to cascade a version bump.
 
-The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is the clearer one we would move to in a separate PR if we decide to.
+The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is what we would rename it to in a separate PR. That rename has not been decided yet.
 
 Prose here says station, not wallet. Identifiers still say wallet, because that is what they literally are: the `wallet-dapp` project, the `wallet` checkbox on the deploy form, `--app wallet`, the `app_wallet` key in `canister_ids.json`. Changing those is the rename PR, not a wording fix.
 
@@ -23,12 +23,12 @@ Prose here says station, not wallet. Identifiers still say wallet, because that 
 | `dfx-orbit` | `orbit-cli`, but see below | CLI | The CLI we ship to users. Git tag and GitHub release, users install it themselves. | Yes |
 | `*-api`, `orbit-essentials` | (unchanged) | Crates | Shared Candid and types. No artifact, deploys nowhere. | Bumped automatically |
 
-Things worth stating plainly, because they are the usual source of confusion:
+The usual points of confusion:
 
 * The three frontends are separate projects with separate versions and separate asset canisters. They are not a single bundle.
 * Only the Control Panel is a singleton. There is one global instance. Station and Upgrader are multi-instance: the Control Panel deploys a fresh Station per org, and each Station comes paired with its own Upgrader. Station and Upgrader deploy and control each other, which is what makes a station upgrade safe.
 * The `station-api` / `upgrader-api` / `control-panel-api` crates are the contract, just the Candid interface and shared types. The bare name (`station`) is the canister that runs; the `-api` crate compiles to no canister. Bumping an api crate cascades a bump into whatever depends on it, which is why one small change can move several version numbers at once.
-* `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. Which is why the rename in the table above has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name refers to two different tools. Every other row in that table is a straight rename; this one is the exception.
+* `dfx-orbit` and `orbit-cli` are not the same tool today. `dfx-orbit` is the CLI we ship to users. `orbit-cli` is our internal tool that drives the release (`release prepare`, `release publish`, `registry publish`). Only `dfx-orbit` is a release target. So the rename in the table has a catch: giving the user-facing CLI the name `orbit-cli` means renaming the internal one in the same change, or the name means two different tools. Every other row is a straight rename.
 
 ## Phase 1: cut a release
 
@@ -51,9 +51,9 @@ This stops at the GitHub release. Nothing is on a live canister yet. That is pha
 
 Playground and production are deployed differently on purpose.
 
-**Playground is a workflow.** Two of them, same shape: tick what you want, run it, done. No gate, because nothing user-facing is behind it.
+**Playground is a workflow.** **Deploy frontend** and **Deploy backend** both work the same way: tick what you want and run it. Neither asks for approval, because no user sees playground.
 
-**Production is a command you run.** The key that signs a production deploy is not a repo secret, so there is no button for it. You run one script from a machine that can read the key. The reason is blast radius: a production frontend sync is live to every user the moment it finishes, and a control-panel upgrade has no buffer either, so we would rather the credential not sit somewhere a merged pull request can reach it.
+**Production is a command you run.** The key that signs a production deploy is not a repo secret, so there is no button for it. You run one script from a machine that can read the key. A production frontend sync reaches every user the moment it finishes, and a control-panel upgrade reaches every station, so the key that does either should not sit where a merged pull request can read it.
 
 Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-backend`. The workflows are wrappers around them, so CI and a laptop do the same thing.
 
@@ -61,9 +61,9 @@ Both halves run the same two scripts, `scripts/deploy-app` and `scripts/deploy-b
 
 Actions tab, run **Deploy frontend**. Tick **wallet** and run it. It builds the station frontend for playground and uploads it to `bxkhk-6yaaa-aaaal-ai6va-cai`. Go test at https://playground.orbitwallet.io.
 
-Only the station frontend has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. The backends are unaffected: all three targets work on playground, since the registry publish path needs only the control-panel and the wasm chunk store, both of which exist there.
+Only the station frontend has a playground canister. `marketing-dapp` and `docs-portal` exist on production only, so ticking them here fails on purpose, with a message telling you to deploy them to production instead. All three backend targets do work on playground. Publishing to the registry needs only the control-panel and the wasm chunk store, and both exist there.
 
-Leave **promote_to_production** unchecked. It is off by default and only does anything if a production key has been put on the environment, which is not how this is set up.
+Leave **promote_to_production** unchecked. It is off by default, and the `production` environment holds no key, so ticking it just fails the second job.
 
 ### Backends to playground
 
@@ -90,18 +90,20 @@ Backends. One target per run, and `station` publishes `upgrader` with it:
 
 Both resolve to the newest stable release and skip pre-releases, so an rc sitting at the top of the list will not be picked up by accident. To deploy one on purpose, pass the tag: `deploy-app --tag @orbit/wallet-dapp-v0.8.0-rc.0`.
 
-Both print what they are about to do and ask for confirmation. Both verify the artifact's published checksum before shipping it. `deploy-backend` also refuses to run if your checkout is not the release you are deploying, because the registry labels the entry with the version from your working tree rather than from the artifact, so a stale checkout would publish the right wasm under the wrong version. If it stops for that reason, check out the tag it names and run it again.
+Both print what they are about to do and wait for you to confirm, and both check the artifact against the checksum published beside it.
 
-Ask the release administrators for the vault reference. Whoever holds it is who can deploy production, which is the point.
+`deploy-backend` also stops if your checkout is not the release you are deploying. The registry takes the version label from your working tree instead of from the artifact, so a stale checkout would publish the right wasm under the wrong version. Check out the tag it names and run it again.
+
+Ask the release administrators for the vault reference. Whoever holds it can deploy production, and nobody else can.
 
 ## One-time setup
 
-The playground network, its canisters and the live site all exist already. What is missing is the GitHub Actions plumbing to reach them:
+The playground network, its canisters and the live site all exist already. What is missing is the GitHub Actions configuration to reach them:
 
 * Mint an identity for CI that can reach playground and nothing else, then create the `playground` GitHub Environment and add it as `DEPLOY_PLAYGROUND_IDENTITY_PEM` (frontends) and `BACKEND_PLAYGROUND_IDENTITY_PEM` (backends).
 
-  Do not reuse the identity that deploys today. It controls the production canisters as well as the playground ones, so putting it here would give CI production access and undo the reason production is deployed by hand. The playground canisters already trust several principals that production does not, so a playground-only controller is a shape they already support. The new identity needs to be a controller of the playground canisters, authorized on the playground asset canister, and a registry admin on the playground control-panel.
+  Do not reuse the identity that deploys today. It controls the production canisters as well as the playground ones, so putting it here would hand CI production access and cancel out the reason production is deployed by hand. The playground canisters already trust several principals that production does not, so this is nothing new for them. The new identity needs to be a controller of the playground canisters, authorized on the playground asset canister, and a registry admin on the playground control-panel.
 * Restrict that environment's deployment branches to `main`, so a job on some other branch cannot claim the credential.
 * Create the `production` environment but leave it without a key, which is what keeps the production job inert. If production deploys are ever moved into CI, that environment needs `DEPLOY_PRODUCTION_IDENTITY_PEM` and `BACKEND_PRODUCTION_IDENTITY_PEM`, plus required reviewers and the same branch restriction, first.
 * Fix the playground `derivationOrigin` so Internet Identity login works there, ideally by making it come from an env var.
-* Stand up a persistent test station so backend wasms published to the playground registry can be exercised by a real self-upgrade before production.
+* Stand up a test station that stays up, so someone can run a real self-upgrade against a wasm in the playground registry before it goes to production.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ There is no single "Orbit release". There are independently versioned projects, 
 
 The current name is fixed. It is the git tag (`@orbit/{name}-v{version}`), the artifact name, and the build target, so renaming it is a real change, not a label. The proposed name is what we would rename it to in a separate PR. That rename has not been decided yet.
 
-Prose here says station, not wallet. Identifiers still say wallet, because that is what they literally are: the `wallet-dapp` project, the `wallet` checkbox on the deploy form, `--app wallet`, the `app_wallet` key in `canister_ids.json`. Changing those is the rename PR, not a wording fix.
+Prose here says station. The identifiers still say wallet for historical reasons: the `wallet-dapp` project, the `wallet` checkbox on the deploy form, `--app wallet`, the `app_wallet` key in `canister_ids.json`. Renaming those is a lot of work for a wording change. It splits the release tag series in two, so the scripts that resolve `latest` have to know both names, and every published release keeps the old one. It needs its own PR.
 
 | Current name | Proposed name | Type | Role and where it deploys | Ships alone |
 | --- | --- | --- | --- | --- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,6 +84,8 @@ Backends. One target per run, and `station` publishes `upgrader` with it:
 ./scripts/deploy-backend --target station --network production --op "op://<vault>/<item>/identity.pem"
 ```
 
+Both resolve to the newest stable release and skip pre-releases, so an rc sitting at the top of the list will not be picked up by accident. To deploy one on purpose, pass the tag: `deploy-app --tag @orbit/wallet-dapp-v0.8.0-rc.0`.
+
 Both print what they are about to do and ask for confirmation. Both verify the artifact's published checksum before shipping it. `deploy-backend` also refuses to run if your checkout is not the release you are deploying, because the registry labels the entry with the version from your working tree rather than from the artifact, so a stale checkout would publish the right wasm under the wrong version. If it stops for that reason, check out the tag it names and run it again.
 
 Ask the release administrators for the vault reference. Whoever holds it is who can deploy production, which is the point.


### PR DESCRIPTION
Adds `RELEASE.md`, an operator guide to the release process.

It opens with the component table, since that is where the confusion lives: what each project is, which pieces are singletons and which are per-org pairs, what an `-api` crate is versus the canister that runs, and that `dfx-orbit` and `orbit-cli` are different tools. Each row carries the current name beside a proposed one, so a rename can be discussed separately from this change.

Then the three phases: which boxes to tick to cut a release, how publish fires on merge with nothing to click, and how deploy splits into playground workflows and production commands, with the reason for that split and the exact commands. It ends with the one-time environment setup, including why the identity that deploys today must not be reused for CI.

Also corrects the Phase 1 section, which described a comma-separated `projects` field after that input became one checkbox per project.
