### PR TITLE
feat(wallet): show wasm_memory_persistence upgrade options on change canister requests

### DIFF
--- a/apps/wallet/src/components/requests/RequestDetailView.spec.ts
+++ b/apps/wallet/src/components/requests/RequestDetailView.spec.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it, vi } from 'vitest';
 import { mount } from '~/test.utils';
 import RequestDetailView from './RequestDetailView.vue';
+import ChangeExternalCanisterOperation from './operations/ChangeExternalCanisterOperation.vue';
 import { variantIs } from '~/utils/helper.utils';
 import { useStationStore } from '~/stores/station.store';
+import { services } from '~/plugins/services.plugin';
 import { flushPromises } from '@vue/test-utils';
 
 type RequestDetailViewProps = InstanceType<typeof RequestDetailView>['$props'];
@@ -250,7 +253,40 @@ const cancelledProps: RequestDetailViewProps = {
   },
 };
 
+const changeCanisterProps: RequestDetailViewProps = {
+  details: pendingProps.details,
+  request: {
+    ...pendingProps.request,
+    operation: {
+      ChangeExternalCanister: {
+        canister_id: Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai'),
+        mode: {
+          upgrade: [{ wasm_memory_persistence: [{ keep: null }], skip_pre_upgrade: [] }],
+        },
+        module_checksum: 'a'.repeat(64),
+        arg_checksum: [],
+      },
+    },
+  },
+};
+
 describe('RequestDetailView', () => {
+  it('renders change canister requests with their upgrade options', async () => {
+    vi.spyOn(services().station, 'getExternalCanisterByCanisterId').mockRejectedValueOnce(
+      new Error('not found'),
+    );
+
+    const wrapper = mount(RequestDetailView, {
+      props: changeCanisterProps,
+    });
+    await flushPromises();
+
+    expect(wrapper.findComponent(ChangeExternalCanisterOperation).exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').text()).toBe(
+      'Keep',
+    );
+  });
+
   it('renders properly', () => {
     const wrapper = mount(RequestDetailView, {
       props: pendingProps,

--- a/apps/wallet/src/components/requests/RequestDetailView.vue
+++ b/apps/wallet/src/components/requests/RequestDetailView.vue
@@ -257,6 +257,7 @@ import AddRequestPolicyOperation from './operations/AddRequestPolicyOperation.vu
 import AddUserGroupOperation from './operations/AddUserGroupOperation.vue';
 import AddUserOperation from './operations/AddUserOperation.vue';
 import CallExternalCanisterOperation from './operations/CallExternalCanisterOperation.vue';
+import ChangeExternalCanisterOperation from './operations/ChangeExternalCanisterOperation.vue';
 import EditAccountOperation from './operations/EditAccountOperation.vue';
 import EditAddressBookEntryOperation from './operations/EditAddressBookEntryOperation.vue';
 import EditPermissionOperation from './operations/EditPermissionOperation.vue';
@@ -318,12 +319,12 @@ const componentsMap: {
   EditAsset: EditAssetOperation,
   RemoveAsset: RemoveAssetOperation,
   CallExternalCanister: CallExternalCanisterOperation,
+  ChangeExternalCanister: ChangeExternalCanisterOperation,
   AddNamedRule: AddNamedRuleOperation,
   EditNamedRule: EditNamedRuleOperation,
   RemoveNamedRule: RemoveNamedRuleOperation,
   SetDisasterRecovery: SetDisasterRecoveryOperation,
 
-  ChangeExternalCanister: UnsupportedOperation,
   CreateExternalCanister: UnsupportedOperation,
   ConfigureExternalCanister: UnsupportedOperation,
   FundExternalCanister: UnsupportedOperation,

--- a/apps/wallet/src/components/requests/RequestListItem.vue
+++ b/apps/wallet/src/components/requests/RequestListItem.vue
@@ -51,6 +51,7 @@ import AddRequestPolicyOperation from './operations/AddRequestPolicyOperation.vu
 import AddUserGroupOperation from './operations/AddUserGroupOperation.vue';
 import AddUserOperation from './operations/AddUserOperation.vue';
 import CallExternalCanisterOperation from './operations/CallExternalCanisterOperation.vue';
+import ChangeExternalCanisterOperation from './operations/ChangeExternalCanisterOperation.vue';
 import EditAccountOperation from './operations/EditAccountOperation.vue';
 import EditAddressBookEntryOperation from './operations/EditAddressBookEntryOperation.vue';
 import EditPermissionOperation from './operations/EditPermissionOperation.vue';
@@ -108,6 +109,7 @@ const componentsMap: {
   EditPermission: EditPermissionOperation,
   ManageSystemInfo: ManageSystemInfoOperation,
   CallExternalCanister: CallExternalCanisterOperation,
+  ChangeExternalCanister: ChangeExternalCanisterOperation,
   AddAsset: AddAssetOperation,
   EditAsset: EditAssetOperation,
   RemoveAsset: RemoveAssetOperation,
@@ -117,7 +119,6 @@ const componentsMap: {
   SetDisasterRecovery: SetDisasterRecoveryOperation,
 
   // below variants are not supported yet
-  ChangeExternalCanister: UnsupportedOperation,
   CreateExternalCanister: UnsupportedOperation,
   ConfigureExternalCanister: UnsupportedOperation,
   FundExternalCanister: UnsupportedOperation,

--- a/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.spec.ts
+++ b/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.spec.ts
@@ -1,0 +1,196 @@
+import { Principal } from '@dfinity/principal';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CanisterInstallMode,
+  ChangeExternalCanisterOperation as ChangeExternalCanisterOperationDTO,
+  Request,
+} from '~/generated/station/station.did';
+import { services } from '~/plugins/services.plugin';
+import { mount } from '~/test.utils';
+import ChangeExternalCanisterOperation from './ChangeExternalCanisterOperation.vue';
+
+type ExternalCanisterLookup = Awaited<
+  ReturnType<ReturnType<typeof services>['station']['getExternalCanisterByCanisterId']>
+>;
+
+const canisterId = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+const moduleChecksum = 'a'.repeat(64);
+const argChecksum = 'b'.repeat(64);
+
+const operationWithMode = (mode: CanisterInstallMode): ChangeExternalCanisterOperationDTO => ({
+  mode,
+  canister_id: canisterId,
+  module_checksum: moduleChecksum,
+  arg_checksum: [argChecksum],
+});
+
+const requestWith = (operation: ChangeExternalCanisterOperationDTO): Request => ({
+  id: 'request-id',
+  title: 'Upgrade canister',
+  summary: [],
+  status: { Created: null },
+  approvals: [],
+  created_at: '',
+  execution_plan: { Immediate: null },
+  expiration_dt: '',
+  requested_by: 'requester-id',
+  tags: [],
+  deduplication_key: [],
+  operation: { ChangeExternalCanister: operation },
+});
+
+const mountOperation = (operation: ChangeExternalCanisterOperationDTO, mode: 'list' | 'detail') =>
+  mount(ChangeExternalCanisterOperation, {
+    props: {
+      request: requestWith(operation),
+      operation,
+      mode,
+    },
+  });
+
+const keepUpgrade: CanisterInstallMode = {
+  upgrade: [{ wasm_memory_persistence: [{ keep: null }], skip_pre_upgrade: [] }],
+};
+
+describe('ChangeExternalCanisterOperation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the canister id, install mode and checksums', () => {
+    const wrapper = mountOperation(operationWithMode({ install: null }), 'list');
+
+    expect(wrapper.find('[data-test-id="change-canister-target"]').text()).toBe(
+      canisterId.toText(),
+    );
+    expect(wrapper.find('[data-test-id="change-canister-mode"]').text()).toBe('Install');
+    expect(wrapper.find('[data-test-id="change-canister-module-checksum"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-id="change-canister-arg-checksum"]').exists()).toBe(true);
+  });
+
+  it('shows the full checksums in detail mode', async () => {
+    vi.spyOn(services().station, 'getExternalCanisterByCanisterId').mockRejectedValueOnce(
+      new Error('not found'),
+    );
+
+    const wrapper = mountOperation(operationWithMode({ reinstall: null }), 'detail');
+    await flushPromises();
+
+    expect(wrapper.find('[data-test-id="change-canister-mode"]').text()).toBe('Reinstall');
+    expect(wrapper.find('[data-test-id="change-canister-module-checksum"]').text()).toBe(
+      moduleChecksum,
+    );
+    expect(wrapper.find('[data-test-id="change-canister-arg-checksum"]').text()).toBe(argChecksum);
+  });
+
+  it('omits the argument checksum row when the request has no argument', () => {
+    const wrapper = mountOperation(
+      { ...operationWithMode({ install: null }), arg_checksum: [] },
+      'list',
+    );
+
+    expect(wrapper.find('[data-test-id="change-canister-arg-checksum"]').exists()).toBe(false);
+  });
+
+  it('shows the wasm memory persistence of an upgrade in list mode when it is set', () => {
+    const wrapper = mountOperation(operationWithMode(keepUpgrade), 'list');
+
+    expect(wrapper.find('[data-test-id="change-canister-mode"]').text()).toBe('Upgrade');
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').text()).toBe(
+      'Keep',
+    );
+    expect(wrapper.text()).toContain('Wasm Memory Persistence');
+  });
+
+  it('shows the skip pre-upgrade flag of an upgrade when it is set', () => {
+    const wrapper = mountOperation(
+      operationWithMode({
+        upgrade: [{ wasm_memory_persistence: [{ replace: null }], skip_pre_upgrade: [true] }],
+      }),
+      'list',
+    );
+
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').text()).toBe(
+      'Replace',
+    );
+    expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').text()).toBe('Yes');
+  });
+
+  it('hides the upgrade options in list mode when the upgrade does not set them', () => {
+    const wrapper = mountOperation(operationWithMode({ upgrade: [] }), 'list');
+
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').exists()).toBe(false);
+  });
+
+  it('shows the effective upgrade options in detail mode for a plain upgrade', async () => {
+    vi.spyOn(services().station, 'getExternalCanisterByCanisterId').mockRejectedValueOnce(
+      new Error('not found'),
+    );
+
+    const wrapper = mountOperation(operationWithMode({ upgrade: [] }), 'detail');
+    await flushPromises();
+
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').text()).toBe(
+      'Default (replace)',
+    );
+    expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').text()).toBe('No');
+  });
+
+  it('does not show upgrade options for install and reinstall requests', async () => {
+    vi.spyOn(services().station, 'getExternalCanisterByCanisterId').mockRejectedValue(
+      new Error('not found'),
+    );
+
+    for (const mode of [{ install: null }, { reinstall: null }] as CanisterInstallMode[]) {
+      const wrapper = mountOperation(operationWithMode(mode), 'detail');
+      await flushPromises();
+
+      expect(
+        wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').exists(),
+      ).toBe(false);
+      expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').exists()).toBe(
+        false,
+      );
+    }
+  });
+
+  it('resolves the canister name in detail mode', async () => {
+    const lookup = vi
+      .spyOn(services().station, 'getExternalCanisterByCanisterId')
+      .mockResolvedValueOnce({ canister: { name: 'Backend' } } as ExternalCanisterLookup);
+
+    const wrapper = mountOperation(operationWithMode(keepUpgrade), 'detail');
+    await flushPromises();
+
+    expect(lookup).toHaveBeenCalledWith(canisterId);
+    expect(wrapper.find('[data-test-id="change-canister-target"]').text()).toBe(
+      `Backend (${canisterId.toText()})`,
+    );
+  });
+
+  it('falls back to the canister id when the canister cannot be resolved', async () => {
+    vi.spyOn(services().station, 'getExternalCanisterByCanisterId').mockRejectedValueOnce(
+      new Error('not found'),
+    );
+
+    const wrapper = mountOperation(operationWithMode(keepUpgrade), 'detail');
+    await flushPromises();
+
+    expect(wrapper.find('[data-test-id="change-canister-target"]').text()).toBe(
+      canisterId.toText(),
+    );
+  });
+
+  it('does not look up the canister in list mode', async () => {
+    const lookup = vi.spyOn(services().station, 'getExternalCanisterByCanisterId');
+
+    mountOperation(operationWithMode(keepUpgrade), 'list');
+    await flushPromises();
+
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.spec.ts
+++ b/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.spec.ts
@@ -117,6 +117,20 @@ describe('ChangeExternalCanisterOperation', () => {
     expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').text()).toBe('Yes');
   });
 
+  it('shows an explicitly disabled skip pre-upgrade flag in list mode', () => {
+    const wrapper = mountOperation(
+      operationWithMode({
+        upgrade: [{ wasm_memory_persistence: [], skip_pre_upgrade: [false] }],
+      }),
+      'list',
+    );
+
+    expect(wrapper.find('[data-test-id="change-canister-skip-pre-upgrade"]').text()).toBe('No');
+    expect(wrapper.find('[data-test-id="change-canister-wasm-memory-persistence"]').exists()).toBe(
+      false,
+    );
+  });
+
   it('hides the upgrade options in list mode when the upgrade does not set them', () => {
     const wrapper = mountOperation(operationWithMode({ upgrade: [] }), 'list');
 
@@ -166,7 +180,8 @@ describe('ChangeExternalCanisterOperation', () => {
     const wrapper = mountOperation(operationWithMode(keepUpgrade), 'detail');
     await flushPromises();
 
-    expect(lookup).toHaveBeenCalledWith(canisterId);
+    // The name is resolved with a verified call, like the request itself.
+    expect(lookup).toHaveBeenCalledWith(canisterId, true);
     expect(wrapper.find('[data-test-id="change-canister-target"]').text()).toBe(
       `Backend (${canisterId.toText()})`,
     );

--- a/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.vue
+++ b/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.vue
@@ -112,7 +112,13 @@ const wasmMemoryPersistence = computed<WasmMemoryPersistence | undefined>(
   () => upgradeOptions.value?.wasm_memory_persistence[0],
 );
 
-const skipPreUpgrade = computed<boolean>(() => upgradeOptions.value?.skip_pre_upgrade[0] ?? false);
+// `undefined` when the request does not set the option, which differs from an
+// explicit `false`.
+const skipPreUpgradeOption = computed<boolean | undefined>(
+  () => upgradeOptions.value?.skip_pre_upgrade[0],
+);
+
+const skipPreUpgrade = computed<boolean>(() => skipPreUpgradeOption.value ?? false);
 
 // The compact list view only surfaces the upgrade options when they were
 // explicitly set on the request, while the detail view always shows the
@@ -122,7 +128,7 @@ const showWasmMemoryPersistence = computed(
 );
 
 const showSkipPreUpgrade = computed(
-  () => isUpgrade.value && (!isListMode.value || skipPreUpgrade.value),
+  () => isUpgrade.value && (!isListMode.value || skipPreUpgradeOption.value !== undefined),
 );
 
 const wasmMemoryPersistenceLabel = computed(() => {
@@ -152,8 +158,12 @@ const canisterLabel = computed(() => {
 
 const loadCanisterName = async (): Promise<void> => {
   try {
+    // The name is shown to approvers next to the canister id as the target of the
+    // change, so it is fetched with a verified (certified) call like the request
+    // itself rather than a plain query.
     const result = await station.service.getExternalCanisterByCanisterId(
       props.operation.canister_id,
+      true,
     );
 
     canisterName.value = result.canister.name;

--- a/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.vue
+++ b/apps/wallet/src/components/requests/operations/ChangeExternalCanisterOperation.vue
@@ -1,0 +1,178 @@
+<template>
+  <div class="d-flex flex-column ga-0 text-caption">
+    <RequestOperationListRow>
+      <template #name>{{ $t('terms.canister') }}</template>
+      <template #content>
+        <span data-test-id="change-canister-target">{{ canisterLabel }}</span>
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow>
+      <template #name>{{ $t('terms.mode') }}</template>
+      <template #content>
+        <span data-test-id="change-canister-mode">{{ installModeLabel }}</span>
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow v-if="showWasmMemoryPersistence">
+      <template #name>{{ $t('external_canisters.wasm_memory_persistence.label') }}</template>
+      <template #content>
+        <span data-test-id="change-canister-wasm-memory-persistence">
+          {{ wasmMemoryPersistenceLabel }}
+        </span>
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow v-if="showSkipPreUpgrade">
+      <template #name>{{ $t('external_canisters.skip_pre_upgrade.label') }}</template>
+      <template #content>
+        <span data-test-id="change-canister-skip-pre-upgrade">
+          {{ skipPreUpgrade ? $t('terms.yes') : $t('terms.no') }}
+        </span>
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow>
+      <template #name>{{ $t('terms.wasm') }}</template>
+      <template #content>
+        <TextOverflow
+          v-if="isListMode"
+          :text="props.operation.module_checksum"
+          :max-length="24"
+          test-id="change-canister-module-checksum"
+        />
+        <span v-else data-test-id="change-canister-module-checksum">
+          {{ props.operation.module_checksum }}
+        </span>
+      </template>
+    </RequestOperationListRow>
+    <RequestOperationListRow v-if="argChecksum">
+      <template #name>{{ $t('terms.arg') }}</template>
+      <template #content>
+        <TextOverflow
+          v-if="isListMode"
+          :text="argChecksum"
+          :max-length="24"
+          test-id="change-canister-arg-checksum"
+        />
+        <span v-else data-test-id="change-canister-arg-checksum">{{ argChecksum }}</span>
+      </template>
+    </RequestOperationListRow>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import {
+  CanisterUpgradeOptions,
+  WasmMemoryPersistence,
+} from '~/components/external-canisters/external-canisters.types';
+import TextOverflow from '~/components/TextOverflow.vue';
+import logger from '~/core/logger.core';
+import { ChangeExternalCanisterOperation, Request } from '~/generated/station/station.did';
+import { useStationStore } from '~/stores/station.store';
+import { variantIs } from '~/utils/helper.utils';
+import RequestOperationListRow from '../RequestOperationListRow.vue';
+
+const props = withDefaults(
+  defineProps<{
+    request: Request;
+    operation: ChangeExternalCanisterOperation;
+    mode?: 'list' | 'detail';
+  }>(),
+  {
+    mode: 'list',
+  },
+);
+
+const i18n = useI18n();
+const station = useStationStore();
+
+const isListMode = computed(() => props.mode === 'list');
+const isUpgrade = computed(() => variantIs(props.operation.mode, 'upgrade'));
+
+const installModeLabel = computed(() => {
+  if (variantIs(props.operation.mode, 'install')) {
+    return i18n.t('external_canisters.install_mode.install');
+  }
+
+  if (variantIs(props.operation.mode, 'reinstall')) {
+    return i18n.t('external_canisters.install_mode.reinstall');
+  }
+
+  return i18n.t('external_canisters.install_mode.upgrade');
+});
+
+// The optional upgrade options record, only present for `upgrade` requests that
+// explicitly set at least one of the options.
+const upgradeOptions = computed<CanisterUpgradeOptions | undefined>(() => {
+  const mode = props.operation.mode;
+
+  return variantIs(mode, 'upgrade') ? mode.upgrade[0] : undefined;
+});
+
+const wasmMemoryPersistence = computed<WasmMemoryPersistence | undefined>(
+  () => upgradeOptions.value?.wasm_memory_persistence[0],
+);
+
+const skipPreUpgrade = computed<boolean>(() => upgradeOptions.value?.skip_pre_upgrade[0] ?? false);
+
+// The compact list view only surfaces the upgrade options when they were
+// explicitly set on the request, while the detail view always shows the
+// effective values for an upgrade so reviewers can see what will be applied.
+const showWasmMemoryPersistence = computed(
+  () => isUpgrade.value && (!isListMode.value || wasmMemoryPersistence.value !== undefined),
+);
+
+const showSkipPreUpgrade = computed(
+  () => isUpgrade.value && (!isListMode.value || skipPreUpgrade.value),
+);
+
+const wasmMemoryPersistenceLabel = computed(() => {
+  const persistence = wasmMemoryPersistence.value;
+
+  if (persistence && variantIs(persistence, 'keep')) {
+    return i18n.t('external_canisters.wasm_memory_persistence.keep');
+  }
+
+  if (persistence && variantIs(persistence, 'replace')) {
+    return i18n.t('external_canisters.wasm_memory_persistence.replace');
+  }
+
+  // When the option is omitted the IC applies its default, which is `replace`.
+  return i18n.t('external_canisters.wasm_memory_persistence.default');
+});
+
+const argChecksum = computed(() => props.operation.arg_checksum?.[0]);
+
+const canisterName = ref<string | undefined>();
+
+const canisterLabel = computed(() => {
+  const canisterId = props.operation.canister_id.toText();
+
+  return canisterName.value ? `${canisterName.value} (${canisterId})` : canisterId;
+});
+
+const loadCanisterName = async (): Promise<void> => {
+  try {
+    const result = await station.service.getExternalCanisterByCanisterId(
+      props.operation.canister_id,
+    );
+
+    canisterName.value = result.canister.name;
+  } catch (err) {
+    // The canister may no longer be linked to the station or the caller may not
+    // have permission to read it, in which case the canister id is shown alone.
+    logger.warn(`Could not resolve the name of canister ${props.operation.canister_id}`, err);
+  }
+};
+
+watch(
+  [isListMode, () => props.operation.canister_id.toText()],
+  ([isListMode]) => {
+    canisterName.value = undefined;
+
+    if (!isListMode) {
+      loadCanisterName();
+    }
+  },
+  { immediate: true },
+);
+</script>

--- a/docs/src/content/docs/users/external-canisters.md
+++ b/docs/src/content/docs/users/external-canisters.md
@@ -53,9 +53,12 @@ Regularly review canister permissions to prevent unauthorized access. The permis
    - **Install:** Install a new WASM file into the canister
    - **Upgrade:** Replace the existing canister code with a new version.
    - **Reinstall:** Reinstall the canister with the same code.
-3. Upload the WASM file and submit the request.
-4. Wait for the approval process (if multi-signature policies are enabled).
-5. Monitor the canister status to ensure the upgrade completes successfully.
+3. For the **Upgrade** mode, review the additional upgrade options:
+   - **Wasm Memory Persistence:** Controls whether the canister's main memory is kept or replaced during the upgrade. Leave it on _Default (replace)_ for most canisters. Motoko canisters that use [Enhanced Orthogonal Persistence](https://docs.internetcomputer.org/motoko/orthogonal-persistence/enhanced) must use **Keep**, otherwise the Internet Computer rejects the upgrade to protect their memory.
+   - **Skip pre-upgrade hook:** Skips the canister's `pre_upgrade` hook. Only useful for recovery when the existing hook traps.
+4. Upload the WASM file and submit the request.
+5. Wait for the approval process (if multi-signature policies are enabled).
+6. Monitor the canister status to ensure the upgrade completes successfully.
 
 :::caution[Important]
 Always test new versions in a staging environment before upgrading production canisters.


### PR DESCRIPTION
## Summary

Completes the `wasm_memory_persistence` support for external canister upgrades across the CLI and the frontend.

The station (#634), the dfx-orbit CLI and the wallet **Install** form (#641) already accept `wasm_memory_persistence` and `skip_pre_upgrade` on external canister upgrades. The remaining gap was on the review side of the wallet: `ChangeExternalCanister` requests rendered through the generic `UnsupportedOperation` JSON dump in both the request list and the request detail dialog, so approvers had no readable view of whether an upgrade keeps or replaces the canister's main memory.

## What changed

### Wallet (`apps/wallet`)
- New `ChangeExternalCanisterOperation` request view, wired into `RequestDetailView` and `RequestListItem`, showing:
  - the target canister (name resolved via `get_external_canister` in detail mode, falling back to the canister id),
  - the install mode (Install / Reinstall / Upgrade),
  - for upgrades, the **Wasm Memory Persistence** (Keep / Replace / Default (replace)) and **Skip pre-upgrade hook** options,
  - the module and argument checksums (truncated in the list, full in the detail view).
- The compact list view only surfaces the upgrade options when they were explicitly set on the request (an explicit `skip_pre_upgrade = false` is shown as "No"); the detail view always shows the effective values for an upgrade.
- The target canister name is fetched with a verified call, like the request itself in the approval dialog, so a non-consensus response cannot attach a misleading name to the verified canister id.
- Reuses the existing `external_canisters.*` and `terms.*` locale keys, so en/fr/pt stay in parity without new strings.

### Docs
- `docs/src/content/docs/users/external-canisters.md`: documents the Wasm Memory Persistence and skip-pre-upgrade options in the canister upgrade steps, including the Motoko Enhanced Orthogonal Persistence requirement for `Keep`.

### dfx-orbit CLI
- No code changes needed: `request canister install` / `verify canister install` already expose `--wasm-memory-persistence keep|replace` and `--skip-pre-upgrade`, and `review` prints them. Re-verified with `cargo test -p dfx-orbit --lib` (5 tests pass).

## Tests
- New `ChangeExternalCanisterOperation.spec.ts` (12 tests): mode labels, upgrade options in list vs. detail mode, explicit `skip_pre_upgrade = false` in list mode, default persistence shown for plain upgrades, options hidden for install/reinstall, canister name resolution through a verified call and fallback, no lookup in list mode.
- `RequestDetailView.spec.ts`: new test asserting change-canister requests render through the dedicated view with their persistence option.
- `vitest` over `components/requests`, `components/external-canisters`, `components/inputs`, `mappers`: 182 tests / 46 files pass.
- `vue-tsc --noEmit`, `eslint` and `prettier --check` on the changed files pass.
- CI is green on the current head, including `e2e-tests:required`. (The first CI run hit the known-flaky `disaster-recovery.spec.ts` end-to-end test, which fails intermittently on unrelated PRs too; see the comment below.)

## Not changed on purpose
- `SystemUpgrade` (station / upgrader) does not carry `wasm_memory_persistence`: both are Rust canisters, for which the IC rejects `keep`, so the option is not meaningful there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wAX3aCg6ov8rMvYeBxbgK