### PR TITLE
refactor(cli): rename the internal orbit-cli to orbit-release-cli

### DIFF
--- a/.claude/skills/orbit-station-audit/SKILL.md
+++ b/.claude/skills/orbit-station-audit/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: orbit-station-audit
 description: >-
-  Build and run the Orbit station configuration audit (`orbit-cli audit`)
+  Build and run the Orbit station configuration audit (`orbit-release-cli audit`)
   end-to-end against a live station, including the icp-cli Internet Identity
   setup that reliably trips people up. Use this whenever the user wants to
   audit, sanity-check, or security-review an Orbit station or wallet — e.g.
-  "audit my Orbit wallet", "run orbit-cli audit on station <canister-id>",
+  "audit my Orbit wallet", "run orbit-release-cli audit on station <canister-id>",
   "check my Orbit station for misconfigured approval policies / empty quorums",
   or any time they pair an Orbit station canister id with auditing, approval
   quorum, or permission checks. Reach for this even if they don't say
-  "orbit-cli" by name. It covers building the CLI from source (the globally
-  installed orbit-cli is usually too old to have the `audit` subcommand),
+  "orbit-release-cli" by name. It covers building the CLI from source (the globally
+  installed orbit-release-cli is usually too old to have the `audit` subcommand),
   obtaining an identity the station recognizes as a member, and reading the
   report.
 ---
 
 # Orbit station audit
 
-`orbit-cli audit` runs read-only sanity checks against a live station and
+`orbit-release-cli audit` runs read-only sanity checks against a live station and
 prints a severity-sorted report — safe to run any time, since it only issues
 `list_*` queries and mutates nothing. Flags, exit codes, and report format are
 documented in [`cli/src/audit/README.md`](../../../cli/src/audit/README.md);
@@ -27,7 +27,7 @@ actually derail a first one.
 
 ## The three gotchas (read these first)
 
-1. **Don't rely on the global `orbit-cli`.** A global on `PATH` may be from an
+1. **Don't rely on the global `orbit-release-cli`.** A global on `PATH` may be from an
    older checkout that predates the `audit` subcommand (unknown-command error).
    Build and run this repo's `cli/dist/cli.js` instead — what the helper script
    does — so there's no doubt about which version you're invoking.
@@ -68,7 +68,7 @@ Equivalent by hand, if you'd rather see each step:
 
 ```bash
 pnpm install                       # once, if node_modules is missing
-pnpm --filter orbit-cli build      # emits cli/dist/cli.js
+pnpm --filter orbit-release-cli build      # emits cli/dist/cli.js
 node cli/dist/cli.js audit --help
 ```
 
@@ -126,7 +126,7 @@ is the fallback to try if the station predates that derivation origin.
   --output ~/Downloads/orbit-audit-$(date +%F).txt
 ```
 
-Every flag after the script name is forwarded verbatim to `orbit-cli audit`, so
+Every flag after the script name is forwarded verbatim to `orbit-release-cli audit`, so
 swap in whichever identity matched in Step 2. `--network` defaults to `ic` (pass
 `--network local` for a local replica), and dropping `--output` prints to
 stdout. `--output` writes internal station metadata (principals, policy ids) —

--- a/.claude/skills/orbit-station-audit/scripts/run-audit.sh
+++ b/.claude/skills/orbit-station-audit/scripts/run-audit.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Build the Orbit CLI from source and run `orbit-cli audit`.
+# Build the Orbit CLI from source and run `orbit-release-cli audit`.
 #
-# Why build from source instead of the global `orbit-cli`: a global on PATH may
+# Why build from source instead of the global `orbit-release-cli`: a global on PATH may
 # be from an older checkout that predates the `audit` subcommand. Building here
 # keeps us on the version in this repo, with no doubt about what's invoked.
 #
@@ -10,7 +10,7 @@
 #   run-audit.sh --station <ID> [--identity <NAME>] [--identity-source icp] \
 #                [--network ic] [--output <PATH>] ...
 #
-# Everything you pass is forwarded verbatim to `orbit-cli audit`, so any flag
+# Everything you pass is forwarded verbatim to `orbit-release-cli audit`, so any flag
 # the audit accepts works here. With no args it prints the audit's help.
 set -euo pipefail
 
@@ -25,7 +25,7 @@ if [ ! -d "$REPO/node_modules" ]; then
 fi
 
 # 2. Build the CLI (fast; just tsc + a copy step).
-(cd "$REPO" && pnpm --filter orbit-cli build) >/dev/null
+(cd "$REPO" && pnpm --filter orbit-release-cli build) >/dev/null
 
 # 3. Run the audit, forwarding all arguments (default to --help if none given,
 #    since `audit` requires --station and would otherwise error).

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,6 @@ jobs:
           git config --global user.name "GitHub Actions"
       - name: 'If new tags, finalize release'
         run: |
-          orbit-cli release publish
+          orbit-release-cli release publish
         env:
           GH_TOKEN: ${{ github.token }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "orbit-cli",
+  "name": "orbit-release-cli",
   "version": "0.0.1",
   "bin": {
+    "orbit-release-cli": "./dist/cli.js",
     "orbit-cli": "./dist/cli.js"
   },
   "main": "cli.js",

--- a/cli/src/audit/README.md
+++ b/cli/src/audit/README.md
@@ -1,4 +1,4 @@
-# `orbit-cli audit`
+# `orbit-release-cli audit`
 
 Read-only sanity checks against an Orbit station's configuration. The command pulls live state via the station's `list_*` query methods using `agent-js`, runs a set of static checks against the configuration, and prints a severity-sorted report. Nothing is mutated — the audit is safe to run at any time, against any station the caller has read access to.
 
@@ -10,7 +10,7 @@ Read-only sanity checks against an Orbit station's configuration. The command pu
 ## Usage
 
 ```bash
-orbit-cli audit --station <CANISTER_ID> [--network <ic|local>] [--identity <NAME>] [--output <PATH>]
+orbit-release-cli audit --station <CANISTER_ID> [--network <ic|local>] [--identity <NAME>] [--output <PATH>]
 ```
 
 ### Options
@@ -38,20 +38,20 @@ Useful for CI integration — `set -e` pipelines fail naturally when a blocker s
 
 ```bash
 # Audit a mainnet station, print report to stdout.
-orbit-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai
+orbit-release-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai
 
 # As an admin-tier identity, write the report to a file.
-orbit-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai \
+orbit-release-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai \
                 --identity admin-readonly \
                 --output ./audit-report.txt
 
 # Sign with an icp-cli identity (II / Okta / linked browser logins).
-orbit-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai \
+orbit-release-cli audit --station rrkah-fqaaa-aaaaa-aaaaq-cai \
                 --identity my-icp-identity \
                 --identity-source icp
 
 # Local development station.
-orbit-cli audit --station <local-canister-id> --network local
+orbit-release-cli audit --station <local-canister-id> --network local
 ```
 
 ## Report format
@@ -85,7 +85,7 @@ Findings include policy, user, group, canister, and method identifiers. When usi
 ## Tests
 
 ```bash
-pnpm --filter orbit-cli test
+pnpm --filter orbit-release-cli test
 ```
 
 Unit tests cover each check across positive and negative cases, including combinator descent and cycle detection on `NamedRule` references. Fixtures are in [checks/fixtures.ts](./checks/fixtures.ts).

--- a/cli/src/audit/identity-icp.ts
+++ b/cli/src/audit/identity-icp.ts
@@ -122,14 +122,14 @@ export const loadIcpIdentity = (name: string): Identity => {
 
   if (entry.kind === 'hsm') {
     throw new Error(
-      `icp identity '${name}' is HSM-backed. PKCS#11 isn't supported by orbit-cli audit yet.`,
+      `icp identity '${name}' is HSM-backed. PKCS#11 isn't supported by orbit-release-cli audit yet.`,
     );
   }
 
   if (entry.kind === 'keyring') {
     if (entry.algorithm && entry.algorithm !== 'ed25519') {
       throw new Error(
-        `icp identity '${name}' uses ${entry.algorithm}. orbit-cli audit currently supports Ed25519 keyring identities only. Use --identity-source icp with an Ed25519 identity, or use --identity-source dfx with a plaintext Ed25519 identity.`,
+        `icp identity '${name}' uses ${entry.algorithm}. orbit-release-cli audit currently supports Ed25519 keyring identities only. Use --identity-source icp with an Ed25519 identity, or use --identity-source dfx with a plaintext Ed25519 identity.`,
       );
     }
     const { stdout, stderr, status } = runIcp(['identity', 'export', name]);
@@ -143,7 +143,7 @@ export const loadIcpIdentity = (name: string): Identity => {
     const { pubKeyPem, identity: session } = generateSessionKey();
     const pubKeyPath = join(
       tmpdir(),
-      `orbit-cli-session-${process.pid}-${process.hrtime.bigint()}.pem`,
+      `orbit-release-cli-session-${process.pid}-${process.hrtime.bigint()}.pem`,
     );
     writeFileSync(pubKeyPath, pubKeyPem);
     try {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -7,7 +7,7 @@ import registry from './registry';
 program
   .storeOptionsAsProperties(false)
   .version(version)
-  .name('orbit-cli')
+  .name('orbit-release-cli')
   .description('The Orbit CLI includes tools for managing projects in the workspace')
   .command('path')
   .description('Print the path to the Orbit CLI')

--- a/cli/src/registry/publish.ts
+++ b/cli/src/registry/publish.ts
@@ -130,7 +130,7 @@ command
 
 // Saves the argument in a temporary file and returns the path to the file.
 const saveArgumentInTempFile = async (argument: string): Promise<string> => {
-  const tempFilePath = join(tmpdir(), 'orbit-cli-argument-' + Math.random().toString(36).slice(2));
+  const tempFilePath = join(tmpdir(), 'orbit-release-cli-argument-' + Math.random().toString(36).slice(2));
 
   await writeFile(tempFilePath, argument, {
     encoding: 'utf-8',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:wallet": "pnpm run --filter \"./apps/wallet\" dev",
     "type-check": "pnpm run -r type-check",
     "postinstall": "pnpm run -r postinstall && pnpm run prepare-cli",
-    "prepare-cli": "pnpm run --filter orbit-cli build && pnpm run --filter orbit-cli expose",
+    "prepare-cli": "pnpm run --filter orbit-release-cli build && pnpm run --filter orbit-release-cli expose",
     "test:e2e:deploy": "dfx start --background --clean --system-canisters && ./orbit --init",
     "test:e2e:run": "WALLET_URL=http://werw6-ayaaa-aaaaa-774aa-cai.localhost:`dfx info webserver-port` playwright test",
     "test:e2e:dev": "concurrently \"pnpm run dev:wallet\" \"WALLET_URL=http://localhost:5173?canisterId=werw6-ayaaa-aaaaa-774aa-cai playwright test --ui\"",

--- a/tests/e2e/utils/orbit.utils.ts
+++ b/tests/e2e/utils/orbit.utils.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 
 export function publishArtifact(artifact: string) {
-  execSync(`orbit-cli registry publish --app ${artifact}`, { stdio: 'inherit' });
+  execSync(`orbit-release-cli registry publish --app ${artifact}`, { stdio: 'inherit' });
 }
 
 export function copyArtifact(artifact: string) {


### PR DESCRIPTION
Renames the internal release tool from `orbit-cli` to `orbit-release-cli`, which frees `orbit-cli` for the CLI we ship to users. Requested in https://github.com/dfinity/orbit/pull/658#discussion_r3934108360.

Covers the workspace package and its bin, the commander program name, the `prepare-cli` build and link script, the `release publish` call in `release.yaml`, the e2e helper, two error messages, two temp-file prefixes, the audit README and the station-audit skill.

`orbit-cli` stays as a second `bin` entry. The deploy stack adds three more call sites that still use that name, and those files are not on `main` yet, so the alias lets this PR and that stack merge in either order. A follow-up renames them and drops it.

The package has no entry in `.release.json`, so it has never been tagged or published and no release history changes. Not marked breaking: there are no external consumers, and a `!` would risk nx forcing a major bump on whichever released project it attributes these files to.

One commit, because every intermediate state would have a package name its own callers do not use.

Verified: `pnpm install` runs the renamed `prepare-cli` end to end, and the built CLI reports `orbit-release-cli` with all subcommands intact.
